### PR TITLE
fix: disable js template

### DIFF
--- a/packages/graphback-cli/src/helpers/init.ts
+++ b/packages/graphback-cli/src/helpers/init.ts
@@ -96,8 +96,6 @@ Next Steps:
 3. Run ${chalk.cyan(`graphback generate`)} to generate schema and resolvers
 4. Run ${chalk.cyan(`docker-compose up -d`)} to run your database
    and ${chalk.cyan(`graphback db`)} to create database resources in postgres
-5. Run ${chalk.cyan(`graphback watch`)} to start the server and watch for changes
-   in model.
 `
 }
 

--- a/packages/graphback-cli/src/templates/starterTemplates.ts
+++ b/packages/graphback-cli/src/templates/starterTemplates.ts
@@ -28,16 +28,16 @@ export const allTemplates: Template[] = [
       branch: 'master',
       path: '/templates/apollo-rest-starter',
     }
-  },
-  {
-    name: 'graphql-js-starter',
-    description: 'GraphQL.js template in typescript',
-    repo: {
-      uri: 'https://github.com/aerogear/graphback',
-      branch: 'master',
-      path: '/templates/graphql-js-starter'
-    }
   }
+  // {
+  //   name: 'graphql-js-starter',
+  //   description: 'GraphQL.js template in typescript',
+  //   repo: {
+  //     uri: 'https://github.com/aerogear/graphback',
+  //     branch: 'master',
+  //     path: '/templates/graphql-js-starter'
+  //   }
+  //}
 ]
 /**
  * information about repository


### PR DESCRIPTION
GraphQL-JS template never worked due to resolver issues. At this point, it makes no sense to build separate resolvers for that. We need to think more deeply what the desired architecture we want for the graphback core, but with this week end of GSOC let's keep all features functional