### PR TITLE
generate resolver types from schema

### DIFF
--- a/packages/graphback/example/index.ts
+++ b/packages/graphback/example/index.ts
@@ -28,7 +28,7 @@ async function main() {
   // tslint:disable-next-line: no-console
   console.log(generated.resolvers)
 
-  await backend.createDatabase()
+  // await backend.createDatabase()
 }
 
 // tslint:disable-next-line: no-floating-promises

--- a/packages/graphback/package.json
+++ b/packages/graphback/package.json
@@ -46,6 +46,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@graphql-codegen/core": "^1.3.1",
+    "@graphql-codegen/plugin-helpers": "^1.3.1",
+    "@graphql-codegen/typescript": "^1.3.1",
+    "@graphql-codegen/typescript-resolvers": "^1.3.1",
     "glob": "7.1.4",
     "graphql": "14.4.0",
     "graphql-code-generator": "0.18.2",

--- a/packages/graphback/src/GraphQLBackend.ts
+++ b/packages/graphback/src/GraphQLBackend.ts
@@ -5,6 +5,7 @@ import { logger } from './logger'
 import { MetadataFormat } from './resolvers/MetadataInstance';
 import { GraphQLResolverGenerator } from './resolvers/ResolverGenerator' 
 import { ResolverManager } from './resolvers/ResolverManager';
+import { ResolverTypeGenerator } from './resolvers/ResolversTypeGenerator';
 import { allTypes, ResolverType } from './resolvers/ResolverType'
 import { GraphQLSchemaGenerator } from './schema/SchemaGenerator'
 import { SchemaParser } from './schema/SchemaParser'
@@ -108,11 +109,14 @@ export class GraphQLBackendCreator {
         logger.info("Schema generation skipped.")
       }
 
+      const resolverTypeGen = new ResolverTypeGenerator(backend.schema)
+      const resolverTypes = await resolverTypeGen.generateTypes()
+      
       /**
        * Generate TS resolvers from the MetadataFormat generated
        */
       const resolverGen = new GraphQLResolverGenerator()
-      backend.resolvers = resolverGen.generateResolvers(this.resolvers)
+      backend.resolvers = resolverGen.generateResolvers(resolverTypes, this.resolvers)
     } catch (error) {
       logger.error(`Error on generation ${error}`)
     }   

--- a/packages/graphback/src/resolvers/ResolverGenerator.ts
+++ b/packages/graphback/src/resolvers/ResolverGenerator.ts
@@ -9,7 +9,7 @@ export class GraphQLResolverGenerator {
    * Generate Typescript compatible schema
    * @param resolvers Array of MetadataInstance
    */
-  public generateResolvers(resolvers: MetadataFormat): string {
+  public generateResolvers(resolverTypes: string, resolvers: MetadataFormat): string {
     // tslint:disable-next-line: typedef
     const queryResolvers = resolvers.query.map(value => value.implementation)
     // tslint:disable-next-line: typedef
@@ -17,15 +17,16 @@ export class GraphQLResolverGenerator {
     const queryString = queryResolvers.join(',\n')
     const mutationString = mutationResolvers.join(',\n')
     
-    return this.generateString(queryString, mutationString)
+    return this.generateString(resolverTypes, queryString, mutationString)
   }
   /**
    * 
    * @param queryString joined query resolvers as a string
    * @param mutationString joined mutation resolvers as a string
    */
-  public generateString(queryString: string, mutationString: string) {
-    return `export const resolvers = {
+  public generateString(resolverTypes: string, queryString: string, mutationString: string) {
+    return `${resolverTypes}
+export const resolvers = {
   Query: {
     ${queryString}
   },

--- a/packages/graphback/src/resolvers/ResolversTypeGenerator.ts
+++ b/packages/graphback/src/resolvers/ResolversTypeGenerator.ts
@@ -1,0 +1,50 @@
+import { codegen } from '@graphql-codegen/core'
+import { Types } from '@graphql-codegen/plugin-helpers';
+import { plugin as typescriptPlugin } from '@graphql-codegen/typescript';
+import { plugin as typescriptResolversPlugin } from '@graphql-codegen/typescript-resolvers'
+import { buildSchema, DocumentNode, GraphQLSchema, parse, printSchema } from 'graphql';
+
+/**
+ * Generate Resolver Types from the generated schema
+ * which is prepended to the output resolver file
+ */
+export class ResolverTypeGenerator {
+  private schema: GraphQLSchema
+  private parsedSchema: DocumentNode
+  private config: Types.GenerateOptions
+
+  /**
+   * Create config for generating Resolver Types
+   * @param schemaText output schema generated
+   */
+  constructor(schemaText: string) {
+    this.schema = buildSchema(schemaText)
+    this.parsedSchema = parse(printSchema(this.schema))
+    this.config = {
+      filename: '',
+      schema: this.parsedSchema,
+      plugins: [
+        {typescript: {}},
+        {typescriptResolvers: {}} // Here you can pass configuration to the plugin
+      ],
+      config: {},
+      documents: [],
+      pluginMap: {
+        typescript: {
+          plugin: typescriptPlugin
+        },
+        typescriptResolvers: {
+          plugin: typescriptResolversPlugin
+        }
+      }
+    }
+  }
+
+  public async generateTypes(): Promise<string> {
+    // tslint:disable-next-line: no-unnecessary-local-variable
+    const types: string = await codegen(this.config)
+    
+    return types
+  }
+}
+


### PR DESCRIPTION
## Implementation
Generate Resolver typings using `@graphql-codegen/core` and `typescript-resolvers` plugin.
