### PR TITLE
fix: add project structure to readme

### DIFF
--- a/templates/apollo-starter-ts/README.md
+++ b/templates/apollo-starter-ts/README.md
@@ -7,3 +7,25 @@ Starter template using graphback and apollo-server
 docker-compose up -d
 npm start
 ```
+
+### Project structure
+
+```
+|-----generated
+       |-----schema.graphql
+       |-----resolvers.ts
+|-----model
+       |-----<your-model-name>.graphql
+|-----src
+       |-----config
+             |-----config.ts
+       |-----db.ts
+       |-----index.ts
+       |-----mapping.ts
+|-----package.json
+|-----Dockerfile
+|-----docker-compose.yml
+|-----package-lock.json
+|-----tslint.json
+|-----README.md
+```

--- a/templates/apollo-starter-ts/README.md
+++ b/templates/apollo-starter-ts/README.md
@@ -3,25 +3,31 @@
 Starter template using graphback and apollo-server
 
 ### Usage
+The project has been created using `graphback`. Run the project using the following steps. 
+- Start the databse
 ```
 docker-compose up -d
+```
+- Generate resources(schema and resolvers) and create database
+```
+graphback generate
+graphback db
+```
+- Start the server
+```
 npm start
 ```
 
-### Project structure
+### Directory structure
 
 ```
 |-----generated
-       |-----schema.graphql
-       |-----resolvers.ts
-|-----model
-       |-----<your-model-name>.graphql
+|-----model                        //Model - type declaration
 |-----src
-       |-----config
-             |-----config.ts
-       |-----db.ts
+       |-----config                //server config
+       |-----db.ts                 //db connection
        |-----index.ts
-       |-----mapping.ts
+       |-----mapping.ts            //map generated content
 |-----package.json
 |-----Dockerfile
 |-----docker-compose.yml


### PR DESCRIPTION
#17 Add the following template structure
```
|-----generated
       |-----schema.graphql
       |-----resolvers.ts
|-----model
       |-----<your-model-name>.graphql
|-----src
       |-----config
             |-----config.ts
       |-----db.ts
       |-----index.ts
       |-----mapping.ts
|-----package.json
|-----Dockerfile
|-----docker-compose.yml
|-----package-lock.json
|-----tslint.json
|-----README.md
```