### PR TITLE
fix: Add documentation for interface support

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -14,7 +14,7 @@ Please follow indidividual releases for more information.
 #### Features
 
 - Support for Interfaces in GraphQL schema
-GraphQL Schema supports now interfaces that can be used to ensure consistency of the data.
+GraphQL Schema now supports interfaces that can be used to ensure consistency of the data.
 Example:
 
 ```graphql

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,6 +8,33 @@ title: Releases
 This file contains changes and migration steps for Graphback project. 
 Please follow indidividual releases for more information.
 
+# Next
+
+### Graphback
+#### Features
+
+- Support for Interfaces in GraphQL schema
+GraphQL Schema supports now interfaces that can be used to ensure consistency of the data.
+Example:
+
+```graphql
+interface Searchable {
+  searchPreviewText: String!
+}
+
+interface Item {
+  price: Int!
+}
+
+type Movie implements Searchable & Item {
+  directory: String!
+  searchPreviewText: String!
+  price: Int!
+}
+```
+
+> NOTE: Interfaces will not be taken into consideration when generating resolvers and database
+
 ## 0.8.3 (29th August, 2019)
 ### Templates
 #### Fixes


### PR DESCRIPTION
Every change we do - skipping some trivial ones will need to land into release notes.
There is no need for documentation for this feature. 