### PR TITLE
fix: disable option in directives

### DIFF
--- a/packages/graphback-cli/package.json
+++ b/packages/graphback-cli/package.json
@@ -59,7 +59,7 @@
     "execa": "2.0.3",
     "figlet": "1.2.3",
     "glob": "7.1.4",
-    "graphback": "^0.6.0",
+    "graphback": "0.6.0",
     "inquirer": "6.5.0",
     "node-emoji": "1.10.0",
     "ora": "3.4.0",

--- a/packages/graphback-cli/src/templates/resources/models/Note.graphql
+++ b/packages/graphback-cli/src/templates/resources/models/Note.graphql
@@ -6,7 +6,7 @@ type Note {
   comments: [Comment]!
 }
 
-type Comment {
+type Comment @update(enable: false){
   id: ID!
   title: String!
   description: String!

--- a/packages/graphback/src/InputTypeVisitor.ts
+++ b/packages/graphback/src/InputTypeVisitor.ts
@@ -61,11 +61,17 @@ export const inputTypeVisitor = {
 
   ObjectTypeDefinition: (node: ObjectTypeDefinitionNode) => {
     let config = {}
+    
     node.directives.map((directive: object) => {
       config = Object.assign(config, directive)
     })
+
     Object.keys(config).forEach((key: string) => {
-      config[`${key}`] = true
+      if(Object.keys(config[key]).length) {
+        config[key] = config[key].enable
+      } else {
+        config[key] = true
+      }
     })
 
     return {

--- a/packages/graphback/src/directives.ts
+++ b/packages/graphback/src/directives.ts
@@ -1,13 +1,13 @@
 const directives = `directive @OneToMany(field: String) on FIELD_DEFINITION
 directive @OneToOne(field: String) on FIELD_DEFINITION
-directive @create on OBJECT
-directive @update on OBJECT
-directive @delete on OBJECT
-directive @find on OBJECT
-directive @findAll on OBJECT
-directive @subCreate on OBJECT
-directive @subUpdate on OBJECT
-directive @subDelete on OBJECT
+directive @create(enable: Boolean) on OBJECT
+directive @update(enable: Boolean) on OBJECT
+directive @delete(enable: Boolean) on OBJECT
+directive @find(enable: Boolean) on OBJECT
+directive @findAll(enable: Boolean) on OBJECT
+directive @subCreate(enable: Boolean) on OBJECT
+directive @subUpdate(enable: Boolean) on OBJECT
+directive @subDelete(enable: Boolean) on OBJECT
 `
 
 export const applyGeneratorDirectives = (schema: string) => {


### PR DESCRIPTION
## Background
```
type Test @update {
.....
}
```
will enable the operation while
```
type Test @update(enable: false) {
.....
}
```
will disable the operation.