### PR TITLE
chore: add tests for sqlite in-memory data provider

### DIFF
--- a/packages/graphback/src/layers/data/KnexDBDataProvider.ts
+++ b/packages/graphback/src/layers/data/KnexDBDataProvider.ts
@@ -74,7 +74,7 @@ export class KnexDBDataProvider<Type = any, GraphbackContext = any> implements G
         throw new NoDataError(`No results for ${name} query and filter: ${JSON.stringify(filter)}`);
     }
 
-    public async batchRead(name: string, ids: [string]): Promise<Type[]> {
+    public async batchRead(name: string, ids: string[]): Promise<Type[]> {
         const dbResult = await this.db.select().from(name).where('id', 'in', ids);
         if (dbResult) {
             return dbResult;

--- a/packages/graphback/tests/layers/data/sqlite_in_memory_data_provider_test.ts
+++ b/packages/graphback/tests/layers/data/sqlite_in_memory_data_provider_test.ts
@@ -1,0 +1,96 @@
+// tslint:disable-next-line: match-default-export-name
+import _test, { TestInterface } from 'ava';
+import * as Knex from 'knex';
+import { KnexDBDataProvider } from '../../../src/layers/data/KnexDBDataProvider';
+
+// tslint:disable: typedef
+
+interface Context {
+  db: Knex;
+  provider: KnexDBDataProvider;
+}
+
+interface Todo {
+  id: number;
+  text: string;
+}
+
+const test = _test as TestInterface<Context>;
+
+// Create a new database before each tests so that
+// all tests can run parallel
+test.beforeEach(async t => {
+  const db = Knex({
+    client: 'sqlite3',
+    connection: {
+      filename: ':memory:',
+    },
+    useNullAsDefault: true,
+  });
+
+  await db.schema.createTable('todos', table => {
+    table.increments(); // id
+    table.string('text');
+  });
+
+  // insert a couple of default data
+  await db('todos').insert({ text: 'my first default todo' });
+  await db('todos').insert({ text: 'the second todo' });
+  await db('todos').insert({ text: 'just another todo' });
+
+  const provider = new KnexDBDataProvider(db);
+
+  t.context = { db, provider };
+});
+
+test('read Todo', async t => {
+  const todo: Todo = await t.context.provider.readObject('todos', '3');
+
+  t.assert(todo.id === 3);
+  t.assert(todo.text === 'just another todo');
+});
+
+test('batch read Todos', async t => {
+  const todos: Todo[] = await t.context.provider.batchRead('todos', ['1', '2']);
+
+  t.assert(todos.length === 2);
+});
+
+test('create Todo', async t => {
+  const todo: Todo = await t.context.provider.createObject('todos', {
+    text: 'create a todo',
+  });
+
+  t.assert(todo.id === 4);
+  t.assert(todo.text === 'create a todo');
+});
+
+test('update Todo', async t => {
+  const todo: Todo = await t.context.provider.updateObject('todos', '1', {
+    text: 'my updated first todo',
+  });
+
+  t.assert(todo.id === 1);
+  t.assert(todo.text === 'my updated first todo');
+});
+
+test('delete Todo', async t => {
+  const id = await t.context.provider.deleteObject('todos', '3');
+
+  t.assert(id === '3');
+});
+
+test('find all Todos', async t => {
+  const todos = await t.context.provider.findAll('todos');
+
+  t.assert(todos.length === 3);
+});
+
+test('find Todo by text', async t => {
+  const todos: Todo[] = await t.context.provider.findBy('todos', {
+    text: 'the second todo',
+  });
+
+  t.assert(todos.length === 1);
+  t.assert(todos[0].id === 2);
+});


### PR DESCRIPTION
Create and update tests are failing:
```
# npx ava ./tests/layers/data/sqlite_in_memory_data_provider_test.ts 

⠴ .returning() is not supported by sqlite3 and will not have any effect.
⠦ .returning() is not supported by sqlite3 and will not have any effect.

  2 tests failed

  update Todo

  /home/dbizzarr/Projects/github.com/aerogear/graphback/packages/graphback/src/layers/data/KnexDBDataProvider.ts:39

   38:         }                                              
   39:         throw new NoDataError(`Cannot update ${name}`);
   40:     }                                                  

  Rejected promise returned by test. Reason:

  Error (NoDataError) {
    message: 'No result from database: Cannot update todos',
  }

  KnexDBDataProvider.<anonymous> (src/layers/data/KnexDBDataProvider.ts:39:15)
  fulfilled (node_modules/tslib/tslib.js:107:62)



  create Todo

  /home/dbizzarr/Projects/github.com/aerogear/graphback/packages/graphback/src/layers/data/KnexDBDataProvider.ts:31

   30:         }                                              
   31:         throw new NoDataError(`Cannot create ${name}`);
   32:     }                                                  

  Rejected promise returned by test. Reason:

  Error (NoDataError) {
    message: 'No result from database: Cannot create todos',
  }

  KnexDBDataProvider.<anonymous> (src/layers/data/KnexDBDataProvider.ts:31:15)
  fulfilled (node_modules/tslib/tslib.js:107:62)
```