### PR TITLE
fix: broken docs link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to the GraphBack
 
-First, ensure you have the https://docs.npmjs.com/[latest LTS npm] installed.
+First, ensure you have the [latest LTS npm](https://docs.npmjs.com/) installed.
 For CLI usage we recomend to use Node version manager - NVM.
 
 ## Building

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ For CLI usage we recommend to use Node version manager - NVM.
 
 ## Building
 
-```
+```sh
 npm install
 npm run bootstrap
 ```
@@ -14,15 +14,15 @@ npm run bootstrap
 
 The SDK is made by a group of modules, each one implemented in a different NPM package and all placed under `/packages`.
 
-#### Run tests with coverage
+### Run tests with coverage
 
 `npm run test`
 
-#### Run linter
+### Run linter
 
 `npm run lint`
 
-#### Build
+### Build
 
 `npm run build`
 
@@ -36,11 +36,12 @@ npm link
 ```
 
 > NOTE: if you have graphback installed globally it will need to be uninstalled first
+
 ```bash
-npm uninstall -g graphback-cli 
+npm uninstall -g graphback-cli
 ```
 
 ## Debugging command line tool
 
-When using Visual Studio Code developers can use debugger configurations for command line tool. 
+When using Visual Studio Code developers can use debugger configurations for command line tool.
 Each individual command can be executed and it will stop on breakpoints.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to the GraphBack
 
 First, ensure you have the [latest LTS npm](https://docs.npmjs.com/) installed.
-For CLI usage we recomend to use Node version manager - NVM.
+For CLI usage we recommend to use Node version manager - NVM.
 
 ## Building
 


### PR DESCRIPTION
This change fixed a badly formatted hyperlink, which appeared to be using the Asciidoc format.

This change also fixed a typo, and some Markdown linting warnings.