### PR TITLE
Adds disableGen to type CreationMetadata

### DIFF
--- a/packages/graphback-cli/src/templates/resources/models/Tasks.graphql
+++ b/packages/graphback-cli/src/templates/resources/models/Tasks.graphql
@@ -8,7 +8,7 @@ type Task {
   assignedTo: User
 }
 
-type CreationMetadata {
+type CreationMetadata @disableGen {
    createdDate: String
    createdBy: User
  }


### PR DESCRIPTION
This (chore) uses the new `@disableGen` directive in the `Tasks.graphql` schema.