### PR TITLE
refactor: use graphql modules

### DIFF
--- a/packages/graphback-cli/src/helpers/db.ts
+++ b/packages/graphback-cli/src/helpers/db.ts
@@ -54,7 +54,7 @@ export const createDBResources = async(): Promise<void> => {
     }
 
      const modelDefinitions: IGraphbackModel[] = models.found.map((m: string) => {
-      const name = path.posix.basename(`${process.cwd()}/${m}`, '.graphql');
+      const name = path.basename(`${process.cwd()}/${m}`, '.graphql');
       const schemaText = readFileSync(`${process.cwd()}/${m}`, 'utf8');
 
       return {

--- a/packages/graphback-cli/src/helpers/generate.ts
+++ b/packages/graphback-cli/src/helpers/generate.ts
@@ -76,7 +76,7 @@ export async function generateBackend(): Promise<void> {
         return;
       }
 
-      writeFileSync(`${modulePath}/${m.name}.ts`, m.schema);
+      writeFileSync(`${modulePath}/${m.name}.graphql`, m.schema);
 
       if (!existsSync(resolverPath)) {
         mkdirSync(resolverPath);

--- a/packages/graphback-cli/src/helpers/generate.ts
+++ b/packages/graphback-cli/src/helpers/generate.ts
@@ -75,22 +75,19 @@ export async function generateBackend(): Promise<void> {
         mkdirSync(`${resolverPath}/generated`)
       }
 
+      m.resolvers.custom.forEach((output: OutputResolver) => {
+        if (!existsSync(`${resolverPath}/custom/${output.name}.ts`) || output.name === 'index') {
+          writeFileSync(`${resolverPath}/custom/${output.name}.ts`, output.output)
+        }
+      });
+
+      const resolverFiles = readdirSync(`${resolverPath}/generated`)
+      resolverFiles.forEach((file: string) => unlinkSync(`${resolverPath}/generated/${file}`))
+
+      m.resolvers.types.forEach((output: OutputResolver) => writeFileSync(`${resolverPath}/generated/${output.name}.ts`, output.output))
+
       writeFileSync(`${modulePath}/index.ts`, m.index);
     });
-
-    // generated.modules.forEach((m: IGraphbackModule) => {
-
-    //   m.resolvers.custom.forEach((output: OutputResolver) => {
-    //     if (!existsSync(`${outputResolverPath}/custom/${output.name}.ts`) || output.name === 'index') {
-    //       writeFileSync(`${outputResolverPath}/custom/${output.name}.ts`, output.output)
-    //     }
-    //   });
-
-    //   const resolverFiles = readdirSync(`${outputResolverPath}/generated`)
-    //   resolverFiles.forEach((file: string) => unlinkSync(`${outputResolverPath}/generated/${file}`))
-
-    //   m.resolvers.types.forEach((output: OutputResolver) => writeFileSync(`${outputResolverPath}/generated/${output.name}.ts`, output.output))
-    // });
 
     writeFileSync(`${modulesPath}/app.ts`, generated.appModule.index)
 

--- a/packages/graphback-cli/src/helpers/generate.ts
+++ b/packages/graphback-cli/src/helpers/generate.ts
@@ -40,7 +40,7 @@ export async function generateBackend(): Promise<void> {
     const modulesPath: string = `${currPath}/src/modules`
 
     const modelDefinitions: IGraphbackModel[] = models.found.map((m: string) => {
-      const name = path.posix.basename(`${process.cwd()}/${m}`, '.graphql');
+      const name = path.basename(`${process.cwd()}/${m}`, '.graphql');
       const schemaText = readFileSync(`${process.cwd()}/${m}`, 'utf8');
 
       return {

--- a/packages/graphback-cli/src/helpers/generate.ts
+++ b/packages/graphback-cli/src/helpers/generate.ts
@@ -72,6 +72,8 @@ export async function generateBackend(): Promise<void> {
         mkdirSync(modulePath, { recursive: true });
       }
 
+      writeFileSync(`${modulePath}/index.ts`, m.index);
+
       if (!m.schema) {
         return;
       }
@@ -102,8 +104,6 @@ export async function generateBackend(): Promise<void> {
       resolverFiles.forEach((file: string) => unlinkSync(`${resolverPath}/generated/${file}`))
 
       m.resolvers.types.forEach((output: OutputResolver) => writeFileSync(`${resolverPath}/generated/${output.name}.ts`, output.output));
-
-      writeFileSync(`${modulePath}/index.ts`, m.index);
     });
 
     writeFileSync(`${modulesPath}/app.ts`, generated.appModule.index)

--- a/packages/graphback-cli/src/helpers/generate.ts
+++ b/packages/graphback-cli/src/helpers/generate.ts
@@ -22,6 +22,7 @@ followed by ${chalk.cyan(`${cliName}db`)} to create database.
  * Generate schema and resolvers using graphback-core and
  * write them into generated folder
  */
+// TODO: make this function smaller (max length nearly exceeded)
 export async function generateBackend(): Promise<void> {
   try {
     const models = new GlobSync('model/*.graphql', { cwd: process.cwd() })
@@ -70,6 +71,11 @@ export async function generateBackend(): Promise<void> {
       if (!existsSync(modulePath)) {
         mkdirSync(modulePath, { recursive: true });
       }
+
+      if (!m.schema) {
+        return;
+      }
+
       writeFileSync(`${modulePath}/${m.name}.ts`, m.schema);
 
       if (!existsSync(resolverPath)) {
@@ -95,7 +101,7 @@ export async function generateBackend(): Promise<void> {
       const resolverFiles = readdirSync(`${resolverPath}/generated`)
       resolverFiles.forEach((file: string) => unlinkSync(`${resolverPath}/generated/${file}`))
 
-      m.resolvers.types.forEach((output: OutputResolver) => writeFileSync(`${resolverPath}/generated/${output.name}.ts`, output.output))
+      m.resolvers.types.forEach((output: OutputResolver) => writeFileSync(`${resolverPath}/generated/${output.name}.ts`, output.output));
 
       writeFileSync(`${modulePath}/index.ts`, m.index);
     });

--- a/packages/graphback/src/GraphQLBackend.ts
+++ b/packages/graphback/src/GraphQLBackend.ts
@@ -9,6 +9,7 @@ import { SchemaGenerator } from './schema';
 import { ModuleGenerator } from './modules';
 import { readFileSync } from 'fs';
 import * as path from 'path';
+import { RelationInfo } from './schema/targetSchemaContext';
 
 /**
  * GraphQLBackend
@@ -136,6 +137,7 @@ export interface IGraphbackModule {
   index?: string
   schema?: string
   resolvers?: IGraphbackResolvers
+  relations?: RelationInfo[]
 }
 
 export interface IGraphbackModel {

--- a/packages/graphback/src/GraphQLBackend.ts
+++ b/packages/graphback/src/GraphQLBackend.ts
@@ -1,6 +1,6 @@
 import { Client, ClientGenerator } from './client';
 import { createInputContext } from './ContextCreator';
-import { Config, OBJECT_TYPE_DEFINITION, Type } from './ContextTypes';
+import { Config, OBJECT_TYPE_DEFINITION, Type, INTERFACE_TYPE_DEFINITION } from './ContextTypes';
 import { DatabaseContextProvider, DefaultDataContextProvider } from './datasource/DatabaseContextProvider';
 import { IDataLayerResourcesManager } from './datasource/DataResourcesManager';
 import { logger } from './logger'
@@ -10,6 +10,7 @@ import { ModuleGenerator } from './modules';
 import { readFileSync } from 'fs';
 import * as path from 'path';
 import { RelationInfo } from './schema/targetSchemaContext';
+import { generateAppModuleTemplate, generateModuleTemplate } from './modules/outputModule/moduleTemplate';
 
 /**
  * GraphQLBackend
@@ -75,10 +76,29 @@ export class GraphQLBackendCreator {
       modules: [commonModule]
     };
 
+    // iterate through the model files and build some core module information.
     this.models.forEach((m: IGraphbackModel) => {
       const modelInputContext = createInputContext(m.schema, this.config);
       const gqlModule = moduleGenerator.generate(m.name, modelInputContext, database);
+
       backend.modules.push(gqlModule);
+    });
+
+    // we need to figure out the inter-dependency between the modules based on the relationship
+    // between different types from each module schema.
+    backend.modules.filter((m: IGraphbackModule) => m.name !== 'Common').forEach((m: IGraphbackModule) => {
+      if (m.dependentTypes && m.dependentTypes.length) {
+        m.dependentTypes.forEach((t: string) => {
+          const dependency = this.findModuleForType(t, backend.modules, [m.name]);
+
+          if (dependency) {
+            m.moduleImports.push(dependency);
+          }
+        });
+      }
+
+      // now that we know the dependencies, we can generate the module entry file.
+      m.index = generateModuleTemplate(m.name, m.moduleImports);
     });
 
     const moduleNames = backend.modules.map((m: IGraphbackModule) => m.name);
@@ -111,6 +131,21 @@ export class GraphQLBackendCreator {
       throw error
     }
   }
+
+  /**
+   *  Find the module where a type exists.
+   *
+   * @param typeName - The name of the type
+   * @param modules - The list of modules to look for the type in
+   * @param excludeModules - Don't search these modules
+   */
+  private findModuleForType(typeName: string, modules: IGraphbackModule[], excludeModules: string[] = []): IGraphbackModule {
+    return modules.filter((m: IGraphbackModule) => !excludeModules.includes(m.name) && !!m.types).find((m: IGraphbackModule) => {
+      return m.types.find((t: Type) => {
+        return t.name === typeName;
+      });
+    });
+  }
 }
 
 /**
@@ -137,7 +172,9 @@ export interface IGraphbackModule {
   index?: string
   schema?: string
   resolvers?: IGraphbackResolvers
-  relations?: RelationInfo[]
+  dependentTypes?: string[]
+  moduleImports?: IGraphbackModule[]
+  types?: Type[]
 }
 
 export interface IGraphbackModel {

--- a/packages/graphback/src/GraphQLBackend.ts
+++ b/packages/graphback/src/GraphQLBackend.ts
@@ -6,6 +6,7 @@ import { IDataLayerResourcesManager } from './datasource/DataResourcesManager';
 import { logger } from './logger'
 import { OutputResolver, ResolverGenerator } from './resolvers';
 import { SchemaGenerator } from './schema';
+import { ModuleGenerator } from './modules';
 /**
  * GraphQLBackend
  *
@@ -65,6 +66,11 @@ export class GraphQLBackendCreator {
     const resolverGenerator = new ResolverGenerator(this.inputContext)
     backend.resolvers = resolverGenerator.generate(database)
 
+    const moduleGenerator = new ModuleGenerator()
+    backend.module = moduleGenerator.generate()
+
+    backend.appModule = moduleGenerator.generateAppModule()
+
     return backend;
   }
 
@@ -101,6 +107,8 @@ export interface IGraphQLBackend {
   schema?: string,
   // Resolvers that should be mounted to schema`
   resolvers?: IGraphbackResolvers
+  module?: IGraphbackModule
+  appModule?: IGraphbackModule
 }
 
 export interface IGraphbackResolvers {
@@ -110,4 +118,8 @@ export interface IGraphbackResolvers {
   types?: OutputResolver[],
   // Custom resolvers stubs
   custom?: OutputResolver[]
+}
+
+export interface IGraphbackModule {
+  index?: string
 }

--- a/packages/graphback/src/GraphQLBackend.ts
+++ b/packages/graphback/src/GraphQLBackend.ts
@@ -81,7 +81,9 @@ export class GraphQLBackendCreator {
       const modelInputContext = createInputContext(m.schema, this.config);
       const gqlModule = moduleGenerator.generate(m.name, modelInputContext, database);
 
-      backend.modules.push(gqlModule);
+      if (gqlModule) {
+        backend.modules.push(gqlModule);
+      }
     });
 
     // we need to figure out the inter-dependency between the modules based on the relationship

--- a/packages/graphback/src/GraphQLBackend.ts
+++ b/packages/graphback/src/GraphQLBackend.ts
@@ -66,11 +66,13 @@ export class GraphQLBackendCreator {
    * Create backend with all related resources
    */
   public async createBackend(database: string): Promise<IGraphQLBackend> {
-    const backend: IGraphQLBackend = {
-      modules: []
-    };
-
     const moduleGenerator = new ModuleGenerator();
+
+    const commonModule = moduleGenerator.generateCommonModule();
+
+    const backend: IGraphQLBackend = {
+      modules: [commonModule]
+    };
 
     this.models.forEach((m: IGraphbackModel) => {
       const modelInputContext = createInputContext(m.schema, this.config);

--- a/packages/graphback/src/GraphQLBackend.ts
+++ b/packages/graphback/src/GraphQLBackend.ts
@@ -91,7 +91,7 @@ export class GraphQLBackendCreator {
         m.dependentTypes.forEach((t: string) => {
           const dependency = this.findModuleForType(t, backend.modules, [m.name]);
 
-          if (dependency) {
+          if (dependency && !m.moduleImports.find((d: IGraphbackModule) => d.name === dependency.name)) {
             m.moduleImports.push(dependency);
           }
         });

--- a/packages/graphback/src/modules/index.ts
+++ b/packages/graphback/src/modules/index.ts
@@ -7,6 +7,10 @@ import { generateAppModuleTemplate, generateCommonModuleTemplate } from './outpu
 export class ModuleGenerator {
 
   public generate(name: string, inputContext: Type[], database: string): IGraphbackModule {
+    if (!inputContext.length) {
+      return undefined;
+    }
+
     const gqlModule: IGraphbackModule = {
       name,
       types: inputContext,
@@ -22,7 +26,7 @@ export class ModuleGenerator {
         interfaces = [...t.interfaces.map((i: InterfaceType) => i.type)];
       }
     });
-    // inputContext.map((t: Type) => t.interfaces.map((i: InterfaceType) => i.type));
+
     gqlModule.dependentTypes = [...schemaGenerator.getRelations(name), ...interfaces];
 
     const resolverGenerator = new ResolverGenerator(inputContext)

--- a/packages/graphback/src/modules/index.ts
+++ b/packages/graphback/src/modules/index.ts
@@ -1,0 +1,17 @@
+import { IGraphbackModule } from '../GraphQLBackend';
+import { generateAppModule, generateModule } from './outputModule/moduleTemplate';
+
+export class ModuleGenerator {
+
+  public generate(): IGraphbackModule {
+    return {
+      index: generateModule()
+    }
+  }
+
+  public generateAppModule(): IGraphbackModule {
+    return {
+      index: generateAppModule()
+    }
+  }
+}

--- a/packages/graphback/src/modules/index.ts
+++ b/packages/graphback/src/modules/index.ts
@@ -1,25 +1,32 @@
-import { Type } from '../ContextTypes';
+import { Type, InterfaceType } from '../ContextTypes';
 import { IGraphbackModule } from '../GraphQLBackend';
-import {  generateAppModuleTemplate, generateModuleTemplate, generateCommonModuleTemplate } from './outputModule/moduleTemplate';
 import { ResolverGenerator } from '../resolvers';
 import { SchemaGenerator } from '../schema';
+import { generateAppModuleTemplate, generateCommonModuleTemplate } from './outputModule/moduleTemplate';
 
 export class ModuleGenerator {
 
   public generate(name: string, inputContext: Type[], database: string): IGraphbackModule {
     const gqlModule: IGraphbackModule = {
-      name
+      name,
+      types: inputContext,
+      moduleImports: []
     };
 
     const schemaGenerator = new SchemaGenerator(inputContext)
     gqlModule.schema = schemaGenerator.generate()
 
-    gqlModule.relations = schemaGenerator.getRelations(name);
+    let interfaces = []
+    inputContext.forEach((t: Type) => {
+      if (t.interfaces) {
+        interfaces = [...t.interfaces.map((i: InterfaceType) => i.type)];
+      }
+    });
+    // inputContext.map((t: Type) => t.interfaces.map((i: InterfaceType) => i.type));
+    gqlModule.dependentTypes = [...schemaGenerator.getRelations(name), ...interfaces];
 
     const resolverGenerator = new ResolverGenerator(inputContext)
     gqlModule.resolvers = resolverGenerator.generate(database)
-
-    gqlModule.index = generateModuleTemplate(gqlModule.name, gqlModule.relations);
 
     return gqlModule;
   }

--- a/packages/graphback/src/modules/index.ts
+++ b/packages/graphback/src/modules/index.ts
@@ -1,17 +1,31 @@
+import { Type } from '../ContextTypes';
 import { IGraphbackModule } from '../GraphQLBackend';
-import { generateAppModule, generateModule } from './outputModule/moduleTemplate';
+import {  generateAppModuleTemplate, generateModule } from './outputModule/moduleTemplate';
+import { ResolverGenerator } from '../resolvers';
+import { SchemaGenerator } from '../schema';
 
 export class ModuleGenerator {
+  private inputContext: Type[]
 
-  public generate(): IGraphbackModule {
-    return {
-      index: generateModule()
-    }
+  public generate(name: string, inputContext: Type[], database: string): IGraphbackModule {
+    const gqlModule: IGraphbackModule = {
+      name
+    };
+
+    const schemaGenerator = new SchemaGenerator(inputContext)
+    gqlModule.schema = schemaGenerator.generate()
+
+    const resolverGenerator = new ResolverGenerator(inputContext)
+    gqlModule.resolvers = resolverGenerator.generate(database)
+
+    gqlModule.index = generateModule(gqlModule.name)
+
+    return gqlModule;
   }
 
-  public generateAppModule(): IGraphbackModule {
+  public generateAppModule(moduleNames: string[]): IGraphbackModule {
     return {
-      index: generateAppModule()
+      index: generateAppModuleTemplate(moduleNames)
     }
   }
 }

--- a/packages/graphback/src/modules/index.ts
+++ b/packages/graphback/src/modules/index.ts
@@ -1,11 +1,10 @@
 import { Type } from '../ContextTypes';
 import { IGraphbackModule } from '../GraphQLBackend';
-import {  generateAppModuleTemplate, generateModule } from './outputModule/moduleTemplate';
+import {  generateAppModuleTemplate, generateModule, generateCommonModuleTemplate } from './outputModule/moduleTemplate';
 import { ResolverGenerator } from '../resolvers';
 import { SchemaGenerator } from '../schema';
 
 export class ModuleGenerator {
-  private inputContext: Type[]
 
   public generate(name: string, inputContext: Type[], database: string): IGraphbackModule {
     const gqlModule: IGraphbackModule = {
@@ -26,6 +25,13 @@ export class ModuleGenerator {
   public generateAppModule(moduleNames: string[]): IGraphbackModule {
     return {
       index: generateAppModuleTemplate(moduleNames)
+    }
+  }
+
+  public generateCommonModule(): IGraphbackModule {
+    return {
+      name: 'Common',
+      index: generateCommonModuleTemplate()
     }
   }
 }

--- a/packages/graphback/src/modules/index.ts
+++ b/packages/graphback/src/modules/index.ts
@@ -1,6 +1,6 @@
 import { Type } from '../ContextTypes';
 import { IGraphbackModule } from '../GraphQLBackend';
-import {  generateAppModuleTemplate, generateModule, generateCommonModuleTemplate } from './outputModule/moduleTemplate';
+import {  generateAppModuleTemplate, generateModuleTemplate, generateCommonModuleTemplate } from './outputModule/moduleTemplate';
 import { ResolverGenerator } from '../resolvers';
 import { SchemaGenerator } from '../schema';
 
@@ -14,10 +14,12 @@ export class ModuleGenerator {
     const schemaGenerator = new SchemaGenerator(inputContext)
     gqlModule.schema = schemaGenerator.generate()
 
+    gqlModule.relations = schemaGenerator.getRelations(name);
+
     const resolverGenerator = new ResolverGenerator(inputContext)
     gqlModule.resolvers = resolverGenerator.generate(database)
 
-    gqlModule.index = generateModule(gqlModule.name)
+    gqlModule.index = generateModuleTemplate(gqlModule.name, gqlModule.relations);
 
     return gqlModule;
   }

--- a/packages/graphback/src/modules/outputModule/moduleTemplate.ts
+++ b/packages/graphback/src/modules/outputModule/moduleTemplate.ts
@@ -5,20 +5,19 @@ const commonImports = [
 ];
 
 const moduleImports = [
-  "import { resolvers } from './resolvers';",
-  "import { CommonModule } from '../common';"
+  "import { importSchema } from 'graphql-import';",
+  "import { CommonModule } from '../common';",
+  "import { resolvers } from './resolvers';"
 ];
 
 export const generateModule = (name: string) => {
-  const modelImport = createImportString(['typeDefs'], `'./${name}'`);
-
   // TODO: Sort imports alphabetically
-  const imports = [...commonImports, ...moduleImports, modelImport];
+  const imports = [...commonImports, ...moduleImports];
 
   return `${imports.join(`\n`)}
 
 export const ${name}Module = new GraphQLModule({
-  typeDefs,
+  typeDefs: importSchema(__dirname + '/${name}.graphql'),
   resolvers,
   imports: [
     CommonModule

--- a/packages/graphback/src/modules/outputModule/moduleTemplate.ts
+++ b/packages/graphback/src/modules/outputModule/moduleTemplate.ts
@@ -1,0 +1,34 @@
+const commonImports = [
+  "import { GraphQLModule } from '@graphql-modules/core';",
+];
+
+const moduleImports = [
+  "import 'graphql-import-node';",
+  "import { typeDefs } from './model';",
+  "import { resolvers } from './resolvers';"
+];
+
+const appImports = [
+  "import { DefaultModule } from './default'"
+];
+
+export const generateModule = () => {
+  return `${[...commonImports, ...moduleImports].join(`\n`)}
+
+export const DefaultModule = new GraphQLModule({
+  typeDefs,
+  resolvers
+});
+`;
+}
+
+export const generateAppModule = () => {
+  return `${[...commonImports, ...appImports].join(`\n`)}
+
+export const AppModule = new GraphQLModule({
+  imports: [
+    DefaultModule
+  ]
+});
+`;
+}

--- a/packages/graphback/src/modules/outputModule/moduleTemplate.ts
+++ b/packages/graphback/src/modules/outputModule/moduleTemplate.ts
@@ -1,26 +1,31 @@
 import { createImportString } from '../../utils';
+import { RelationInfo } from '../../schema/targetSchemaContext';
 
 const commonImports = [
   "import { GraphQLModule } from '@graphql-modules/core';",
 ];
 
-const moduleImports = [
-  "import { importSchema } from 'graphql-import';",
+const commonModuleImports = [
+  "import 'graphql-import-node';",
   "import { CommonModule } from '../common';",
   "import { resolvers } from './resolvers';"
 ];
 
-export const generateModule = (name: string) => {
+export const generateModuleTemplate = (name: string, relations: RelationInfo[]) => {
+  const moduleImports = relations.map((r: RelationInfo) => createImportString([`${r.name}Module`], `'../${r.name.toLowerCase()}'`));
+
+  const schemaImport = createImportString(['* as typeDefs'], `'./${name}.graphql'`, true)
+
   // TODO: Sort imports alphabetically
-  const imports = [...commonImports, ...moduleImports];
+  const imports = [...commonImports, ...commonModuleImports, ...moduleImports, schemaImport];
 
   return `${imports.join(`\n`)}
 
 export const ${name}Module = new GraphQLModule({
-  typeDefs: importSchema(__dirname + '/${name}.graphql'),
+  typeDefs,
   resolvers,
   imports: [
-    CommonModule
+    CommonModule,${relations.length ? relations.map((r: RelationInfo) => `\n${r.name}Module`).join(',') : ''}
   ]
 });
 `;

--- a/packages/graphback/src/modules/outputModule/moduleTemplate.ts
+++ b/packages/graphback/src/modules/outputModule/moduleTemplate.ts
@@ -24,6 +24,9 @@ export const generateModuleTemplate = (name: string, importedModules: IGraphback
 export const ${name}Module = new GraphQLModule({
   typeDefs,
   resolvers,
+  resolverValidationOptions: {
+    requireResolversForResolveType: false
+  },
   imports: [
     CommonModule,${importedModules.length ? importedModules.map((m: IGraphbackModule) => `\n    ${m.name}Module`).join(',') : ''}
   ]

--- a/packages/graphback/src/modules/outputModule/moduleTemplate.ts
+++ b/packages/graphback/src/modules/outputModule/moduleTemplate.ts
@@ -1,33 +1,38 @@
+import { createImportString } from '../../utils';
+
 const commonImports = [
   "import { GraphQLModule } from '@graphql-modules/core';",
 ];
 
 const moduleImports = [
   "import 'graphql-import-node';",
-  "import { typeDefs } from './model';",
   "import { resolvers } from './resolvers';"
 ];
 
-const appImports = [
-  "import { DefaultModule } from './default'"
-];
+export const generateModule = (name: string) => {
+  const modelImport = createImportString(['typeDefs'], `'./${name}'`);
 
-export const generateModule = () => {
-  return `${[...commonImports, ...moduleImports].join(`\n`)}
+  // TODO: Sort imports alphabetically
+  const imports = [...commonImports, ...moduleImports, modelImport];
 
-export const DefaultModule = new GraphQLModule({
+  return `${imports.join(`\n`)}
+
+export const ${name}Module = new GraphQLModule({
   typeDefs,
   resolvers
 });
 `;
 }
 
-export const generateAppModule = () => {
-  return `${[...commonImports, ...appImports].join(`\n`)}
+export const generateAppModuleTemplate = (moduleNames: string[]) => {
+
+  const imports = moduleNames.map((m: string) => createImportString([`${m}Module`], `'./${m.toLowerCase()}'`))
+
+  return `${[...commonImports, ...imports].join(`\n`)}
 
 export const AppModule = new GraphQLModule({
   imports: [
-    DefaultModule
+    ${moduleNames.map((m: string) => `${m}Module`).join(`,\n    `)}
   ]
 });
 `;

--- a/packages/graphback/src/modules/outputModule/moduleTemplate.ts
+++ b/packages/graphback/src/modules/outputModule/moduleTemplate.ts
@@ -1,5 +1,5 @@
+import { IGraphbackModule } from '../../GraphQLBackend';
 import { createImportString } from '../../utils';
-import { RelationInfo } from '../../schema/targetSchemaContext';
 
 const commonImports = [
   "import { GraphQLModule } from '@graphql-modules/core';",
@@ -11,8 +11,8 @@ const commonModuleImports = [
   "import { resolvers } from './resolvers';"
 ];
 
-export const generateModuleTemplate = (name: string, relations: RelationInfo[]) => {
-  const moduleImports = relations.map((r: RelationInfo) => createImportString([`${r.name}Module`], `'../${r.name.toLowerCase()}'`));
+export const generateModuleTemplate = (name: string, importedModules: IGraphbackModule[] = []) => {
+  const moduleImports = importedModules.map((m: IGraphbackModule) => createImportString([`${m.name}Module`], `'../${m.name.toLowerCase()}'`));
 
   const schemaImport = createImportString(['* as typeDefs'], `'./${name}.graphql'`, true)
 
@@ -25,7 +25,7 @@ export const ${name}Module = new GraphQLModule({
   typeDefs,
   resolvers,
   imports: [
-    CommonModule,${relations.length ? relations.map((r: RelationInfo) => `\n${r.name}Module`).join(',') : ''}
+    CommonModule,${importedModules.length ? importedModules.map((m: IGraphbackModule) => `\n    ${m.name}Module`).join(',') : ''}
   ]
 });
 `;

--- a/packages/graphback/src/modules/outputModule/moduleTemplate.ts
+++ b/packages/graphback/src/modules/outputModule/moduleTemplate.ts
@@ -5,8 +5,8 @@ const commonImports = [
 ];
 
 const moduleImports = [
-  "import 'graphql-import-node';",
-  "import { resolvers } from './resolvers';"
+  "import { resolvers } from './resolvers';",
+  "import { CommonModule } from '../common';"
 ];
 
 export const generateModule = (name: string) => {
@@ -19,21 +19,45 @@ export const generateModule = (name: string) => {
 
 export const ${name}Module = new GraphQLModule({
   typeDefs,
-  resolvers
+  resolvers,
+  imports: [
+    CommonModule
+  ]
 });
 `;
 }
 
 export const generateAppModuleTemplate = (moduleNames: string[]) => {
-
   const imports = moduleNames.map((m: string) => createImportString([`${m}Module`], `'./${m.toLowerCase()}'`))
 
   return `${[...commonImports, ...imports].join(`\n`)}
 
 export const AppModule = new GraphQLModule({
+  resolverValidationOptions: {
+    requireResolversForResolveType: false
+  },
   imports: [
     ${moduleNames.map((m: string) => `${m}Module`).join(`,\n    `)}
   ]
 });
 `;
+}
+
+export const generateCommonModuleTemplate = () => {
+  return `
+${commonImports.map((i: string) => i).join('\n')}
+import config from '../../config/config';
+import { connect } from '../../db';
+import { pubsub } from '../../subscriptions';
+
+export const CommonModule = new GraphQLModule({
+  async context(session, context, info) {
+    return {
+      req: session.req,
+      db: await connect(config.db),
+      pubsub
+    }
+  },
+});
+`
 }

--- a/packages/graphback/src/resolvers/outputResolvers/resolverTemplate.ts
+++ b/packages/graphback/src/resolvers/outputResolvers/resolverTemplate.ts
@@ -1,6 +1,6 @@
 import { Custom, TargetResolverContext, TypeContext } from '../knex/targetResolverContext';
 
-const imports = `import { GraphQLContext } from '../../context'`
+const imports = `import { GraphQLContext } from '../../../../context'`
 
 /**
  * Generate resolvers for each type

--- a/packages/graphback/src/schema/index.ts
+++ b/packages/graphback/src/schema/index.ts
@@ -17,10 +17,10 @@ export class SchemaGenerator {
     this.context = buildTargetContext(inputContext);
   }
 
-  public getRelations(name: string): RelationInfo[] {
-    const relations = this.context.relations.filter((r: RelationInfo) => r.name !== name);
+  public getRelations(name: string): string[] {
+    const relations = this.context.relations.filter((r: RelationInfo) => r.name !== name).map((r: RelationInfo) => r.name);
 
-    return uniqueBy(relations, 'name');
+    return [...new Set(relations)];
   }
 
   /**

--- a/packages/graphback/src/schema/index.ts
+++ b/packages/graphback/src/schema/index.ts
@@ -1,6 +1,7 @@
 import { Type } from '../ContextTypes';
+import { uniqueBy } from '../utils';
 import { generateSchema } from './schemaTemplate';
-import { buildTargetContext, createCustomSchemaContext, TargetContext } from './targetSchemaContext';
+import { buildTargetContext, createCustomSchemaContext, RelationInfo, TargetContext } from './targetSchemaContext';
 
 
 /**
@@ -12,14 +13,20 @@ export class SchemaGenerator {
   private inputContext: Type[]
 
   constructor(inputContext: Type[]) {
-    this.inputContext = inputContext
+    this.inputContext = inputContext;
+    this.context = buildTargetContext(inputContext);
+  }
+
+  public getRelations(name: string): RelationInfo[] {
+    const relations = this.context.relations.filter((r: RelationInfo) => r.name !== name);
+
+    return uniqueBy(relations, 'name');
   }
 
   /**
    * Generate output schema as string
    */
   public generate() {
-    this.context = buildTargetContext(this.inputContext)
     const [ customQueries, customMutations, customSubscriptions ] = createCustomSchemaContext(this.inputContext)
 
     return generateSchema(this.context, customQueries, customMutations, customSubscriptions)

--- a/packages/graphback/src/schema/schemaTemplate.ts
+++ b/packages/graphback/src/schema/schemaTemplate.ts
@@ -38,8 +38,6 @@ const filters = (defs: TargetType[]): string => {
   }`).join('\n\n  ')}`
 }
 
-const imports = `import gql from 'graphql-tag'`
-
 /**
  * Patch together generated and custom queries
  * @param queries queries generated from the types (CRUD)
@@ -128,10 +126,7 @@ const outputSchema = (context: TargetContext, customQueries: string[], customMut
   const allMutations = generateMutations(mutations, customMutations)
   const allSubs = generateSubscriptions(subscriptions, customSubscriptions)
 
-  let output = `${imports}
-
-export const typeDefs = gql\`
-  ${nodeInterfaces(interfaces)}
+  let output = `${nodeInterfaces(interfaces)}
 
   ${nodeTypes(types)}
 
@@ -150,8 +145,6 @@ export const typeDefs = gql\`
   if (allSubs) {
     output += `\n\n  ${allSubs}`
   }
-
-  output += `\n\`\n`
 
   return output
 }

--- a/packages/graphback/src/schema/targetSchemaContext.ts
+++ b/packages/graphback/src/schema/targetSchemaContext.ts
@@ -7,7 +7,7 @@ export interface TargetType {
   fields: string[]
 }
 
-interface RelationInfo {
+export interface RelationInfo {
   name: string
   //tslint:disable-next-line
   type: string
@@ -24,6 +24,7 @@ export interface TargetContext {
   interfaces: TargetType[]
   inputFields: TargetType[]
   filterFields: TargetType[],
+  relations: RelationInfo[],
   // pagination: Type[],
   queries: string[],
   mutations: string[],
@@ -168,12 +169,12 @@ export const buildTargetContext = (input: Type[]) => {
     })
   });
 
-
   const context: TargetContext = {
     types: [],
     interfaces: [],
     inputFields: [],
     filterFields: [],
+    relations,
     // pagination: [],
     queries: [],
     mutations: [],
@@ -182,7 +183,6 @@ export const buildTargetContext = (input: Type[]) => {
 
   const objectTypes = filterObjectTypes(inputContext);
   const interfaceTypes = filterInterfaceTypes(inputContext);
-
 
   context.types = objectTypes.map((t: Type) => {
     return {

--- a/packages/graphback/src/utils/index.ts
+++ b/packages/graphback/src/utils/index.ts
@@ -33,8 +33,25 @@ export const createImplementsInterfaceString = (names: string[]) => {
   return `implements ${names.map((name: string) => name).join(' & ')} `;
 }
 
-export const createImportString = (names: string[], path: string) => {
+export const createImportString = (names: string[], path: string, isDefault: boolean = false) => {
   const imports = names.map((name: string) => name).join(', ');
 
-  return `import { ${imports} } from ${path};`;
+  return `import ${ isDefault ? '' : '{ '}${imports}${ isDefault ? '' : ' }'} from ${path};`;
 };
+
+/**
+ * Filter duplicate items in an array by one of their keys
+ *
+ * @param arr - The array to filter
+ * @param key - The key to compare each item on.
+ */
+/* tslint:disable:no-any */
+export const uniqueBy = (arr: any[], key: string) => {
+  const seen = new Set();
+
+  return arr.filter((item: any) => {
+    const k = item[key];
+
+    return seen.has(k) ? false : seen.add(k);
+  });
+}

--- a/packages/graphback/src/utils/index.ts
+++ b/packages/graphback/src/utils/index.ts
@@ -32,3 +32,9 @@ export const filterInterfaceTypes = (types: Type[]) => types.filter((t: Type) =>
 export const createImplementsInterfaceString = (names: string[]) => {
   return `implements ${names.map((name: string) => name).join(' & ')} `;
 }
+
+export const createImportString = (names: string[], path: string) => {
+  const imports = names.map((name: string) => name).join(', ');
+
+  return `import { ${imports} } from ${path};`;
+};

--- a/templates/apollo-starter-ts/package.json
+++ b/templates/apollo-starter-ts/package.json
@@ -20,7 +20,8 @@
     "graphql-import-node": "0.0.4",
     "graphql-subscriptions": "1.1.0",
     "graphql-tag": "2.10.1",
-    "knex": "0.19.3"
+    "knex": "0.19.3",
+    "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
     "@types/graphql": "14.2.3",

--- a/templates/apollo-starter-ts/package.json
+++ b/templates/apollo-starter-ts/package.json
@@ -18,6 +18,7 @@
     "express": "4.17.1",
     "graphql": "14.5.4",
     "graphql-import": "0.7.1",
+    "graphql-import-node": "0.0.4",
     "graphql-subscriptions": "1.1.0",
     "graphql-tag": "2.10.1",
     "knex": "0.19.3",

--- a/templates/apollo-starter-ts/package.json
+++ b/templates/apollo-starter-ts/package.json
@@ -17,6 +17,7 @@
     "cors": "2.8.5",
     "express": "4.17.1",
     "graphql": "14.5.4",
+    "graphql-import-node": "0.0.4",
     "graphql-subscriptions": "1.1.0",
     "graphql-tag": "2.10.1",
     "knex": "0.19.3"

--- a/templates/apollo-starter-ts/package.json
+++ b/templates/apollo-starter-ts/package.json
@@ -17,7 +17,6 @@
     "cors": "2.8.5",
     "express": "4.17.1",
     "graphql": "14.5.4",
-    "graphql-import": "0.7.1",
     "graphql-import-node": "0.0.4",
     "graphql-subscriptions": "1.1.0",
     "graphql-tag": "2.10.1",

--- a/templates/apollo-starter-ts/package.json
+++ b/templates/apollo-starter-ts/package.json
@@ -12,6 +12,7 @@
   },
   "license": "Apache 2.0",
   "dependencies": {
+    "@graphql-modules/core": "^0.7.11",
     "apollo-server-express": "2.9.3",
     "cors": "2.8.5",
     "express": "4.17.1",

--- a/templates/apollo-starter-ts/package.json
+++ b/templates/apollo-starter-ts/package.json
@@ -17,7 +17,7 @@
     "cors": "2.8.5",
     "express": "4.17.1",
     "graphql": "14.5.4",
-    "graphql-import-node": "0.0.4",
+    "graphql-import": "0.7.1",
     "graphql-subscriptions": "1.1.0",
     "graphql-tag": "2.10.1",
     "knex": "0.19.3",

--- a/templates/apollo-starter-ts/src/index.ts
+++ b/templates/apollo-starter-ts/src/index.ts
@@ -2,12 +2,9 @@ import cors from "cors"
 import express from "express"
 import http from "http"
 
-import { ApolloServer, makeExecutableSchema } from "apollo-server-express"
+import { ApolloServer } from "apollo-server-express"
 
 import config from "./config/config"
-import { connect } from "./db"
-import { resolvers, typeDefs } from "./mapping"
-import { pubsub } from './subscriptions'
 import { AppModule } from './modules/app';
 
 async function start() {
@@ -19,32 +16,7 @@ async function start() {
 
   const { schema } = AppModule;
 
-  // connect to db
-  const client = await connect(config.db);
-
-  // const schema = makeExecutableSchema({
-  //   typeDefs,
-  //   resolvers,
-  //   resolverValidationOptions: {
-  //     requireResolversForResolveType: false
-  //   }
-  // });
-
-  const apolloConfig = {
-    schema,
-    context: async ({
-      req
-    }: {req: express.Request}) => {
-      // pass request + db ref into context for each resolver
-      return {
-        req: req,
-        db: client,
-        pubsub
-      }
-    }
-  }
-
-  const apolloServer = new ApolloServer(apolloConfig)
+  const apolloServer = new ApolloServer({ schema });
 
   apolloServer.applyMiddleware({ app })
 

--- a/templates/apollo-starter-ts/src/index.ts
+++ b/templates/apollo-starter-ts/src/index.ts
@@ -8,6 +8,7 @@ import config from "./config/config"
 import { connect } from "./db"
 import { resolvers, typeDefs } from "./mapping"
 import { pubsub } from './subscriptions'
+import { AppModule } from './modules/app';
 
 async function start() {
   const app = express()
@@ -16,16 +17,18 @@ async function start() {
 
   app.get("/health", (req, res) => res.sendStatus(200))
 
+  const { schema } = AppModule;
+
   // connect to db
   const client = await connect(config.db);
 
-  const schema = makeExecutableSchema({
-    typeDefs,
-    resolvers,
-    resolverValidationOptions: {
-      requireResolversForResolveType: false
-    }
-  });
+  // const schema = makeExecutableSchema({
+  //   typeDefs,
+  //   resolvers,
+  //   resolverValidationOptions: {
+  //     requireResolversForResolveType: false
+  //   }
+  // });
 
   const apolloConfig = {
     schema,


### PR DESCRIPTION
https://github.com/aerogear/graphback/issues/337

The purpose of this pull request is to investigate the feasibility and benefits of refactoring Graphback to use [graphql-modules](https://graphql-modules.com/).

## Tasks

- [x] Separate type definitions into individual module folder.
- [x] Separate resolvers into their own module folder.
- [x] Update database generation process.
- [x] Figure out how to dynamically import modules into each other, based on required relationship between types defined in each schema.
- [ ] Move database access logic from resolvers into providers.
- [ ] Clean up.

## Verification

1. Define 3 .graphql files in the model directory.

**Interfaces.gql**

```gql
interface Person {
    name: String
}

```

**Comment.graphql**

```gql
type Comment {
    text: String
}
```
**Note.graphql**

```gql
type Note {
    title: String
    text: String
    comments: [Comment!]!
    author: Author
}

type Author implements Person {
    id: ID
    name: String
}

type Reader implements Person {
  name: String
}
```

2. Run `graphback generate`.
3. Run `graphback db`.
4. Run `npm run develop`.
5. Open your GraphQL playground and create/fetch some data.