### PR TITLE
Change `SchemaMigration` ID type to number

### DIFF
--- a/examples/generator-fullstack/graphback.json
+++ b/examples/generator-fullstack/graphback.json
@@ -25,7 +25,7 @@
     "resolvers": "./server/src/resolvers/",
     "schema": "./server/src/schema",
     "client": "./client/src/graphql",
-    "migrations": "./model/migrations"
+    "migrations": "./server/migrations"
   },
   "client": true
 }

--- a/examples/runtime-example/src/runtime.ts
+++ b/examples/runtime-example/src/runtime.ts
@@ -8,7 +8,7 @@ import { PubSub } from 'graphql-subscriptions';
 import { makeExecutableSchema } from 'graphql-tools';
 import * as Knex from 'knex';
 import * as jsonConfig from '../graphback.json'
-import { loadSchema } from './loadSchema.js';
+import { loadSchema } from './loadSchema';
 
 /**
  * Method used to create runtime schema

--- a/packages/graphql-migrations/src/DatabaseMigrater.ts
+++ b/packages/graphql-migrations/src/DatabaseMigrater.ts
@@ -151,7 +151,7 @@ export class DatabaseMigrater {
     }
 
     const newMigration: SchemaMigration = {
-      id: new Date().getTime().toString(),
+      id: new Date().getTime(),
       model: this.schemaText
     };
 

--- a/packages/graphql-migrations/src/database/initialization/strategies/UpdateDatabaseIfChanges.ts
+++ b/packages/graphql-migrations/src/database/initialization/strategies/UpdateDatabaseIfChanges.ts
@@ -1,6 +1,5 @@
 import * as knex from 'knex';
 import { DatabaseMigrater } from '../../../DatabaseMigrater';
-import { DatabaseStrategyOptions } from '../../DatabaseConnectionOptions';
 import { DatabaseInitializationStrategy } from '../DatabaseInitializationStrategy';
 
 /**

--- a/packages/graphql-migrations/src/migrations/KnexMigrationManager.ts
+++ b/packages/graphql-migrations/src/migrations/KnexMigrationManager.ts
@@ -141,7 +141,6 @@ export class KnexMigrationManager {
       } catch (err) {
         logError(err);
       }
-
     }
 
     return Promise.resolve();

--- a/packages/graphql-migrations/src/migrations/KnexMigrationProvider.ts
+++ b/packages/graphql-migrations/src/migrations/KnexMigrationProvider.ts
@@ -46,7 +46,7 @@ export class KnexMigrationProvider implements MigrationProvider {
     try {
       await this.knexMigrationManager.applyMigration(migration);
     } catch (err) {
-      logError(`Failed to execute migration ${chalk.cyan(migration.id)} - ${err.message}`)
+      logError(`Failed to execute migration ${chalk.cyan(migration.id.toString())} - ${err.message}`)
     }
 
     return Promise.resolve();
@@ -65,7 +65,7 @@ export class KnexMigrationProvider implements MigrationProvider {
     try {
       await this.knexMigrationManager.createMigration(migration);
     } catch (err) {
-      logError(`Failed to create migration ${chalk.cyan(migration.id)} - ${err.message}`)
+      logError(`Failed to create migration ${chalk.cyan(migration.id.toString())} - ${err.message}`)
     }
   }
 }

--- a/packages/graphql-migrations/src/migrations/LocalMigrationManager.ts
+++ b/packages/graphql-migrations/src/migrations/LocalMigrationManager.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
-import { join, dirname } from 'path';
-import { ModelChange } from '../changes/ChangeTypes';
+import { join } from 'path';
 import { logError } from '../utils/log';
 import { SchemaMigration } from './SchemaMigration';
 

--- a/packages/graphql-migrations/src/migrations/SchemaMigration.ts
+++ b/packages/graphql-migrations/src/migrations/SchemaMigration.ts
@@ -7,7 +7,7 @@ import { ModelChange } from '../changes/ChangeTypes';
  * @interface SchemaMigration
  */
 export interface SchemaMigration {
-  id?: string
+  id?: Number
   applied_at?: Date
   changes?: string
   model?: string


### PR DESCRIPTION
## Motivation

Fixes https://github.com/aerogear/graphback/issues/495

## What

Change the ID type of `SchemaMigration` to match the ID type in the database.

## Verification

## Postgres

Postgres migrations should work as before.

## SQLite

1. Install sqlite3 to the runtime example.
2. Change database configuration to:

```
"db": {
  "database": "sqlite3",
  "dbConfig": {
    "filename": "./db.sqlite"
  }
},
```

3. Executing migrations with SQLite should now work.
