### PR TITLE
Fix failed migration execution

### DIFF
--- a/examples/runtime-example/model/runtime.graphql
+++ b/examples/runtime-example/model/runtime.graphql
@@ -4,15 +4,4 @@
 type User {
     id: ID!
     name: String
-    age: String
-}
-
-type City {
-    id: ID!
-    name: String
-}
-
-type Note {
-    id: ID!
-    text: String
 }

--- a/packages/graphql-migrations/src/DatabaseMigrater.ts
+++ b/packages/graphql-migrations/src/DatabaseMigrater.ts
@@ -8,8 +8,8 @@ import { KnexMigrationProvider, LocalMigrationManager } from './migrations';
 import { KnexMigrationManager } from './migrations/KnexMigrationManager';
 import { MigrationProvider } from './migrations/MigrationProvider';
 import { SchemaMigration } from './migrations/SchemaMigration';
-import { mapModelChanges } from './utils/graphqlUtils';
 import { getChanges } from './migrations/utils';
+import { mapModelChanges } from './utils/graphqlUtils';
 
 export async function migrate(schemaText: string, strategy: DatabaseInitializationStrategy) {
   await strategy.init(schemaText);

--- a/packages/graphql-migrations/src/DatabaseMigrater.ts
+++ b/packages/graphql-migrations/src/DatabaseMigrater.ts
@@ -58,17 +58,13 @@ export class DatabaseMigrater {
     await this.applyMigrations(migrations);
   }
 
-  public async createMetadataTables() {
-    await this.knexMigrationManager.createMetadataTables();
-  }
-
   /**
    * Get the migrations that have not been applied and apply them
    *
    * @private
    * @memberof DatabaseMigrater
    */
-  public async applyMigrations(migrations: SchemaMigration[]) {
+  private async applyMigrations(migrations: SchemaMigration[]) {
     const migrationsToApply = migrations.filter((m: SchemaMigration) => !m.applied_at);
 
     const sorted = migrationsToApply.sort((a: SchemaMigration, b: SchemaMigration) => {
@@ -88,7 +84,7 @@ export class DatabaseMigrater {
    * @returns
    * @memberof DatabaseMigrater
    */
-  public groupChangesByModel(changes: ModelChange[]) {
+  private groupChangesByModel(changes: ModelChange[]) {
     return changes.reduce((acc: ModelChange, current: ModelChange) => {
 
       if (!acc[current.path.type]) {
@@ -109,7 +105,7 @@ export class DatabaseMigrater {
    * @returns {DatabaseChange[]}
    * @memberof DatabaseMigrater
    */
-  public getSqlStatements(changes: ModelChange[]): DatabaseChange[] {
+  private getSqlStatements(changes: ModelChange[]): DatabaseChange[] {
     const groupedChanges = this.groupChangesByModel(changes);
     const dirtyModels = this.getContext().filter((t: InputModelTypeContext) => {
       return !!groupedChanges[t.name];
@@ -141,7 +137,7 @@ export class DatabaseMigrater {
    * @returns
    * @memberof DatabaseMigrater
    */
-  public async generateMigration(): Promise<SchemaMigration> {
+  private async generateMigration(): Promise<SchemaMigration> {
     const newSchema = buildSchema(this.schemaText);
 
     const migrations = await this.migrationProvider.getMigrations();
@@ -185,5 +181,9 @@ export class DatabaseMigrater {
 
   private getContext(): InputModelTypeContext[] {
     return this.inputContext.filter((t: InputModelTypeContext) => t.kind === OBJECT_TYPE_DEFINITION && t.name !== 'Query' && t.name !== 'Mutation' && t.name !== 'Subscription');
+  }
+
+  private async createMetadataTables() {
+    await this.knexMigrationManager.createMetadataTables();
   }
 }

--- a/packages/graphql-migrations/src/index.ts
+++ b/packages/graphql-migrations/src/index.ts
@@ -1,3 +1,3 @@
-export { DatabaseMigrater, migrate } from './DatabaseMigrater';
+export { migrate } from './DatabaseMigrater';
 export { DatabaseInitializationStrategy, UpdateDatabaseIfChanges, DropCreateDatabaseAlways, DatabaseContextProvider, DefaultDataContextProvider, DatabaseSchemaManager } from './database';
 export { KnexMigrationProvider } from './migrations';

--- a/packages/graphql-migrations/src/migrations/KnexMigrationManager.ts
+++ b/packages/graphql-migrations/src/migrations/KnexMigrationManager.ts
@@ -5,6 +5,7 @@ import knex from 'knex';
 import { ModelChange } from '../changes/ChangeTypes';
 import { logError, logInfo } from '../utils/log';
 import { SchemaMigration } from './SchemaMigration';
+import { mapSchemaMigrationTypes } from './utils';
 
 const handleError = (err: { code: string; message: string }) => {
   if (err.code === '42P07') {
@@ -90,7 +91,7 @@ export class KnexMigrationManager {
 
           if (method) {
             table[method](field.name)
-            ;
+              ;
           }
         }
       }
@@ -190,6 +191,8 @@ export class KnexMigrationManager {
       handleError(err);
     }
 
-    return Promise.resolve(migrations);
+    const mappedValues = mapSchemaMigrationTypes(migrations);
+
+    return Promise.resolve(mappedValues);
   }
 }

--- a/packages/graphql-migrations/src/migrations/SchemaMigration.ts
+++ b/packages/graphql-migrations/src/migrations/SchemaMigration.ts
@@ -7,7 +7,7 @@ import { ModelChange } from '../changes/ChangeTypes';
  * @interface SchemaMigration
  */
 export interface SchemaMigration {
-  id?: Number
+  id?: number
   applied_at?: Date
   changes?: string
   model?: string

--- a/packages/graphql-migrations/src/migrations/utils.ts
+++ b/packages/graphql-migrations/src/migrations/utils.ts
@@ -29,3 +29,14 @@ export function findMigrationsToApply(localMigrations: SchemaMigration[], remote
     return !remoteMigrations.find((r: SchemaMigration) => r.id === l.id);
   });
 }
+
+/**
+ * Get the changes from schema migrations
+ *
+ * @export
+ * @param {SchemaMigration[]} migrations
+ * @returns {string[]}
+ */
+export function getChanges(migrations: SchemaMigration[]): string[] {
+  return [].concat(...migrations.map((m: SchemaMigration) => m.changes));
+}

--- a/packages/graphql-migrations/src/migrations/utils.ts
+++ b/packages/graphql-migrations/src/migrations/utils.ts
@@ -1,0 +1,31 @@
+import { SchemaMigration } from './SchemaMigration';
+
+/**
+ * Map values to their true types
+ *
+ * @export
+ * @param {SchemaMigration[]} migrations
+ * @returns
+ */
+export function mapSchemaMigrationTypes(migrations: SchemaMigration[]) {
+  return migrations.map((m: SchemaMigration) => {
+    return {
+      ...m,
+      id: Number(m.id)
+    };
+  });
+}
+
+/**
+ * For each local migration, find the ones that do not exist in the database
+ *
+ * @export
+ * @param {SchemaMigration[]} localMigrations
+ * @param {SchemaMigration[]} remoteMigrations
+ * @returns {SchemaMigration[]}
+ */
+export function findMigrationsToApply(localMigrations: SchemaMigration[], remoteMigrations: SchemaMigration[]): SchemaMigration[] {
+  return localMigrations.filter((l: SchemaMigration) => {
+    return !remoteMigrations.find((r: SchemaMigration) => r.id === l.id);
+  });
+}

--- a/packages/graphql-migrations/tests/DatabaseMigrater.test.ts
+++ b/packages/graphql-migrations/tests/DatabaseMigrater.test.ts
@@ -41,7 +41,7 @@ ava('it should generate a SQL migration script', async (t: ExecutionContext) => 
   const databaseMigrater = setup();
 
   await databaseMigrater.createMetadataTables();
-  const migration = await databaseMigrater.createMigration();
+  const migration = await databaseMigrater.generateMigration();
 
   const changes = JSON.parse(migration.changes);
   t.assert(changes.length === 3);


### PR DESCRIPTION
Closes https://github.com/aerogear/graphback/issues/481

## What

Migrations were not executing because reading the migration table with Knex was not mapping the ID column back to an number. This meant that local migrations were different to remote and it tried to create the migration twice, which failed.

This change also allows migrations to be executed when only local migration data exists.

## Verification

1. Run 2 migrations using the runtime-example. Everything should work.
2. Delete both migrations from the `gb_schema_migrations` table and delete the changes that were applied in them.
3. Now you should have two migrations on your local filesystem. Run the runtime example again.
4. Both of these migrations should be applied.