### PR TITLE
fix: duplicate schema in type extension

### DIFF
--- a/packages/graphback/src/ContextCreator.ts
+++ b/packages/graphback/src/ContextCreator.ts
@@ -2,6 +2,7 @@ import { parse, visit } from 'graphql';
 import { Config, INTERFACE_TYPE_DEFINITION, InterfaceType, OBJECT_TYPE_DEFINITION, OBJECT_TYPE_EXTENSION, Type } from './ContextTypes'
 import { applyGeneratorDirectives } from './directives';
 import { inputTypeVisitor } from './InputTypeVisitor';
+import { filterInterfaceTypes, filterObjectExtensions, filterObjectTypes } from './utils';
 
 /**
  * create input context to be reused for
@@ -24,11 +25,11 @@ export const createInputContext = (schemaText: string, defaultConfig: Config): T
 
 
 
-    const extendNodes = context.filter((t: Type) => t.kind === OBJECT_TYPE_EXTENSION)
+    const extendNodes = filterObjectExtensions(context)
 
-    const interfaces = context.filter((t: Type) => t.kind === INTERFACE_TYPE_DEFINITION)
+    const interfaces = filterInterfaceTypes(context)
 
-    context = context.filter((t: Type) => t.kind !== OBJECT_TYPE_EXTENSION && t.kind !== INTERFACE_TYPE_DEFINITION)
+    context = filterObjectTypes(context)
 
     return [...context.map((t: Type) => {
       const extendNode = extendNodes.find((node: Type) => node.name === t.name)

--- a/packages/graphback/src/ContextTypes.ts
+++ b/packages/graphback/src/ContextTypes.ts
@@ -1,5 +1,6 @@
 export const INTERFACE_TYPE_DEFINITION = 'InterfaceTypeDefinition';
 export const OBJECT_TYPE_DEFINITION = 'ObjectTypeDefinition';
+export const OBJECT_TYPE_EXTENSION = 'ObjectTypeExtension';
 
 /**
  * 1:1 relationship directive

--- a/packages/graphback/src/utils/index.ts
+++ b/packages/graphback/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { INTERFACE_TYPE_DEFINITION, OBJECT_TYPE_DEFINITION, Type } from '../ContextTypes';
+import { INTERFACE_TYPE_DEFINITION, OBJECT_TYPE_DEFINITION, OBJECT_TYPE_EXTENSION, Type } from '../ContextTypes';
 
 export enum ResolverType {
   CREATE = 'create',
@@ -21,6 +21,8 @@ export const getTableName = (typeName: string): string => {
 export const filterObjectTypes = (types: Type[]) => types.filter((t: Type) => t.kind === OBJECT_TYPE_DEFINITION);
 
 export const filterInterfaceTypes = (types: Type[]) => types.filter((t: Type) => t.kind === INTERFACE_TYPE_DEFINITION);
+
+export const filterObjectExtensions = (types: Type[]) => types.filter((t: Type) => t.kind === OBJECT_TYPE_EXTENSION);
 
 /**
  * Generate a string literal with the following format:


### PR DESCRIPTION
## Issue
#331 

## Summary
- Modified visited output to combine `ObjectTypeDefinition` and `ObjectTypeExtension` nodes.

## Verification
- Use type extension in model
```
type Note {
  title: String
}

extend type Note {
  description: String
}
```
- Run `graphback generate` and check for duplication in schema as in #331 