### PR TITLE
Generate client queries based on datamodel

### DIFF
--- a/docs/clientsidequeries.md
+++ b/docs/clientsidequeries.md
@@ -1,0 +1,90 @@
+---
+id: clientqueries
+title: Client-side Queries
+---
+
+Graphback allows users to generate client-side queries based on the data model. All the queries/mutations/subscriptions
+which are generated through `graphback generate` for the user can also be generated as client-side queries. Users may follow up 
+with using `create-react-app` or `apollo-client` to kickstart client experience.
+
+## Autogenerating forms based on server-side schema
+These can be used by client side frameworks like [uniform.tools](https://uniforms.tools) to create
+GraphQL client applications.
+
+## How it works
+Graphback asks whether you want to generate client-side queries in the `graphback init` command. Answering it yes,
+will set `client` in `config.json` to `true`.
+
+For a data model having
+```
+type Note {
+  id: ID!
+  title: String!
+  description: String!
+}
+```
+running `graphback generate` will generate all operations which are enabled in `config.json` or using `directives`.
+
+## Examples
+### Fragment
+```
+import gql from "graphql-tag"
+
+export const NoteFragment = gql`
+  fragment NoteFields on Note {
+    id
+    title
+    description
+    published
+  }
+`
+```
+
+### Query
+```
+import gql from "graphql-tag"
+import { NoteFragment } from "../fragments/Note"
+
+export const findAllNotes = gql`
+  query findAllNotes {
+    findAllNotes {
+      ...NoteFields
+    }
+  }
+
+  ${NoteFragment}
+`
+```
+
+### Mutation
+```
+import gql from "graphql-tag"
+import { NoteFragment } from "../fragments/Note"
+
+export const updateNote = gql`
+  mutation updateNote($id: ID!, title: String!, description: String!, published: Boolean!) {
+    updateNote(id: $id, input: {title: $title, description: $description, published: $published}) {4
+      ...NoteFields
+    }
+  }
+
+  ${NoteFragment}
+`
+```
+
+### Subscription
+```
+import gql from "graphql-tag"
+import { CommentFragment } from "../fragments/Comment"
+
+export const newComment = gql`
+  subscription newComment {
+    newComment {
+      ...CommentFields
+    }
+  }
+
+  ${CommentFragment}
+`
+
+```

--- a/packages/graphback-cli/src/helpers/init.ts
+++ b/packages/graphback-cli/src/helpers/init.ts
@@ -4,7 +4,7 @@ import * as figlet from 'figlet'
 import { accessSync, mkdirSync, writeFileSync } from 'fs'
 import { prompt as ask } from 'inquirer'
 import ora from 'ora'
-import { chooseDatabase, createConfig } from '../templates/configTemplates'
+import { askForClient, chooseDatabase, createConfig } from '../templates/configTemplates'
 import { addModel, createModel } from '../templates/modelTemplates';
 import { allTemplates, extractTemplate } from '../templates/starterTemplates'
 import { Template } from '../templates/templateMetadata'
@@ -139,11 +139,12 @@ export async function init(name: string, templateName?: string, templateUrl?: st
 
   const [modelName, content] = await createModel()
   const database = await chooseDatabase()
+  const client = await askForClient()
   mkdirSync(path)
   logInfo(`
 Bootstraping graphql server :dizzy: :sparkles:`)
   await extractTemplate(template, name)
   addModel(name, modelName, content)
-  await Promise.all([installDependencies(name, database), createConfig(database)])
+  await Promise.all([installDependencies(name, database), createConfig(database, client)])
   logInfo(postSetupMessage(name))
 }

--- a/packages/graphback-cli/src/templates/configTemplates.ts
+++ b/packages/graphback-cli/src/templates/configTemplates.ts
@@ -56,10 +56,20 @@ export const chooseDatabase = async(): Promise<string> => {
   return database
 }
 
+export const askForClient = async(): Promise<boolean> => {
+  const { client } = await ask({
+    type: 'confirm',
+    name: 'client',
+    message: 'Do you want to generate client?'
+  })
+
+  return client
+}
+
 /**
  * Create config file with db info
  */
-export const createConfig = async(database: string) => {
+export const createConfig = async(database: string, client: boolean) => {
   const configPath = `${process.cwd()}/config.json`
   const dockerComposePath = `${process.cwd()}/docker-compose.yml`
   const subscriptionPath = `${process.cwd()}/src/subscriptions.ts`
@@ -68,6 +78,7 @@ export const createConfig = async(database: string) => {
   config["dbConfig"] = JSON.parse(dbConfig)
   config["generation"] = generationConfig
   config["database"] = database
+  config["client"] = client
   if(dockerCompose) {
     writeFileSync(dockerComposePath, dockerCompose)
   }

--- a/packages/graphback-cli/src/templates/configTemplates.ts
+++ b/packages/graphback-cli/src/templates/configTemplates.ts
@@ -60,7 +60,7 @@ export const askForClient = async(): Promise<boolean> => {
   const { client } = await ask({
     type: 'confirm',
     name: 'client',
-    message: 'Do you want to generate client?'
+    message: 'Do you want to generate client-side queries?'
   })
 
   return client

--- a/packages/graphback/example/Note.graphql
+++ b/packages/graphback/example/Note.graphql
@@ -9,6 +9,5 @@ type Note {
 
 type Comment {
   id: ID!
-  title: String!
-  description: String!
+  text: String!
 }

--- a/packages/graphback/src/GraphQLBackend.ts
+++ b/packages/graphback/src/GraphQLBackend.ts
@@ -1,3 +1,4 @@
+import { Client, ClientGenerator } from './client';
 import { createInputContext } from './ContextCreator';
 import { Config, Type } from './ContextTypes';
 import { DatabaseContextProvider, DefaultDataContextProvider } from './datasource/DatabaseContextProvider';
@@ -65,6 +66,12 @@ export class GraphQLBackendCreator {
     backend.resolvers = resolverGenerator.generate(database)  
     
     return backend;
+  }
+
+  public async createClient(): Promise<Client> {
+    const clientGenerator = new ClientGenerator(this.inputContext)
+
+    return clientGenerator.generate()
   }
 
 

--- a/packages/graphback/src/client/index.ts
+++ b/packages/graphback/src/client/index.ts
@@ -1,6 +1,18 @@
 import { Type } from '../ContextTypes';
 import { createSampleQueries } from './targetContext';
 
+export interface ClientImplementation {
+  name: string
+  implementation: string
+}
+
+export interface Client {
+  queries?: ClientImplementation[]
+  mutations?: ClientImplementation[]
+  fragments?: ClientImplementation[]
+  subscriptions?: ClientImplementation[]
+}
+
 /**
  * Generate sample queries from the datamodel
  */

--- a/packages/graphback/src/client/index.ts
+++ b/packages/graphback/src/client/index.ts
@@ -1,0 +1,17 @@
+import { Type } from '../ContextTypes';
+import { createSampleQueries } from './targetContext';
+
+/**
+ * Generate sample queries from the datamodel
+ */
+export class ClientGenerator {
+  private inputContext: Type[]
+
+  constructor(inputContext: Type[]) {
+    this.inputContext = inputContext
+  }
+
+  public generate() {
+    return createSampleQueries(this.inputContext)
+  }
+}

--- a/packages/graphback/src/client/targetContext.ts
+++ b/packages/graphback/src/client/targetContext.ts
@@ -9,6 +9,12 @@ const variableFields = (t: Type) => {
                   .join(', ')
 }
 
+const inputVariableFields = (t: Type) => {
+  return t.fields.filter((f: Field) => !f.isType && !f.isArray && f.type!=='ID')
+                  .map((f: Field) => `${f.name}: ${f.type}${f.isNull ? '': '!'}`)
+                  .join(', ')
+}
+
 const variables = (t: Type) => {
   return t.fields.filter((f: Field) => !f.isType && !f.isArray)
                   .map((f: Field) => `${f.name}: \$${f.name}`)
@@ -34,7 +40,8 @@ export const ${fieldName} = gql\`
   }
 
   \$\{${t.name}Fragment}
-\``
+\`
+`
 }
 
 const findQuery = (t: Type, imports: string) => {
@@ -50,7 +57,8 @@ export const ${fieldName} = gql\`
   }
 
   \$\{${t.name}Fragment}
-\``
+\`
+`
 }
 
 
@@ -67,6 +75,7 @@ export const ${fieldName} = gql\`
   }
 
   \$\{${t.name}Fragment}
+\`
 `
 }
 
@@ -76,11 +85,14 @@ const updateMutation = (t: Type, imports: string) => {
   return `${imports}
 
 export const ${fieldName} = gql\`
-  mutation ${fieldName}($id: ID!, ${variableFields(t)}) {
-    ${fieldName}(id: $id, input: {${inputVariables(t)}})
+  mutation ${fieldName}($id: ID!, ${inputVariableFields(t)}) {
+    ${fieldName}(id: $id, input: {${inputVariables(t)}}) {4
+      ...${t.name}Fields
+    }
   }
 
   \$\{${t.name}Fragment}
+\`
 `
 }
 
@@ -95,6 +107,7 @@ export const ${fieldName} = gql\`
       id
     }
   }  
+\`
 `
 }
 
@@ -105,6 +118,7 @@ export const ${t.name}Fragment = gql\`
   fragment ${t.name}Fields on ${t.name} {
     ${t.fields.filter((f: Field) => !f.isArray && !f.isType).map((f: Field) => `${f.name}`).join('\n    ')}
   }
+\`
 `
 }
 

--- a/packages/graphback/src/client/targetContext.ts
+++ b/packages/graphback/src/client/targetContext.ts
@@ -1,0 +1,189 @@
+import { Field, Type } from "../ContextTypes";
+import { getFieldName, ResolverType } from '../utils';
+
+const gqlImport = `import gql from "graphql-tag"`
+
+const variableFields = (t: Type) => {
+  return t.fields.filter((f: Field) => !f.isType && !f.isArray)
+                  .map((f: Field) => `${f.name}: ${f.type}${f.isNull ? '': '!'}`)
+                  .join(', ')
+}
+
+const variables = (t: Type) => {
+  return t.fields.filter((f: Field) => !f.isType && !f.isArray)
+                  .map((f: Field) => `${f.name}: \$${f.name}`)
+                  .join(', ')
+}
+
+const inputVariables = (t: Type) => {
+  return t.fields.filter((f: Field) => !f.isType && !f.isArray && f.type!=='ID')
+                  .map((f: Field) => `${f.name}: \$${f.name}`)
+                  .join(', ')
+}
+
+const findAllQuery = (t: Type, imports: string) => {
+  const fieldName = getFieldName(t.name, ResolverType.FIND_ALL, 's')
+  
+  return `${imports}
+
+export const ${fieldName} = gql\`
+  query ${fieldName} {
+    ${fieldName} {
+      ...${t.name}Fields
+    }
+  }
+
+  \$\{${t.name}Fragment}
+\``
+}
+
+const findQuery = (t: Type, imports: string) => {
+  const fieldName = getFieldName(t.name, ResolverType.FIND)
+
+  return `${imports}
+
+export const ${fieldName} = gql\`
+  query ${fieldName}(${variableFields(t)}) {
+    ${fieldName}(fields: {${variables(t)}}) {
+      ...${t.name}Fields
+    }
+  }
+
+  \$\{${t.name}Fragment}
+\``
+}
+
+
+const createMutation = (t: Type, imports: string) => {
+  const fieldName = getFieldName(t.name, ResolverType.CREATE)
+
+  return `${imports}
+
+export const ${fieldName} = gql\`
+  mutation ${fieldName}(${variableFields(t)}) {
+    ${fieldName}(input: {${inputVariables(t)}}) {
+      ...${t.name}Fields
+    }
+  }
+
+  \$\{${t.name}Fragment}
+`
+}
+
+const updateMutation = (t: Type, imports: string) => {
+  const fieldName = getFieldName(t.name, ResolverType.UPDATE)
+
+  return `${imports}
+
+export const ${fieldName} = gql\`
+  mutation ${fieldName}($id: ID!, ${variableFields(t)}) {
+    ${fieldName}(id: $id, input: {${inputVariables(t)}})
+  }
+
+  \$\{${t.name}Fragment}
+`
+}
+
+const deleteMutation = (t: Type, imports: string) => {
+  const fieldName = getFieldName(t.name, ResolverType.DELETE)
+
+  return `${imports}
+
+export const ${fieldName} = gql\`
+  mutation ${fieldName}($id: ID!) {
+    ${fieldName}(id: $id) {
+      id
+    }
+  }  
+`
+}
+
+const fragment = (t: Type) => {
+  return `${gqlImport}
+
+export const ${t.name}Fragment = gql\`
+  fragment ${t.name}Fields on ${t.name} {
+    ${t.fields.filter((f: Field) => !f.isArray && !f.isType).map((f: Field) => `${f.name}`).join('\n    ')}
+  }
+`
+}
+
+const createFragments = (types: Type[]) => {
+  return types.map((t: Type) => {
+    return {
+      name: t.name,
+      implementation: fragment(t)
+    }
+  })
+}
+
+
+
+const createQueries = (types: Type[]) => {
+  const queries = []
+
+  types.forEach((t: Type) => {
+    const imports = `import gql from "graphql-tag"
+import { ${t.name}Fragment } from "../fragments/${t.name}"`
+
+    if(t.config.find) {
+      queries.push({
+        name: getFieldName(t.name, ResolverType.FIND),
+        implementation: findQuery(t, imports)
+      })
+    }
+
+    if(t.config.findAll) {
+      queries.push({
+        name: getFieldName(t.name, ResolverType.FIND_ALL, 's'),
+        implementation: findAllQuery(t, imports)
+      })
+    }
+  })
+
+  return queries
+}
+
+const createMutations = (types: Type[]) => {
+  const mutations = []
+
+  types.forEach((t: Type) => {
+    const imports = `import gql from "graphql-tag"
+import { ${t.name}Fragment } from "../fragments/${t.name}"`
+
+    if(t.config.create) {
+      mutations.push({
+        name: getFieldName(t.name, ResolverType.CREATE),
+        implementation: createMutation(t, imports)
+      })
+    }
+
+    if(t.config.update) {
+      mutations.push({
+        name: getFieldName(t.name, ResolverType.UPDATE),
+        implementation: updateMutation(t, imports)
+      })
+    }
+
+    if(t.config.delete) {
+      mutations.push({
+        name: getFieldName(t.name, ResolverType.DELETE),
+        implementation: deleteMutation(t, imports)
+      })
+    }
+  })
+
+  return mutations
+}
+
+
+
+export const createSampleQueries = (inputContext: Type[]) => {
+  const context = inputContext.filter((t: Type) => t.name !== 'Query' && t.name !== 'Mutation' && t.name !== 'Subscription')
+
+  return {
+    fragments: createFragments(context),
+    queries: createQueries(context),
+    mutations: createMutations(context)
+  }
+}

--- a/packages/graphback/src/index.ts
+++ b/packages/graphback/src/index.ts
@@ -6,6 +6,9 @@ export * from './GraphQLBackend'
 // Resolvers
 export * from './resolvers'
 
+// Client
+export * from './client'
+
 // DDL layer
 export * from './datasource/DataResourcesManager'
 

--- a/packages/graphback/src/resolvers/outputResolvers/resolverTemplate.ts
+++ b/packages/graphback/src/resolvers/outputResolvers/resolverTemplate.ts
@@ -40,7 +40,7 @@ const generateTypeResolvers = (context: TargetResolverContext, name: string): st
   let output = `${imports}`
 
   if(context.subscriptions.length) {
-    output += `\n\n enum Subscriptions {
+    output += `\n\nenum Subscriptions {
   ${context.subscriptionTypes}
 }`
   }

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -5,6 +5,9 @@
     "previous": "Previous",
     "tagline": "Generate production ready GraphQL backend in less 2 minutes",
     "docs": {
+      "clientqueries": {
+        "title": "Client-side Queries"
+      },
       "commands": {
         "title": "CLI commands"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -11,7 +11,8 @@
       "concepts",
       "templates",
       "datasources",
-      "modules"
+      "modules",
+      "clientqueries"
     ],
     "Reference": [
       "commands"


### PR DESCRIPTION
## How it works
Generate queries and mutation with fragments according to config(which are enabled). #72 

### Mutation
```
import gql from "graphql-tag"
import { NoteFragment } from "../fragments/Note"

export const updateNote = gql`
  mutation updateNote($id: ID!, title: String!, description: String!, published: Boolean!) {
    updateNote(id: $id, input: {title: $title, description: $description, published: $published}) {4
      ...NoteFields
    }
  }

  ${NoteFragment}
`
```

### Query
```
import gql from "graphql-tag"
import { NoteFragment } from "../fragments/Note"

export const findAllNotes = gql`
  query findAllNotes {
    findAllNotes {
      ...NoteFields
    }
  }

  ${NoteFragment}
`
```
### Subscription
```
import gql from "graphql-tag"
import { CommentFragment } from "../fragments/Comment"

export const newComment = gql`
  subscription newComment {
    newComment {
      ...CommentFields
    }
  }

  ${CommentFragment}
`
```

### Fragment
```
import gql from "graphql-tag"

export const NoteFragment = gql`
  fragment NoteFields on Note {
    id
    title
    description
    published
  }
`
```