### PR TITLE
Add CLI shorthands (aliases) for --help and --version

### DIFF
--- a/packages/graphback-cli/src/index.ts
+++ b/packages/graphback-cli/src/index.ts
@@ -11,6 +11,8 @@ if (require.main === module) {
     .demandCommand(1)
     .strict()
     .help()
+    .alias('h', 'help')
     .version()
+    .alias('v', 'version')
     .argv;
 }


### PR DESCRIPTION
Due to cheatsheet: https://devhints.io/yargs
Resolves: #366, #367