### PR TITLE
fix: validate release script when releasing dev

### DIFF
--- a/scripts/validateRelease.sh
+++ b/scripts/validateRelease.sh
@@ -24,7 +24,7 @@ fi
 
 # validate that all packages have the same version found in lerna.json
 for package in $PACKAGES; do
-  version=$(lerna --loglevel=silent ls -l | grep $package | awk -F ' ' '{print $2}' | awk -F 'v' '{print $2}')
+  version=$(lerna --loglevel=silent ls -l | grep $package | awk -F ' ' '{print $2}' | cut -c2-)
   if [[ $version =~ $PACKAGE_VERSION ]]; then
     echo "package $package has version $version"
   else


### PR DESCRIPTION
## Description

The old `awk` piped command was cutting the version at the next `v`, I've copied this new command from the offix project: https://github.com/aerogear/offix/blob/550802ff97077b62d850786138f898a0dbc3ea92/scripts/validateRelease.sh#L27 
