### PR TITLE
Relation support in graphback

### DIFF
--- a/packages/graphback-cli/package.json
+++ b/packages/graphback-cli/package.json
@@ -59,7 +59,7 @@
     "execa": "2.0.3",
     "figlet": "1.2.3",
     "glob": "7.1.4",
-    "graphback": "^0.3.1",
+    "graphback": "0.3.1",
     "inquirer": "6.5.0",
     "node-emoji": "1.10.0",
     "ora": "3.4.0",

--- a/packages/graphback/src/resolvers/knex/resolverImplementation.ts
+++ b/packages/graphback/src/resolvers/knex/resolverImplementation.ts
@@ -68,15 +68,15 @@ export const deletedSub = (typeName: string): string => {
     }`
 }
 
-export const typeRelation = (relation: string, typeName: string, fieldName: string, tableName: string): string => {
+export const typeRelation = (relation: string, columnName: string, fieldName: string, tableName: string): string => {
   if(relation === 'OneToOne') {
     return `${fieldName}: (parent: any, _: any, context: GraphQLContext) => {
-      return context.db.select().from('${tableName}').where('${typeName.toLowerCase()}Id', '=', parent.id)
+      return context.db.select().from('${tableName}').where('${columnName}', '=', parent.id)
                                 .then((result) => result[0])
     }`
   } else if(relation === 'OneToMany') {
     return `${fieldName}: (parent: any, _: any, context: GraphQLContext) => {
-      return context.db.select().from('${tableName}').where('${typeName.toLowerCase()}Id', '=', parent.id)
+      return context.db.select().from('${tableName}').where('${columnName}', '=', parent.id)
     }`
   } else {
     return undefined

--- a/packages/graphback/src/resolvers/knex/resolverImplementation.ts
+++ b/packages/graphback/src/resolvers/knex/resolverImplementation.ts
@@ -67,3 +67,18 @@ export const deletedSub = (typeName: string): string => {
       }
     }`
 }
+
+export const typeRelation = (relation: string, typeName: string, fieldName: string, tableName: string): string => {
+  if(relation === 'OneToOne') {
+    return `${fieldName}: (parent: any, _: any, context: GraphQLContext) => {
+      return context.db.select().from('${tableName}').where('${typeName.toLowerCase()}Id', '=', parent.id)
+                                .then((result) => result[0])
+    }`
+  } else if(relation === 'OneToMany') {
+    return `${fieldName}: (parent: any, _: any, context: GraphQLContext) => {
+      return context.db.select().from('${tableName}').where('${typeName.toLowerCase()}Id', '=', parent.id)
+    }`
+  } else {
+    return undefined
+  }
+}

--- a/packages/graphback/src/resolvers/knex/targetResolverContext.ts
+++ b/packages/graphback/src/resolvers/knex/targetResolverContext.ts
@@ -73,18 +73,26 @@ export const buildResolverTargetContext = (inputContext: Type[]): TargetResolver
 
   inputContext.forEach((t: Type) => {
     t.fields.forEach((f: Field) => {
-      if(f.isType){createRelationResolvers([...new Set(relationTypes)], relationImplementations)
+      if(f.isType){
         if(f.directives.OneToOne || !f.isArray) {
+          let columnName = `${t.name.toLowerCase()}Id`
+          if(f.directives.OneToOne) {
+            columnName = f.directives.OneToOne.field
+          }
           relationTypes.push(t.name)
           relationImplementations.push({
             typeName: t.name,
-            implementation: knex.typeRelation('OneToOne', t.name, f.name, f.type.toLowerCase())
+            implementation: knex.typeRelation('OneToOne', columnName, f.name, f.type.toLowerCase())
           })
         } else if(f.directives.OneToMany || f.isArray) {
+          let columnName = `${t.name.toLowerCase()}Id`
+          if(f.directives.OneToMany) {
+            columnName = f.directives.OneToMany.field
+          }
           relationTypes.push(t.name)
           relationImplementations.push({
             typeName: t.name,
-            implementation: knex.typeRelation('OneToMany', t.name, f.name, f.type.toLowerCase())
+            implementation: knex.typeRelation('OneToMany', columnName, f.name, f.type.toLowerCase())
           })
         }
       }

--- a/packages/graphback/src/resolvers/resolverTemplate.ts
+++ b/packages/graphback/src/resolvers/resolverTemplate.ts
@@ -3,8 +3,32 @@ import { TargetResolverContext } from './knex/targetResolverContext';
 const imports = `import { GraphQLContext } from '../src/context'`
 
 export const generateResolvers = (context: TargetResolverContext): string => {
-  return `${imports}
+  if(context.relations.length) {
+    return `${imports}
+  
+enum Subscriptions {
+  ${context.subscriptionTypes.join(',\n  ')}
+}
 
+export const resolvers = {
+  ${context.relations.join(',\n\n  ')},
+
+  Query: {
+    ${context.queries.join(',\n    ')}
+  },
+
+  Mutation: {
+    ${context.mutations.join(',\n    ')}
+  },
+
+  Subscription: {
+    ${context.subscriptions.join(',\n    ')}
+  }
+}
+`
+  } else {
+    return `${imports}
+  
 enum Subscriptions {
   ${context.subscriptionTypes.join(',\n  ')}
 }
@@ -23,4 +47,5 @@ export const resolvers = {
   }
 }
 `
+}
 }


### PR DESCRIPTION
## Work done
Added relationships info to schema generation

### Example
```
type Note {
  id: ID!
  title: String!
  description: String!
  ## Relationship
  comment: [Comment]!
}

type Comment {
  id: ID!
  title: String!
  description: String!
}
```
output schema looks like
```
type Note {
  id: ID!
  title: String!
  description: String!
  comment: [Comment]!
}

type Comment {
  id: ID!
  title: String!
  description: String!
  noteId: ID!
}

input NoteInput {
  title: String!
  description: String!
}

input CommentInput {
  title: String!
  description: String!
  noteId: ID!
}

input NoteFilter {
  id: ID
  title: String
  description: String
}

input CommentFilter {
  id: ID
  title: String
  description: String
  noteId: ID
}
......
```
Changes in output resolvers
```
Note: {
  comments: (parent: any, _: any, context: GraphQLContext) => {
    return context.db.select().from('comment').where('noteId', '=', parent.id)
  }
},
......
```
Resolves #130