### PR TITLE
Implement Subscriptions resolvers

### DIFF
--- a/packages/graphback-cli/src/templates/resources/docker/pg-docker-compose.yml
+++ b/packages/graphback-cli/src/templates/resources/docker/pg-docker-compose.yml
@@ -10,10 +10,7 @@ services:
       POSTGRES_USER: postgresql
       POSTGRES_DB: users
 
-  # Mosca is a simple MQTT Broker
-  # In OpenShift/Production we would use the Red Hat AMQ broker
-  mosca:
-    image: matteocollina/mosca
+  redis:
+    image: redis:3.2
     ports:
-      - "1883:1883" # MQTT
-      - "80:80" # web interface
+      - "6379:6379"

--- a/packages/graphback/src/resolvers/knex/resolverImplementation.ts
+++ b/packages/graphback/src/resolvers/knex/resolverImplementation.ts
@@ -1,9 +1,10 @@
 const knexContext = `context.db`
+const pubsub = `context.pubsub`
 
 export const createTemplate = (fieldName: string, tableName: string, typeName: string): string => {
-    return `${fieldName}: async (root, args, context, info) => {
+    return `${fieldName}: async (_, args, context) => {
       const result = await ${knexContext}('${tableName}').insert(args.input).returning('*')
-      pubsub.publish(Subscriptions.NEW_${typeName.toUpperCase()}, {
+      ${pubsub}.publish(Subscriptions.NEW_${typeName.toUpperCase()}, {
         new${typeName}: result[0]
       })
       return result[0]
@@ -11,9 +12,9 @@ export const createTemplate = (fieldName: string, tableName: string, typeName: s
   }
 
 export const deleteTemplate = (fieldName: string, tableName: string, typeName: string): string => {
-    return `${fieldName}: (root, args, context, info) => {
+    return `${fieldName}: (_, args, context) => {
       return ${knexContext}('${tableName}').where('id', '=' , args.id).del().then( () => {
-        pubsub.publish(Subscriptions.DELETED_${typeName.toUpperCase()}, {
+        ${pubsub}.publish(Subscriptions.DELETED_${typeName.toUpperCase()}, {
           deleted${typeName}: args.id
         })
         return args.id;
@@ -21,22 +22,22 @@ export const deleteTemplate = (fieldName: string, tableName: string, typeName: s
 }
 
 export const findAllTemplate = (fieldName: string, tableName: string): string => {
-    return `${fieldName}: (root, args, context, info) => {
+    return `${fieldName}: (_, __, context) => {
       return ${knexContext}.select().from('${tableName}')
     }`
   }
 
 export const findTemplate = (fieldName: string, tableName: string): string => {
-    return `${fieldName}: (root, args, context, info) => {
+    return `${fieldName}: (_, args, context) => {
       return ${knexContext}.select().from('${tableName}').where(args.fields)
     }`
 }
 
 export const updateTemplate = (fieldName: string, tableName: string, typeName: string): string => {
-    return `${fieldName}: (root, args, context, info) => {
+    return `${fieldName}: (_, args, context) => {
       return ${knexContext}('${tableName}').where('id', '=' , args.id).update(args.input).then( async () => {
         const result = await ${knexContext}.select().from('${tableName}').where('id', '=' , args.id);
-        pubsub.publish(Subscriptions.UPDATED_${typeName.toUpperCase()}, {
+        ${pubsub}.publish(Subscriptions.UPDATED_${typeName.toUpperCase()}, {
           updated${typeName}: result[0]
         })
         return result[0]
@@ -45,18 +46,18 @@ export const updateTemplate = (fieldName: string, tableName: string, typeName: s
 
 export const newSub = (typeName: string): string => {
     return `new${typeName}: {
-      subscribe: () => pubsub.asyncIterator(Subscriptions.NEW_${typeName.toUpperCase()})
+      subscribe: (_, __, context) => ${pubsub}.asyncIterator(Subscriptions.NEW_${typeName.toUpperCase()})
     }`
 }
 
 export const updatedSub = (typeName: string): string => {
     return `updated${typeName}: {
-      subscribe: () => pubsub.asyncIterator(Subscriptions.UPDATED_${typeName.toUpperCase()})
+      subscribe: (_, __, context) => ${pubsub}.asyncIterator(Subscriptions.UPDATED_${typeName.toUpperCase()})
     }`
 }
 
 export const deletedSub = (typeName: string): string => {
     return `deleted${typeName}: {
-      subscribe: () => pubsub.asyncIterator(Subscriptions.DELETED_${typeName.toUpperCase()})
+      subscribe: (_, __, context) => ${pubsub}.asyncIterator(Subscriptions.DELETED_${typeName.toUpperCase()})
     }`
 }

--- a/packages/graphback/src/resolvers/knex/targetResolverContext.ts
+++ b/packages/graphback/src/resolvers/knex/targetResolverContext.ts
@@ -5,21 +5,23 @@ import * as knex from './resolverImplementation'
 export interface TargetResolverContext {
   queries: string[]
   mutations: string[]
+  subscriptions: string[],
+  subscriptionTypes: string[]
 }
 
 const createResolvers = (context: Type[]): string[] => {
   return context.filter((i: Type) => i.config.create)
-                .map((i: Type) => knex.createTemplate(getFieldName(i.name, ResolverType.CREATE), getTableName(i.name)))
+                .map((i: Type) => knex.createTemplate(getFieldName(i.name, ResolverType.CREATE), getTableName(i.name), i.name))
 }
 
 const updateResolvers = (context: Type[]): string[] => {
   return context.filter((i: Type) => i.config.update)
-                .map((i: Type) => knex.updateTemplate(getFieldName(i.name, ResolverType.UPDATE), getTableName(i.name)))
+                .map((i: Type) => knex.updateTemplate(getFieldName(i.name, ResolverType.UPDATE), getTableName(i.name), i.name))
 }
 
 const deleteResolvers = (context: Type[]): string[] => {
   return context.filter((i: Type) => i.config.delete)
-                .map((i: Type) => knex.deleteTemplate(getFieldName(i.name, ResolverType.DELETE), getTableName(i.name)))
+                .map((i: Type) => knex.deleteTemplate(getFieldName(i.name, ResolverType.DELETE), getTableName(i.name), i.name))
 }
 
 const findResolvers = (context: Type[]): string[] => {
@@ -32,14 +34,39 @@ const findAllResolvers = (context: Type[]): string[] => {
                 .map((i: Type) => knex.findAllTemplate(getFieldName(i.name, ResolverType.FIND_ALL, 's'), getTableName(i.name)))
 }
 
+const newSubs = (context: Type[]): string[] => {
+  return context.filter((i: Type) => i.config.create)
+                .map((i: Type) => knex.newSub(i.name))
+}
+
+const updatedSubs = (context: Type[]): string[] => {
+  return context.filter((i: Type) => i.config.update)
+                .map((i: Type) => knex.updatedSub(i.name))
+}
+
+const deletedSubs = (context: Type[]): string[] => {
+  return context.filter((i: Type) => i.config.delete)
+                .map((i: Type) => knex.deletedSub(i.name))
+}
+
+const createSubscriptionTypes = (context: Type[]): string[] => {
+  return context.map((i: Type) => `NEW_${i.name.toUpperCase()} = 'new${i.name.toLowerCase()}',
+  UPDATED_${i.name.toUpperCase()} = 'updated${i.name.toLowerCase()}',
+  DELETED_${i.name.toUpperCase()} = 'deleted${i.name.toLowerCase()}'`)
+}
+
 export const buildResolverTargetContext = (inputContext: Type[]): TargetResolverContext => {
   const context = {
     queries: [],
-    mutations: []
+    mutations: [],
+    subscriptions: [],
+    subscriptionTypes: []
   }
 
   context.queries = [...findResolvers(inputContext), ...findAllResolvers(inputContext)]
   context.mutations = [...createResolvers(inputContext), ...updateResolvers(inputContext), ...deleteResolvers(inputContext)]
+  context.subscriptions = [...newSubs(inputContext), ...updatedSubs(inputContext), ...deletedSubs(inputContext)]
+  context.subscriptionTypes = createSubscriptionTypes(inputContext)
 
   return context
 }

--- a/packages/graphback/src/resolvers/resolverTemplate.ts
+++ b/packages/graphback/src/resolvers/resolverTemplate.ts
@@ -1,13 +1,26 @@
 import { TargetResolverContext } from './knex/targetResolverContext';
 
+const imports = `import { pubsub } from '../src/subscriptions'`
+
 export const generateResolvers = (context: TargetResolverContext): string => {
-  return `export const resolvers = {
+  return `${imports}
+
+enum Subscriptions {
+  ${context.subscriptionTypes.join(',\n  ')}
+}
+
+export const resolvers = {
   Query: {
     ${context.queries.join(',\n    ')}
   },
 
   Mutation: {
     ${context.mutations.join(',\n    ')}
+  },
+
+  Subscription: {
+    ${context.subscriptions.join(',\n    ')}
   }
-}`
+}
+`
 }

--- a/packages/graphback/src/resolvers/resolverTemplate.ts
+++ b/packages/graphback/src/resolvers/resolverTemplate.ts
@@ -1,11 +1,7 @@
 import { TargetResolverContext } from './knex/targetResolverContext';
 
-const imports = `import { pubsub } from '../src/subscriptions'`
-
 export const generateResolvers = (context: TargetResolverContext): string => {
-  return `${imports}
-
-enum Subscriptions {
+  return `enum Subscriptions {
   ${context.subscriptionTypes.join(',\n  ')}
 }
 

--- a/templates/apollo-starter-ts/package.json
+++ b/templates/apollo-starter-ts/package.json
@@ -14,6 +14,7 @@
     "cors": "2.8.5",
     "express": "4.17.1",
     "graphql": "14.4.2",
+    "graphql-redis-subscriptions": "^2.1.0",
     "graphql-tag": "2.10.1",
     "knex": "0.19.0",
     "pg": "7.11.0"

--- a/templates/apollo-starter-ts/src/index.ts
+++ b/templates/apollo-starter-ts/src/index.ts
@@ -1,5 +1,6 @@
 import * as cors from "cors"
 import * as express from "express"
+import * as http from "http"
 
 import { altairExpress } from "altair-express-middleware"
 import { ApolloServer } from "apollo-server-express"
@@ -40,7 +41,10 @@ async function start() {
 
   apolloServer.applyMiddleware({ app })
 
-  const server = app.listen(config.port, () => {
+  const httpServer = http.createServer(app)
+  apolloServer.installSubscriptionHandlers(httpServer)
+
+  httpServer.listen({ port: config.port }, () => {
     console.log(`🚀  Server ready at http://localhost:${config.port}/graphql`)
   })
 }

--- a/templates/apollo-starter-ts/src/index.ts
+++ b/templates/apollo-starter-ts/src/index.ts
@@ -8,6 +8,7 @@ import { ApolloServer } from "apollo-server-express"
 import config from "./config/config"
 import { connect } from "./db"
 import { resolvers, typeDefs } from "./mapping"
+import { pubsub } from './subscriptions'
 
 async function start() {
   const app = express()
@@ -32,6 +33,7 @@ async function start() {
       return {
         req: req,
         db: client,
+        pubsub,
         serverName: "graphback"
       }
     }

--- a/templates/apollo-starter-ts/src/subscriptions.ts
+++ b/templates/apollo-starter-ts/src/subscriptions.ts
@@ -1,0 +1,3 @@
+import { RedisPubSub } from 'graphql-redis-subscriptions'
+
+export const pubsub = new RedisPubSub()


### PR DESCRIPTION
## Implementation
For each type generate
- `new`
- `updated`
- `deleted`

Use redis pubsub for subscription

## Example
For input
```
type Note {
  id: ID!
  title: String!
  description: String!
}
```

the output resolver file
```
enum Subscriptions {
  NEW_NOTE = 'newnote',
  UPDATED_NOTE = 'updatednote',
  DELETED_NOTE = 'deletednote'
}

export const resolvers = {
  Query: {
    findNotes: (_, args, context) => {
      return context.db.select().from('note').where(args.fields)
    },
    findAllNotes: (_, __, context) => {
      return context.db.select().from('note')
    }
  },

  Mutation: {
    createNote: async (_, args, context) => {
      const result = await context.db('note').insert(args.input).returning('*')
      context.pubsub.publish(Subscriptions.NEW_NOTE, {
        newNote: result[0]
      })
      return result[0]
    },
    updateNote: (_, args, context) => {
      return context.db('note').where('id', '=' , args.id).update(args.input).then( async () => {
        const result = await context.db.select().from('note').where('id', '=' , args.id);
        context.pubsub.publish(Subscriptions.UPDATED_NOTE, {
          updatedNote: result[0]
        })
        return result[0]
    })},
    deleteNote: (_, args, context) => {
      return context.db('note').where('id', '=' , args.id).del().then( () => {
        context.pubsub.publish(Subscriptions.DELETED_NOTE, {
          deletedNote: args.id
        })
        return args.id;
    })}
  },

  Subscription: {
    newNote: {
      subscribe: (_, __, context) => context.pubsub.asyncIterator(Subscriptions.NEW_NOTE)
    },
    updatedNote: {
      subscribe: (_, __, context) => context.pubsub.asyncIterator(Subscriptions.UPDATED_NOTE)
    },
    deletedNote: {
      subscribe: (_, __, context) => context.pubsub.asyncIterator(Subscriptions.DELETED_NOTE)
    }
  }
}

```