### PR TITLE
Sofa integration

### DIFF
--- a/docs/working.md
+++ b/docs/working.md
@@ -2,6 +2,14 @@
 id: working
 title: How Graphback works
 ---
+
+## Introduction
+
+The target of GraphBack is to bind industry templates and sample applications with business logic.
+GraphBack making prototyping applications very easy. You can think about your business objects that will be represented as GraphQL schema and objects you want to map and what kind of stack and requirements you want to from set of the predefined base templates and databases we support. 
+
+Graphback generates Node.js application with an entire codebase that is editable and can be later deployed to your own server.  By default, GraphBack will follow the best patterns of the writing database schema and allow users to benefit from the rich environment of GraphQL modules that can be applied out of the box giving developers Authentication, Logging and Monitoring features out of the box.
+
 ## GraphQL Schema Input
 
 Graphback is processing GraphQL Schema DSL language to generate server and client side artifacts to speed up development.

--- a/docs/working.md
+++ b/docs/working.md
@@ -36,10 +36,12 @@ Input model can contain custom queries and mutations that can be implemented man
 Graphback provides users with the choice of setting up a custom environment with features with the help of templates. We plan to provide
 templates with multiple use cases including various server frameworks like GraphQL server frameworks like Apollo GraphQL, GraphQL-js and others.
 
-Currently we provide `apollo-typescript-starter` only, and we'll be supporting more soon.
-
 #### [apollo-typescript-starter](https://github.com/aerogear/graphback/tree/master/templates/apollo-starter-ts)
 Production ready typescript implementation of GraphQL server using apollo-express framework. Uses knex.js library for database access.
+
+#### [apollo-rest-starter](https://github.com/aerogear/graphback/tree/master/templates/apollo-rest-starter)
+Production ready typescript implementation of GraphQL server using apollo-express framework and Sofa library. Sofa enables exposing REST API along with GraphQL based endpoint. 
+Uses knex.js library for database access.
 
 ## Generated source code
 

--- a/packages/graphback-cli/src/templates/starterTemplates.ts
+++ b/packages/graphback-cli/src/templates/starterTemplates.ts
@@ -13,11 +13,20 @@ import { Template } from './templateMetadata'
 export const allTemplates: Template[] = [
   {
     name: 'apollo-starter-ts',
-    description: 'Basic apollo template in typescript',
+    description: 'Apollo GraphQL template in typescript',
     repo: {
       uri: 'https://github.com/aerogear/graphback',
       branch: 'master',
       path: '/templates/apollo-starter-ts',
+    }
+  },
+  {
+    name: 'apollo-rest-starter-ts',
+    description: 'Apollo GraphQL template exposing additional REST API ',
+    repo: {
+      uri: 'https://github.com/aerogear/graphback',
+      branch: 'master',
+      path: '/templates/apollo-rest-starter',
     }
   }
 ]

--- a/templates/apollo-rest-starter/.dockerignore
+++ b/templates/apollo-rest-starter/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/templates/apollo-rest-starter/.gitignore
+++ b/templates/apollo-rest-starter/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+types

--- a/templates/apollo-rest-starter/.template.json
+++ b/templates/apollo-rest-starter/.template.json
@@ -1,0 +1,4 @@
+{
+    "name": "apollo-starter-rest-ts",
+    "description": "TypeScript starter using Apollo framework that will expose Restfull endpoints using Sofa"
+}

--- a/templates/apollo-rest-starter/Dockerfile
+++ b/templates/apollo-rest-starter/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:8
+
+# Create app directory
+WORKDIR /usr/src/app
+
+COPY . .
+RUN npm install
+
+VOLUME ./files
+
+EXPOSE 4000
+CMD [ "npm", "start" ]

