### PR TITLE
Runtime subscription

### DIFF
--- a/docs/custom.md
+++ b/docs/custom.md
@@ -50,7 +50,7 @@ and will generated a resolver file in custom folder
 ```
 export const likePost = {
   Mutation: {
-    likePost: (_: any, args: any, context: GraphQLContext) => {
+    likePost: (_: any, args: any, context: any) => {
         // Implementation here
     }
   }

--- a/examples/generator-fullstack/server/package.json
+++ b/examples/generator-fullstack/server/package.json
@@ -14,6 +14,7 @@
         "@types/cors": "2.8.6",
         "@types/express": "4.17.2",
         "@types/node": "12.12.5",
+        "apollo-server-express": "^2.9.8",
         "cors": "2.8.5",
         "express": "4.17.1",
         "express-graphql": "0.9.0",

--- a/examples/runtime-example/src/runtime.ts
+++ b/examples/runtime-example/src/runtime.ts
@@ -1,8 +1,5 @@
 import { gql } from 'apollo-server-core';
 import {
-  DatabaseConnectionOptions,
-  DatabaseInitializationStrategy,
-  DropCreateDatabaseIfChanges,
   GraphQLBackendCreator,
   InputModelProvider,
   PgKnexDBDataProvider,

--- a/packages/graphback-codegen-resolvers/src/api/targetResolverContext.ts
+++ b/packages/graphback-codegen-resolvers/src/api/targetResolverContext.ts
@@ -8,7 +8,7 @@ import { ResolverRelationContext, ResolverTypeContext, TargetResolverContext } f
  */
 const createResolver = (t: InputModelTypeContext): string | undefined => {
   if (t.config.create) {
-    return templates.createTemplate(getFieldName(t.name, GraphbackOperationType.CREATE), t.name)
+    return templates.createTemplate(getFieldName(t.name, GraphbackOperationType.CREATE), t.name, t.config.subCreate)
   }
 
   return undefined
@@ -16,7 +16,7 @@ const createResolver = (t: InputModelTypeContext): string | undefined => {
 
 const updateResolver = (t: InputModelTypeContext): string | undefined => {
   if (t.config.update) {
-    return templates.updateTemplate(getFieldName(t.name, GraphbackOperationType.UPDATE), t.name)
+    return templates.updateTemplate(getFieldName(t.name, GraphbackOperationType.UPDATE), t.name, t.config.subUpdate)
   }
 
   return undefined
@@ -24,7 +24,7 @@ const updateResolver = (t: InputModelTypeContext): string | undefined => {
 
 const deleteResolver = (t: InputModelTypeContext): string | undefined => {
   if (t.config.delete) {
-    return templates.deleteTemplate(getFieldName(t.name, GraphbackOperationType.DELETE), t.name)
+    return templates.deleteTemplate(getFieldName(t.name, GraphbackOperationType.DELETE), t.name, t.config.subDelete)
   }
 
   return undefined

--- a/packages/graphback-codegen-resolvers/src/templates/LayeredResolverTemplates.ts
+++ b/packages/graphback-codegen-resolvers/src/templates/LayeredResolverTemplates.ts
@@ -3,21 +3,27 @@
 export const createTemplate = (fieldName: string, typeName: string, subscription?: boolean): string => {
   return `${fieldName}: (_, args, context) => {
       validateRuntimeContext(context)
-      return context.crudService.create("${typeName.toLowerCase()}", args.input, context);
+      return context.crudService.create("${typeName.toLowerCase()}", args.input, {
+        publishEvent: ${subscription}
+      }, context);
     }`
 }
 
 export const updateTemplate = (fieldName: string, typeName: string, subscription?: boolean): string => {
   return `${fieldName}: (_, args, context) => {
       validateRuntimeContext(context)
-      return context.crudService.update("${typeName.toLowerCase()}", args.id, args.input, context);
+      return context.crudService.update("${typeName.toLowerCase()}", args.id, args.input, {
+        publishEvent: ${subscription}
+      }, context);
     }`
 }
 
 export const deleteTemplate = (fieldName: string, typeName: string, subscription?: boolean): string => {
   return `${fieldName}: (_, args, context) => {
       validateRuntimeContext(context)
-      return context.crudService.delete("${typeName.toLowerCase()}", args.id, args.input, context);
+      return context.crudService.delete("${typeName.toLowerCase()}", args.id, args.input, {
+        publishEvent: ${subscription}
+      }, context);
     }`
 }
 
@@ -37,7 +43,7 @@ export const findTemplate = (fieldName: string, typeName: string, ): string => {
 
 export const newSub = (typeName: string): string => {
   return `new${typeName}: {
-      subscribe: (_: any, __: any, context: GraphQLContext) => {
+      subscribe: (_, args, context) => {
         validateRuntimeContext(context)
         return context.crudService.subscribeToCreate("${typeName.toLowerCase()}", context);
       }
@@ -46,7 +52,7 @@ export const newSub = (typeName: string): string => {
 
 export const updatedSub = (typeName: string): string => {
   return `updated${typeName}: {
-      subscribe  : (_: any, __: any, context: GraphQLContext) => {
+      subscribe: (_, args, context) => {
         validateRuntimeContext(context)
         return context.crudService.subscribeToUpdate("${typeName.toLowerCase()}", context);
       }
@@ -55,7 +61,7 @@ export const updatedSub = (typeName: string): string => {
 
 export const deletedSub = (typeName: string): string => {
   return `deleted${typeName}: {
-      subscribe: (_: any, __: any, context: GraphQLContext) => {
+      subscribe: (_, args, context) => {
         validateRuntimeContext(context)
         return context.crudService.subscribeToDelete("${typeName.toLowerCase()}", context);
       }
@@ -99,7 +105,7 @@ export const blankResolver = (name: string) => {
 
 export const blankSubscription = (name: string) => {
   return `${name}: {
-      subscribe: (_: any, __: any, context: GraphQLContext) => {
+      subscribe: (_, args, context) => {
         // Implementation here
       }
     }`

--- a/packages/graphback-runtime/src/GraphbackRuntimeOptions.ts
+++ b/packages/graphback-runtime/src/GraphbackRuntimeOptions.ts
@@ -1,0 +1,12 @@
+
+
+/**
+ * Runtime layer flags that can be used to trigger various events in service level
+ */
+export interface GraphbackRuntimeOptions {
+    
+    /**
+     * Flag used to force publising pubsub event
+     */
+    publishEvent: boolean
+}

--- a/packages/graphback-runtime/src/createKnexRuntimeContext.ts
+++ b/packages/graphback-runtime/src/createKnexRuntimeContext.ts
@@ -1,6 +1,6 @@
 import { PubSubEngine } from 'graphql-subscriptions';
 import * as Knex from 'knex'
-import { DefaultCRUDService, PgKnexDBDataProvider } from '.';
+import { CRUDService, PgKnexDBDataProvider } from '.';
 import { GraphbackRuntimeContext } from './GraphbackRuntimeContext';
  
 /**
@@ -8,7 +8,7 @@ import { GraphbackRuntimeContext } from './GraphbackRuntimeContext';
  */
 export const createKnexRuntimeContext = (db: Knex, pubSub: PubSubEngine): GraphbackRuntimeContext => {
   const crudDb = new PgKnexDBDataProvider(db);
-  const crudService = new DefaultCRUDService(crudDb, pubSub);
+  const crudService = new CRUDService(crudDb, pubSub);
 
   return {
     crudService,

--- a/packages/graphback-runtime/src/data/GraphbackDataProvider.ts
+++ b/packages/graphback-runtime/src/data/GraphbackDataProvider.ts
@@ -1,4 +1,5 @@
 import { InputModelTypeContext } from "@graphback/core"
+import { GraphbackRuntimeOptions } from '../GraphbackRuntimeOptions';
 
 // If we come with Union on client we might use some complex JSON for describing rules
 // and single key for type for simple use cases

--- a/packages/graphback-runtime/src/data/KnexDBDataProvider.ts
+++ b/packages/graphback-runtime/src/data/KnexDBDataProvider.ts
@@ -60,7 +60,7 @@ export class KnexDBDataProvider<Type = any, GraphbackContext = any> implements G
         throw new NoDataError(`Cannot read ${name}`);
     }
 
-    public async findAll(name: string, ): Promise<Type[]> {
+    public async findAll(name: string): Promise<Type[]> {
         const dbResult = await this.db.select().from(name);
         if (dbResult) {
             return dbResult;

--- a/packages/graphback-runtime/src/index.ts
+++ b/packages/graphback-runtime/src/index.ts
@@ -6,7 +6,7 @@ export * from "./data/PgKnexDBDataProvider"
 export * from "./data/KnexDBDataProvider"
 
 // Service
-export * from "./service/DefaultCRUDService"
+export * from "./service/CRUDService"
 export * from "./service/GraphbackCRUDService"
 
 export * from "./resolvers/LayeredRuntimeResolverGen"

--- a/packages/graphback-runtime/src/resolvers/LayeredRuntimeResolverGen.ts
+++ b/packages/graphback-runtime/src/resolvers/LayeredRuntimeResolverGen.ts
@@ -40,21 +40,27 @@ export class LayeredRuntimeResolverGenerator {
         const resolverCreateField = getFieldName(resolverElement.name, GraphbackOperationType.CREATE);
         // tslint:disable-next-line: no-any
         resolvers.Mutation[resolverCreateField] = (parent: any, args: any, context: any) => {
-          return this.service.create(objectName, args.input, context)
+          return this.service.create(objectName, args.input, {
+            publishEvent: resolverElement.config.subCreate
+          }, context)
         }
       }
       if (resolverElement.config.update) {
         const updateField = getFieldName(resolverElement.name, GraphbackOperationType.UPDATE);
         // tslint:disable-next-line: no-any
         resolvers.Mutation[updateField] = (parent: any, args: any, context: any) => {
-          return this.service.update(objectName, args.id, args.input, context)
+          return this.service.update(objectName, args.id, args.input, {
+            publishEvent: resolverElement.config.subUpdate
+          }, context)
         }
       }
       if (resolverElement.config.delete) {
         const deleteField = getFieldName(resolverElement.name, GraphbackOperationType.DELETE);
         // tslint:disable-next-line: no-any
         resolvers.Mutation[deleteField] = (parent: any, args: any, context: any) => {
-          return this.service.delete(objectName, args.id, args.input, context)
+          return this.service.delete(objectName, args.id, args.input, {
+            publishEvent: resolverElement.config.subDelete
+          }, context)
         }
       }
 

--- a/packages/graphback-runtime/src/service/CRUDService.ts
+++ b/packages/graphback-runtime/src/service/CRUDService.ts
@@ -1,14 +1,12 @@
-import { GraphbackOperationType, InputModelTypeContext } from "@graphback/core"
+import { GraphbackOperationType } from "@graphback/core"
 import { PubSub, PubSubEngine } from 'graphql-subscriptions';
 import { GraphbackDataProvider } from "../data/GraphbackDataProvider";
+import { GraphbackRuntimeContext } from '../GraphbackRuntimeContext';
+import { GraphbackRuntimeOptions } from '../GraphbackRuntimeOptions';
 import { defaultLogger, GraphbackMessageLogger } from '../utils/Logger';
 import { GraphbackCRUDService } from "./GraphbackCRUDService";
 import { subscriptionTopicMapping } from './subscriptionTopicMapping';
 
-
-interface GraphbackContext {
-    publish: boolean
-}
 
 /**
  * Default implementation of the CRUD service offering following capabilities:
@@ -17,9 +15,7 @@ interface GraphbackContext {
  * - Logging: using logging abstraction
  */
 // tslint:disable-next-line: no-any
-export class DefaultCRUDService<T = any>
-    implements GraphbackCRUDService<T, GraphbackContext>  {
-
+export class CRUDService<T = any> implements GraphbackCRUDService<T, GraphbackRuntimeContext | any>  {
     private db: GraphbackDataProvider;
     private logger: GraphbackMessageLogger;
     private pubSub: PubSubEngine;
@@ -31,11 +27,10 @@ export class DefaultCRUDService<T = any>
         this.logger = logger || defaultLogger;
     }
 
-    public async create(name: string, data: T, context?: GraphbackContext): Promise<T> {
+    public async create(name: string, data: T, options?: GraphbackRuntimeOptions, context?: GraphbackRuntimeContext): Promise<T> {
         this.logger.log(`Creating object ${name}`)
         const result = await this.db.create(name, data, context);
-        // TODO subscriptions
-        if (this.pubSub && context && context.publish) {
+        if (this.pubSub && options && options && options.publishEvent) {
             const topic = subscriptionTopicMapping(GraphbackOperationType.CREATE, name);
             const payload = this.buildEventPayload('new', name, result);
             await this.pubSub.publish(topic, payload);
@@ -43,11 +38,11 @@ export class DefaultCRUDService<T = any>
 
         return result;
     }
-    public async update(name: string, id: string, data: T, context?: GraphbackContext): Promise<T> {
+    public async update(name: string, id: string, data: T, options?: GraphbackRuntimeOptions, context?: GraphbackRuntimeContext): Promise<T> {
         this.logger.log(`Updating object ${name}`)
 
         const result = await this.db.update(name, id, data, context);
-        if (this.pubSub && context && context.publish) {
+        if (this.pubSub && options && options.publishEvent) {
             const topic = subscriptionTopicMapping(GraphbackOperationType.UPDATE, name);
             const payload = this.buildEventPayload('updated', name, result);
             await this.pubSub.publish(topic, payload);
@@ -57,11 +52,11 @@ export class DefaultCRUDService<T = any>
     }
 
     // tslint:disable-next-line: no-reserved-keywords
-    public async delete(name: string, id: string, data?: T, context?: GraphbackContext): Promise<string> {
+    public async delete(name: string, id: string, data?: T, options?: GraphbackRuntimeOptions, context?: GraphbackRuntimeContext): Promise<string> {
         this.logger.log(`deleting object ${name}`)
 
         const result = await this.db.delete(name, id, data, context);
-        if (this.pubSub && context && context.publish) {
+        if (this.pubSub && options && options.publishEvent) {
             const topic = subscriptionTopicMapping(GraphbackOperationType.DELETE, name);
             const payload = this.buildEventPayload('deleted', name, result);
             await this.pubSub.publish(topic, payload);
@@ -70,52 +65,52 @@ export class DefaultCRUDService<T = any>
         return result;
     }
 
-    public read(name: string, id: string, context?: GraphbackContext): Promise<T> {
+    public read(name: string, id: string, options?: GraphbackRuntimeOptions, context?: GraphbackRuntimeContext): Promise<T> {
         this.logger.log(`reading object ${name}`)
 
         return this.db.read(name, id, context);
     }
 
-    public findAll(name: string, context?: GraphbackContext): Promise<T[]> {
+    public findAll(name: string, options?: GraphbackRuntimeOptions, context?: GraphbackRuntimeContext): Promise<T[]> {
         this.logger.log(`querying object ${name}`)
 
         return this.db.findAll(name, context);
     }
 
     // tslint:disable-next-line: no-any
-    public findBy(name: string, filter: any, context?: GraphbackContext): Promise<T[]> {
+    public findBy(name: string, filter: any, options?: GraphbackRuntimeOptions, context?: GraphbackRuntimeContext): Promise<T[]> {
         this.logger.log(`querying object ${name} with filter ${JSON.stringify(filter)}`)
 
         return this.db.findBy(name, filter, context);
     }
 
-    public subscribeToCreate(name: string, context?: GraphbackContext): AsyncIterator<T> | undefined {
+    public subscribeToCreate(name: string, context?: GraphbackRuntimeContext): AsyncIterator<T> | undefined {
         if (!this.pubSub) {
             this.logger.log(`Cannot subscribe to events for ${name}`)
 
-            return undefined;
+            throw Error(`Missing PubSub implementation in CRUDService`);
         }
         const createSubKey = subscriptionTopicMapping(GraphbackOperationType.CREATE, name);
 
         return this.pubSub.asyncIterator(createSubKey)
     }
 
-    public subscribeToUpdate(name: string, context?: GraphbackContext): AsyncIterator<T> | undefined {
+    public subscribeToUpdate(name: string, context?: GraphbackRuntimeContext): AsyncIterator<T> | undefined {
         if (!this.pubSub) {
             this.logger.log(`Cannot subscribe to events for ${name}`)
 
-            return undefined;
+            throw Error(`Missing PubSub implementation in CRUDService`);
         }
         const updateSubKey = subscriptionTopicMapping(GraphbackOperationType.UPDATE, name);
 
         return this.pubSub.asyncIterator(updateSubKey)
     }
 
-    public subscribeToDelete(name: string, context?: GraphbackContext): AsyncIterator<T> | undefined {
+    public subscribeToDelete(name: string, context?: GraphbackRuntimeContext): AsyncIterator<T> | undefined {
         if (!this.pubSub) {
             this.logger.log(`Cannot subscribe to events for ${name}`)
 
-            return undefined;
+            throw Error(`Missing PubSub implementation in CRUDService`);
         }
         const deleteSubKey = subscriptionTopicMapping(GraphbackOperationType.DELETE, name);
 

--- a/packages/graphback-runtime/src/service/CRUDService.ts
+++ b/packages/graphback-runtime/src/service/CRUDService.ts
@@ -119,7 +119,9 @@ export class CRUDService<T = any> implements GraphbackCRUDService<T, GraphbackRu
 
     private buildEventPayload(action: string, name: string, result: string) {
         const payload = {};
-        payload[`${action}${name}`] = result;
+        const capitalName = name[0].toUpperCase() +
+            name.slice(1);
+        payload[`${action}${capitalName}`] = result;
 
         return payload;
     }

--- a/packages/graphback-runtime/src/service/GraphbackCRUDService.ts
+++ b/packages/graphback-runtime/src/service/GraphbackCRUDService.ts
@@ -1,5 +1,5 @@
-import { InputModelTypeContext } from "@graphback/core"
 import { AdvancedFilter } from '../data/GraphbackDataProvider';
+import { GraphbackRuntimeOptions } from '../GraphbackRuntimeOptions';
 
 
 /**
@@ -25,7 +25,7 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
      * @param data input data
      * @param context context object passed from graphql or rest layer
      */
-    create(name: string, data: Type, context?: GraphbackContext): Promise<Type>;
+    create(name: string, data: Type, options?: GraphbackRuntimeOptions, context?: GraphbackContext): Promise<Type>;
 
     /**
      * Implementation for object updates
@@ -35,7 +35,7 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
      * @param data input data
      * @param context context object passed from graphql or rest layer
      */
-    update(name: string, id: string, data: Type, context?: GraphbackContext): Promise<Type>;
+    update(name: string, id: string, data: Type, options?: GraphbackRuntimeOptions, context?: GraphbackContext): Promise<Type>;
 
     /**
      * Implementation for object deletes
@@ -45,7 +45,7 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
      * @param data data used for consistency reasons
      * @param context context object passed from graphql or rest layer
      */
-    delete(name: string, id: string, data?: Type, context?: GraphbackContext): Promise<string>;
+    delete(name: string, id: string, data?: Type, options?: GraphbackRuntimeOptions, context?: GraphbackContext): Promise<string>;
 
     /**
      * Implementation for reading object
@@ -54,7 +54,7 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
      * @param id id of the object
      * @param context context object passed from graphql or rest layer
      */
-    read(name: string, id: string, context?: GraphbackContext): Promise<Type>;
+    read(name: string, id: string, options?: GraphbackRuntimeOptions, context?: GraphbackContext): Promise<Type>;
 
     /**
      * Implementation for finding all objects
@@ -63,7 +63,7 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
      * @param id id of the object
      * @param context context object passed from graphql or rest layer
      */
-    findAll(name: string, context?: GraphbackContext): Promise<Type[]>;
+    findAll(name: string, options?: GraphbackRuntimeOptions, context?: GraphbackContext): Promise<Type[]>;
 
     /**
      * Implementation for reading objects with filtering capabilities
@@ -72,7 +72,7 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
      * @param filter filter by specific type
      * @param context context object passed from graphql or rest layer
      */
-    findBy(name: string, filter: Type | AdvancedFilter, context?: GraphbackContext): Promise<Type[]>;
+    findBy(name: string, filter: Type | AdvancedFilter, options?: GraphbackRuntimeOptions, context?: GraphbackContext): Promise<Type[]>;
 
     /**
      * Subscription for all creation events

--- a/packages/graphback-runtime/tests/service/DefaultCRUDServiceTest.ts
+++ b/packages/graphback-runtime/tests/service/DefaultCRUDServiceTest.ts
@@ -3,14 +3,14 @@ import _test, { TestInterface } from 'ava';
 import { PubSub } from 'graphql-subscriptions';
 import * as Knex from 'knex';
 import { KnexDBDataProvider } from '../../src/data/KnexDBDataProvider';
-import { DefaultCRUDService } from  '../../src/service/DefaultCRUDService'
+import { CRUDService } from  '../../src/service/CRUDService'
 
 // tslint:disable: typedef
 
 interface Context {
   db: Knex;
   provider: KnexDBDataProvider;
-  crudService: DefaultCRUDService
+  crudService: CRUDService
 }
 
 interface Todo {
@@ -51,7 +51,7 @@ test.beforeEach(async t => {
 
   const provider = new KnexDBDataProvider(db);
   const pubSub = new PubSub();
-  const crudService = new DefaultCRUDService(provider, pubSub)
+  const crudService = new CRUDService(provider, pubSub)
   t.context = { db, provider, crudService };
 });
 

--- a/packages/graphback/src/GraphQLBackendCreator.ts
+++ b/packages/graphback/src/GraphQLBackendCreator.ts
@@ -3,7 +3,7 @@ import { ApolloServiceResolverGenerator} from "@graphback/codegen-resolvers"
 import { SchemaGenerator, tsSchemaFormatter } from '@graphback/codegen-schema';
 import { GraphbackGeneratorConfig, graphQLInputContext, InputModelTypeContext, OBJECT_TYPE_DEFINITION } from '@graphback/core';
 import { DatabaseContextProvider, DatabaseInitializationStrategy, DefaultDataContextProvider, GraphQLSchemaManager, SchemaProvider } from '@graphback/db-manage';
-import { DefaultCRUDService, GraphbackDataProvider, LayeredRuntimeResolverGenerator, RuntimeResolversDefinition } from "@graphback/runtime"
+import { CRUDService, GraphbackDataProvider, LayeredRuntimeResolverGenerator, RuntimeResolversDefinition } from "@graphback/runtime"
 import { PubSub } from 'graphql-subscriptions';
 import { IGraphQLBackend } from '.';
 
@@ -80,7 +80,7 @@ export class GraphQLBackendCreator {
 
     const schemaGenerator = new SchemaGenerator(this.inputContext)
     backend.schema = schemaGenerator.generate()
-    const defaultProvider = new DefaultCRUDService(db, pubSub);
+    const defaultProvider = new CRUDService(db, pubSub);
     const resolverGenerator = new LayeredRuntimeResolverGenerator(this.inputContext, defaultProvider)
     backend.resolvers = resolverGenerator.generate()
 

--- a/website/blog/2019-08-27-crash-course-on-graphback.md
+++ b/website/blog/2019-08-27-crash-course-on-graphback.md
@@ -189,11 +189,9 @@ $ graphback generate
 ```
 And if you navigate to `./src/resolvers/custom` you will see `userByName.ts` file. As it is custom resolver we need to implement it ourselves. Change it to:
 ```js
-import { GraphQLContext } from '../../context'
-
 export const userByName = {
   Query: {
-    userByName: (_: any, args: any, context: GraphQLContext) => {
+    userByName: (_: any, args: any, context: any) => {
       return context.db.select().from('user').where('firstName', '=', args.firstName)
     }
   }


### PR DESCRIPTION
## Motivation 

Support subscriptions for both runtime and generated source code. 
I have added extra parameter to the service layer that can determine runtime options. 
For example developers might decide after to not publish change to subscriptions. 

There are two types here:
GraphbackRuntimeOptions - runtime options and modifiers triggered on resolver level
GraphbackRuntimeContext - global context with applied service etc.

## Verification

```
subscription subtest {
  newNote{
    id
    title
    description
  }
```
