### PR TITLE
fix: add missing documentation

### DIFF
--- a/docs/working.md
+++ b/docs/working.md
@@ -2,7 +2,29 @@
 id: working
 title: How Graphback works
 ---
+## GraphQL Schema Input
+
+Graphback is processing GraphQL Schema DSL language to generate server and client side artifacts to speed up development.
+Developers can focus on data and application requirements by modeling them using GraphQL DSL.
+For example:
+
+```
+type Note {
+  id: ID!
+  title: String!
+}
+
+type Query {
+  customOperation(): String
+}
+```
+
+GraphBack provides set of the GraphQL directives that allow to provide hints for generation process to customize output source code. Based on provided model GraphBack will generate set of queries, mutations and subscriptions together with resolvers that will by default conenct with database of your choice. 
+
+Input model can contain custom queries and mutations that can be implemented manually by developers at later stage.
+
 ## Templates
+
 Graphback provides users with the choice of setting up a custom environment with features with the help of templates. We plan to provide
 templates with multiple use cases including various server frameworks like GraphQL server frameworks like Apollo GraphQL, GraphQL-js and others.
 
@@ -11,9 +33,22 @@ Currently we provide `apollo-typescript-starter` only, and we'll be supporting m
 #### [apollo-typescript-starter](https://github.com/aerogear/graphback/tree/master/templates/apollo-starter-ts)
 Production ready typescript implementation of GraphQL server using apollo-express framework. Uses knex.js library for database access.
 
+## Generated source code
+
+Generated server side code will consist of the template together with additional elements:
+
+`./model` folder will contain input schema
+`./resolvers` folder will contain generated and custom GraphQL resolvers for the project.
+
 ## Databases
 Graphback allows you to configure your database according to your needs. Graphback provides support to multiple databases(MySQL, MongoDB etc).
 Currently, we are supporting `PostgreSQL`.
+
+
+## GraphQL Modules
+
+GraphQL modules provide way to extract common functionalities and decorate existing templates and generated source code. 
+For example authentication module will introduce new set of directives that can be used directly in the schema to authorize specific users and roles. Modules integration is currently in progress.
 
 ## Commands
 ### Init


### PR DESCRIPTION
Feedback provided shown us that we are missing critical parts of the docs and it is not clear how graphback works. This should do the job.