--- a/templates/apollo-rest-starter/README.md
+++ b/templates/apollo-rest-starter/README.md
@@ -1,0 +1,37 @@
+## apollo-starter-ts
+
+Starter template using graphback and apollo-server
+
+### Usage
+The project has been created using `graphback`. Run the project using the following steps. 
+- Start the databse
+```
+docker-compose up -d
+```
+- Generate resources(schema and resolvers) and create database
+```
+graphback generate
+graphback db
+```
+- Start the server
+```
+npm start
+```
+
+### Directory structure
+
+```
+|-----generated
+|-----model                        //Model - type declaration
+|-----src
+       |-----config                //server config
+       |-----db.ts                 //db connection
+       |-----index.ts
+       |-----mapping.ts            //map generated content
+|-----package.json
+|-----Dockerfile
+|-----docker-compose.yml
+|-----package-lock.json
+|-----tslint.json
+|-----README.md
+```

--- a/templates/apollo-rest-starter/generated/resolvers.ts
+++ b/templates/apollo-rest-starter/generated/resolvers.ts
@@ -1,0 +1,11 @@
+export const resolvers = {
+  Query: {
+    me: (obj: any, args: any, context: any, info: any) => {
+      // we can access the request object provided by the Voyager framework
+
+      // we can access the context added below also
+      // console.log(context.serverName)
+      return { id: 1, name: `GraphBack` };
+    }
+  }
+}

--- a/templates/apollo-rest-starter/generated/schema.ts
+++ b/templates/apollo-rest-starter/generated/schema.ts
@@ -1,0 +1,12 @@
+import gql from 'graphql-tag'
+
+export const typeDefs = gql`
+type User {
+  id: ID
+  name: String
+}
+
+type Query {
+  me: User
+}
+`

--- a/templates/apollo-rest-starter/package.json
+++ b/templates/apollo-rest-starter/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "apollo-rest-template",
+  "name": "apollo-template",
   "version": "0.3.2",
   "description": "",
   "private": true,
@@ -21,7 +21,8 @@
     "graphql-tag": "2.10.1",
     "ioredis": "4.13.1",
     "knex": "0.19.1",
