### PR TITLE
fix: creating unnecesarry types

### DIFF
--- a/packages/graphback-cli/src/templates/resources/models/Shop.graphql
+++ b/packages/graphback-cli/src/templates/resources/models/Shop.graphql
@@ -4,6 +4,7 @@ type Shop {
   ## Relationship
   products: [Product]!
   customers: [Person]!
+  owner: Person!
 }
 
 type Person {

--- a/packages/graphback/src/resolvers/knex/targetResolverContext.ts
+++ b/packages/graphback/src/resolvers/knex/targetResolverContext.ts
@@ -141,7 +141,7 @@ export const buildTypeContext = (context: Type, database: string, relations: str
     typeContext.subscriptions = [newSub(context), updatedSub(context), deletedSub(context)].filter((s: string) => s!==undefined)
     typeContext.subscriptionTypes = createSubscriptionTypes(context)
   }
-
+  
   return typeContext
 }
 
@@ -167,10 +167,6 @@ export const buildResolverTargetContext = (input: Type[], database: string) => {
             typeName: t.name,
             implementation: knex.typeRelation('OneToOne', columnName, f.name, f.type.toLowerCase())
           })
-          relations.push({
-            typeName: f.type,
-            implementation: knex.invertTypeRelation(columnName, t.name.toLowerCase(), t.name.toLowerCase())
-          })
         } else if(f.directives.OneToMany || f.isArray) {
           let columnName = `${t.name.toLowerCase()}Id`
           if(f.directives.OneToMany) {
@@ -179,10 +175,6 @@ export const buildResolverTargetContext = (input: Type[], database: string) => {
           relations.push({
             typeName: t.name,
             implementation: knex.typeRelation('OneToMany', columnName, f.name, f.type.toLowerCase())
-          })
-          relations.push({
-            typeName: f.type,
-            implementation: knex.invertTypeRelation(columnName, t.name.toLowerCase(), t.name.toLowerCase())
           })
         }
       }


### PR DESCRIPTION
#360 

Leaving it as a draft for now as I'm still investigating whether that's a solution for the issue

Issue before:
![image](https://user-images.githubusercontent.com/43473912/65763087-7a5faa80-e11a-11e9-8521-ec7f08a52824.png)

When for example Shop had an attribute of type of another entity it would generate resolver for that entity also. Creating ` *:* ` relationship out of ` 1:* ` causing it to fail.

Fix:

![image](https://user-images.githubusercontent.com/43473912/65766172-235dd380-e122-11e9-98e8-a599a8fc4e29.png)



Given above schema our person resolvers look like this now:
![image](https://user-images.githubusercontent.com/43473912/65763223-d296ac80-e11a-11e9-9d78-76d86f998807.png)

and shop resolvers :

![image](https://user-images.githubusercontent.com/43473912/65766474-0f66a180-e123-11e9-8c38-bd9c02b65b28.png)
