### PR TITLE
fix: Use templates-master branch for next release

### DIFF
--- a/packages/graphback-cli/src/templates/starterTemplates.ts
+++ b/packages/graphback-cli/src/templates/starterTemplates.ts
@@ -16,7 +16,7 @@ export const allTemplates: Template[] = [
     description: 'Apollo GraphQL template in typescript',
     repo: {
       uri: 'https://github.com/aerogear/graphback',
-      branch: 'master',
+      branch: 'templates-master',
       path: '/templates/apollo-starter-ts',
     }
   }


### PR DESCRIPTION
# Motivation

Use a separate branches (not master) for templates to avoid breaking changes. 
This is important now that we do not plan other templates to be available and we want current releases to work. 