### PR TITLE
fix: change scripts

### DIFF
--- a/templates/apollo-starter-ts/package.json
+++ b/templates/apollo-starter-ts/package.json
@@ -5,9 +5,9 @@
   "private": true,
   "main": "dist/src/index.js",
   "scripts": {
-    "start": "node dist/src/index.js",
+    "start": "ts-node src/index.ts",
     "build": "tsc",
-    "dev": "ts-node src/index.ts",
+    "serve": "node dist/src/index.js",
     "watch": "graphback watch"
   },
   "license": "Apache 2.0",


### PR DESCRIPTION
Currently `npm start` runs the built js files. Since `graphback watch` runs `npm start`(currently not working as rebuild is not done),
- changed `start` script to `ts-node`
- add `serve` script for built files