### PR TITLE
fix(config.json): add CRUD config by default to templates

### DIFF
--- a/templates/apollo-rest-starter/config.json
+++ b/templates/apollo-rest-starter/config.json
@@ -6,5 +6,16 @@
     "host": "127.0.0.1",
     "port": 55432
   },
+  "generation": {
+    "create": true,
+    "update": true,
+    "findAll": true,
+    "find": true,
+    "delete": false,
+    "subCreate": false,
+    "subUpdate": false,
+    "subDelete": false,
+    "disableGen": false
+  },
   "database": "pg"
 }

--- a/templates/apollo-starter-ts/config.json
+++ b/templates/apollo-starter-ts/config.json
@@ -6,5 +6,16 @@
     "host": "127.0.0.1",
     "port": 55432
   },
+  "generation": {
+    "create": true,
+    "update": true,
+    "findAll": true,
+    "find": true,
+    "delete": false,
+    "subCreate": false,
+    "subUpdate": false,
+    "subDelete": false,
+    "disableGen": false
+  },
   "database": "pg"
 }

--- a/templates/graphql-js-starter/config.json
+++ b/templates/graphql-js-starter/config.json
@@ -6,5 +6,16 @@
     "host": "127.0.0.1",
     "port": 55432
   },
+  "generation": {
+    "create": true,
+    "update": true,
+    "findAll": true,
+    "find": true,
+    "delete": false,
+    "subCreate": false,
+    "subUpdate": false,
+    "subDelete": false,
+    "disableGen": false
+  },
   "database": "pg"
 }


### PR DESCRIPTION
## Motivation

https://github.com/aerogear/graphback/issues/292

## Verification

1. From each template directory, run `graphback generate`.
2. Resolvers should have been generated.