### PR TITLE
feat: unrecognized commands throw an error

### DIFF
--- a/packages/graphback-cli/src/index.ts
+++ b/packages/graphback-cli/src/index.ts
@@ -9,6 +9,7 @@ if (require.main === module) {
   yargs
     .commandDir('commands')
     .demandCommand(1)
+    .strict()
     .help()
     .version()
     .argv;


### PR DESCRIPTION
feat: check if the command exits or if enough arguments have been passed.
#348 

Check:
- Link graphback-cli
- Use graphback with command `graphback start` should produce an error.
- Use graphback with no commands should provide the same output as usual with 
`Not enough non-option arguments: got 0, need at least 1` 
- Everything else works as normal
