### PR TITLE
fix: Replace watch with develop

### DIFF
--- a/packages/graphback-cli/src/helpers/db.ts
+++ b/packages/graphback-cli/src/helpers/db.ts
@@ -70,7 +70,7 @@ export const createDBResources = async(): Promise<void> => {
 const postCommandMessage = () => {
   logInfo(`
 Database resources created.
-Run ${chalk.cyan(`graphback watch`)} to start the server and watch for changes.
+Run ${chalk.cyan(`npm run develop`)} to start the server.
   `)
 }
 


### PR DESCRIPTION
Replace watch command with develop. For long term we should have detached run process from the template - for now we can just say that each template needs develop command. 