### PR TITLE
Fix integration test

### DIFF
--- a/examples/generator-example/package.json
+++ b/examples/generator-example/package.json
@@ -20,7 +20,7 @@
     "graphql-tag": "2.10.1",
     "knex": "0.20.0",
     "pg": "7.12.1",
-    "sqlite3": "^4.1.0"
+    "sqlite3": "4.1.0"
   },
   "devDependencies": {
     "@types/graphql": "14.2.3",

--- a/examples/generator-example/package.json
+++ b/examples/generator-example/package.json
@@ -20,7 +20,7 @@
     "graphql-tag": "2.10.1",
     "knex": "0.20.0",
     "pg": "7.12.1",
-    "sqlite3": "4.1.0"
+    "sqlite3": "^4.1.0"
   },
   "devDependencies": {
     "@types/graphql": "14.2.3",

--- a/packages/graphback-cli/tests/workflow-test.ts
+++ b/packages/graphback-cli/tests/workflow-test.ts
@@ -1,11 +1,11 @@
+// tslint:disable-next-line: match-default-export-name no-implicit-dependencies
 import ava, { ExecutionContext } from 'ava';
-// tslint:disable-next-line: no-var-requires
+// tslint:disable-next-line: no-var-requires no-require-imports
 const execa = require('execa');
 import { existsSync } from 'fs';
 import { DropCreateDatabaseAlways } from 'graphback';
 import { join, resolve } from 'path';
 import { createDB, generate, initConfig } from '../src';
-import { exec } from 'child_process';
 
 const model = {
   modelName: "testSchema",
@@ -23,15 +23,6 @@ ava('Test cli workflow', async (t: ExecutionContext) => {
   console.info(`Starting tests in ${process.cwd()}`)
   await initConfig("testback ", { model, database: "sqlite3", client: true });
   await generate();
-
-  const defaultConfig = {
-    db: {
-      dbConfig: {
-        "filename": "./db.sqlite"
-      },
-      database: "sqlite3"
-    },
-  }
 
   const databaseInitializationStrategy = new DropCreateDatabaseAlways({
     connectionOptions: {
@@ -52,5 +43,6 @@ ava('Test cli workflow', async (t: ExecutionContext) => {
   } catch (error) {
     t.fail(`build failed with ${error}`);
   }
+
 });
 

--- a/packages/graphback-cli/tests/workflow-test.ts
+++ b/packages/graphback-cli/tests/workflow-test.ts
@@ -5,6 +5,7 @@ import { existsSync } from 'fs';
 import { DropCreateDatabaseAlways } from 'graphback';
 import { join, resolve } from 'path';
 import { createDB, generate, initConfig } from '../src';
+import { exec } from 'child_process';
 
 const model = {
   modelName: "testSchema",
@@ -23,7 +24,20 @@ ava('Test cli workflow', async (t: ExecutionContext) => {
   await initConfig("testback ", { model, database: "sqlite3", client: true });
   await generate();
 
-  const databaseInitializationStrategy = new DropCreateDatabaseAlways({ connectionOptions: "sqlite3", client: true })
+  const defaultConfig = {
+    db: {
+      dbConfig: {
+        "filename": "./db.sqlite"
+      },
+      database: "sqlite3"
+    },
+  }
+
+  const databaseInitializationStrategy = new DropCreateDatabaseAlways({
+    connectionOptions: {
+      filename: "./db.sqlite"
+    }, client: "sqlite3"
+  })
 
   await createDB(databaseInitializationStrategy);
 

--- a/packages/graphback-db-manage/package.json
+++ b/packages/graphback-db-manage/package.json
@@ -12,6 +12,7 @@
     "@graphql-inspector/core": "1.26.0",
     "glob": "7.1.5",
     "knex": "0.20.0",
+    "sqlite3": "4.1.0",
     "pino": "5.13.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Integration test was not executing because the incorrect SQLite database connection options were being provided.

Tests never failed, because they were never executed.

## Tasks

- [x] Fix integration test. 
- [x] Hide tslint warning.

## Verification

1. `cd packages/graphback-cli`
2. `npm run test`
3. Tests pass.