-    "pg": "7.11.0"
+    "pg": "7.11.0",
+    "sofa-api": "^0.4.0"
   },
   "devDependencies": {
     "@types/graphql": "14.2.3",

--- a/templates/apollo-rest-starter/src/config/config.ts
+++ b/templates/apollo-rest-starter/src/config/config.ts
@@ -1,0 +1,27 @@
+import knex from 'knex'
+
+/**
+ * config class
+ */
+class Config {
+  public port: any
+  public db: knex.MySqlConnectionConfig
+  public altairConfig: object
+  constructor() {
+    this.port = process.env.PORT || 4000
+    this.db = {
+      database: process.env.DB_NAME || 'users',
+      user: process.env.DB_USERNAME || 'postgresql',
+      password: process.env.DB_PASSWORD || 'postgres',
+      host: process.env.DB_HOSTNAME || '127.0.0.1',
+      port: Number(process.env.DB_PORT) || 55432
+    }
+
+    this.altairConfig = {
+      endpointURL: '/graphql',
+      subscriptionsEndpoint: 'ws://localhost:4000/graphql'
+    }
+  }
+}
+
+export default new Config()

--- a/templates/apollo-rest-starter/src/context.ts
+++ b/templates/apollo-rest-starter/src/context.ts
@@ -1,0 +1,9 @@
+import express from 'express'
+import { RedisPubSub } from 'graphql-redis-subscriptions';
+import knex from 'knex'
+
+export interface GraphQLContext {
+  pubsub: RedisPubSub
+  req: express.Request
+  db: knex<any, unknown[]>
+}

--- a/templates/apollo-rest-starter/src/db.ts
+++ b/templates/apollo-rest-starter/src/db.ts
@@ -1,0 +1,8 @@
+import knex from 'knex'
+
+export async function connect(options: knex.MySqlConnectionConfig) {
+  return knex({
+    client: 'pg',
+    connection: options
+  })
+}

--- a/templates/apollo-rest-starter/src/index.ts
+++ b/templates/apollo-rest-starter/src/index.ts
@@ -1,0 +1,64 @@
+import cors from "cors"
+import express from "express"
+import { makeExecutableSchema } from 'graphql-tools';
+import http from "http"
+import { useSofa } from "sofa-api"
+
+import { altairExpress } from "altair-express-middleware"
+import { ApolloServer } from "apollo-server-express"
+
+import config from "./config/config"
+import { connect } from "./db"
+import { resolvers, typeDefs } from "./mapping"
+import { pubsub } from './subscriptions'
+
+async function start() {
+  const app = express()
+
+  app.use(cors())
+
+  app.get("/health", (req, res) => res.sendStatus(200))
+
+  app.use("/graphql", altairExpress(config.altairConfig));
+
+  const schema = makeExecutableSchema({
+    typeDefs,
+    resolvers,
+  });
+
+  app.use("/rest", useSofa({
+    schema,
+  }))
+
+  // connect to db
+  const client = await connect(config.db);
+
+  const apolloConfig = {
+    typeDefs,
+    resolvers,
+    playground: false,
+    context: async ({
+      req
+    }: { req: express.Request }) => {
+      // pass request + db ref into context for each resolver
+      return {
+        req: req,
+        db: client,
+        pubsub
+      }
+    }
+  }
+
+  const apolloServer = new ApolloServer(apolloConfig)
+
+  apolloServer.applyMiddleware({ app })
+
+  const httpServer = http.createServer(app)
+  apolloServer.installSubscriptionHandlers(httpServer)
+
+  httpServer.listen({ port: config.port }, () => {
+    console.log(`🚀  Server ready at http://localhost:${config.port}/graphql`)
+  })
+}
+
+start()

--- a/templates/apollo-rest-starter/src/mapping.ts
+++ b/templates/apollo-rest-starter/src/mapping.ts
@@ -1,0 +1,2 @@
+export * from '../generated/schema'
+export * from '../generated/resolvers'

--- a/templates/apollo-rest-starter/src/subscriptions.ts
+++ b/templates/apollo-rest-starter/src/subscriptions.ts
@@ -1,0 +1,7 @@
+import { RedisPubSub } from 'graphql-redis-subscriptions'
+import Redis from 'ioredis'
+
+export const pubsub = new RedisPubSub({
+  publisher: new Redis(6789),
+  subscriber: new Redis(6789)
+})

--- a/templates/apollo-rest-starter/tsconfig.json
+++ b/templates/apollo-rest-starter/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist/",
+    "declarationDir": "./types",
+    "lib": [
+      "esnext",
+      "esnext.asynciterable",
+      "es2015",
+      "dom",
+      "es2016"
+    ],
+    "noImplicitAny": true,
+    "preserveConstEnums": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "target": "es6",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "importHelpers": true,
+    "alwaysStrict": false,
+    "sourceMap": true,
+    "declaration": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitThis": false
+  },
+}

--- a/templates/apollo-rest-starter/tslint.json
+++ b/templates/apollo-rest-starter/tslint.json
@@ -1,0 +1,25 @@
+{
+  "extends": "tslint:recommended",
+  "rules": {
+      "max-line-length": {
+          "options": [120]
+      },
+      "semicolon": false,
+      "quotemark": false,
+      "new-parens": true,
+      "no-arg": true,
+      "no-bitwise": true,
+      "no-conditional-assignment": false,
+      "no-consecutive-blank-lines": false,
+      "object-literal-sort-keys": false,
+      "trailing-comma": false,
+      "object-literal-shorthand": false,
+      "no-console": false,
+      "interface-name": false
+  },
+  "jsRules": {
+      "max-line-length": {
+          "options": [120]
+      }
+  }
+}


### PR DESCRIPTION
## Motivation

Not everyone is fully into GraphQL. While using DSL as a way to model data seems very cool and people like it sometimes there is need to use rest for some clients where GraphQL cannot be used (embedded etc.) Adding new template that will offer both REST and GraphQL options. index.ts has main changes.

We are using here Sofa from @urigo that makes this task very simple. 
Going to follow up with testing this template with production ready schemas we have to see how this plays up and if we need to add much more later.


## Verification
```
npm run start
curl http://localhost:4000/rest/me
```