### PR TITLE
feat: change public API methods in `graphql-migrations`

### DIFF
--- a/docs/database-schema-migrations.md
+++ b/docs/database-schema-migrations.md
@@ -125,7 +125,7 @@ SQLite is not yet fully supported but will be soon.
 
 ### Migrations in Production
 
-`migrateProduction` can be used to perform migrations in a controlled/production environment.
+`migrateDBUsingSchema` can be used to perform migrations in a controlled/production environment.
 
 Options:
 
@@ -155,7 +155,7 @@ Here is an example of how to configure database initialization strategies.
 ```ts
 import * as jsonConfig from '../graphback.json'
 import { schemaText } from './schema';
-import { migrateProduction, UpdateDatabaseIfChanges } from 'graphql-migrations';
+import { migrateDBUsingSchema, UpdateDatabaseIfChanges } from 'graphql-migrations';
 
 const db = new Knex(...);
 
@@ -164,7 +164,7 @@ const dbClientProvider = new PgKnexDBDataProvider(client);
 
 const dbInitialization = new UpdateDatabaseIfChanges(client, jsonConfig.folders.migrations);
 
-await migrateProduction(schemaText, dbInitialization)
+await migrateDBUsingSchema(schemaText, dbInitialization)
 
 const pubSub = new PubSub();
 const runtime = await backend.createRuntime(dbClientProvider, pubSub);

--- a/docs/database-schema-migrations.md
+++ b/docs/database-schema-migrations.md
@@ -50,7 +50,7 @@ const runtime = await backend.createRuntime(dbClientProvider, pubSub);
 ### Migration Options
 
 - `config`: database configuration options.
-- `schema`: a GraphQL schema object.
+- `schemaText`: GraphQL schema text.
 - `options`:
   - `updateComments`: overwrite comments on table and columns.
   - `scalarMap`: Custom scalar mapping. Default: `null`.
@@ -122,3 +122,57 @@ The following database providers support full database schema migrations.
 - PostgreSQL
 
 SQLite is not yet fully supported but will be soon.
+
+### Migrations in Production
+
+`migrateProduction` can be used to perform migrations in a controlled/production environment.
+
+Options:
+
+- `schemaText`: GraphQL schema text.
+- `strategy`: Database initialization strategy. Options: `UpdateDatabaseIfChanges`, `DropCreateDatabaseAlways`.
+  
+#### Strategies
+
+**UpdateDatabaseIfChanges** - Only update the database when your input schema has been changed.
+
+Options:
+
+- `client`: [knex](http://knexjs.org/) configuration object.
+- `migrationsDir`: Folder to save/read local migration data.
+
+**DropCreateDatabaseAlways** - Wipe and recreate a new database every time.
+
+Options:
+
+- `client`: Database provider type (e.g: `pg`, `sqlite3`)
+- `db`: [knex](http://knexjs.org/) configuration object.
+
+#### Configuration
+
+Here is an example of how to configure database initialization strategies.
+
+```ts
+import * as jsonConfig from '../graphback.json'
+import { schemaText } from './schema';
+import { migrateProduction, UpdateDatabaseIfChanges } from 'graphql-migrations';
+
+const db = new Knex(...);
+
+const backend = new GraphQLBackendCreator(schemaText, jsonConfig.graphqlCRUD);
+const dbClientProvider = new PgKnexDBDataProvider(client);
+
+const dbInitialization = new UpdateDatabaseIfChanges(client, jsonConfig.folders.migrations);
+
+await migrateProduction(schemaText, dbInitialization)
+
+const pubSub = new PubSub();
+const runtime = await backend.createRuntime(dbClientProvider, pubSub);
+```
+
+#### Limitations
+
+Schema migrations are in a very early phase. At present the change types that are allowed is limited to the following:
+
+- **TYPE_ADDED** - Adding a new GraphQL type to your model will create an associated database table.
+- **FIELD_ADDED** - Adding a field to an existing model will create a new column in your database table.

--- a/docs/database-schema-migrations.md
+++ b/docs/database-schema-migrations.md
@@ -17,14 +17,14 @@ graphback db
 
 ### Usage
 
-The `migrate` method creates and updates your tables and columns to match your GraphQL schema.
+The `migrateDB` method creates and updates your tables and columns to match your GraphQL schema.
 
 All the database operations are wrapped in a single transaction, so your database will be fully rolled back to its initial state if an error occurs.
 
 ```ts
 import * as jsonConfig from '../graphback.json'
 import { schemaText } from './schema';
-import { migrate } from 'graphql-migrations';
+import { migrateDB } from 'graphql-migrations';
 import { GraphQLBackendCreator, PgKnexDBDataProvider } from 'graphback';
 
 const backend = new GraphQLBackendCreator(schemaText, jsonConfig.graphqlCRUD);
@@ -35,7 +35,7 @@ const dbConfig = {
   connection: jsonConfig.db.dbConfig
 };
 
-migrate(dbConfig, schemaText, {
+migrateDB(dbConfig, schemaText, {
   // Additional options
 }).then((ops) => {
     console.log(ops);

--- a/examples/runtime-example/src/runtime.ts
+++ b/examples/runtime-example/src/runtime.ts
@@ -1,10 +1,10 @@
 import { gql } from 'apollo-server-core';
 import {
+  applyGeneratorDirectives,
   GraphQLBackendCreator,
   PgKnexDBDataProvider,
-  applyGeneratorDirectives,
 } from 'graphback';
-import { migrate } from 'graphql-migrations';
+import { migrateDB } from 'graphql-migrations';
 import { PubSub } from 'graphql-subscriptions';
 import { makeExecutableSchema } from 'graphql-tools';
 import * as Knex from 'knex';
@@ -27,7 +27,7 @@ export const createRuntime = async (client: Knex) => {
     connection: jsonConfig.db.dbConfig
   };
 
-  migrate(dbConfig, schemaWithDirectives).then((ops) => {
+  migrateDB(dbConfig, schemaWithDirectives).then((ops) => {
     console.log(ops);
   });
 

--- a/packages/graphback-cli/src/helpers/db.ts
+++ b/packages/graphback-cli/src/helpers/db.ts
@@ -1,7 +1,7 @@
 import * as execa from 'execa'
 import { GlobSync } from 'glob'
 import { applyGeneratorDirectives } from 'graphback';
-import { migrate } from 'graphql-migrations';
+import { migrateDB } from 'graphql-migrations';
 import { ConfigBuilder } from '../config/ConfigBuilder';
 import { ProjectConfig } from '../config/ProjectConfig';
 import { logError, logInfo } from '../utils'
@@ -42,7 +42,7 @@ export const createDBResources = async (config: ProjectConfig): Promise<any[]> =
 
     const schemaWithDirectives = applyGeneratorDirectives(schemaText);
 
-    databaseOperations = await migrate(dbConfig, schemaWithDirectives);
+    databaseOperations = await migrateDB(dbConfig, schemaWithDirectives);
 
   } catch (err) {
     handleError(err)

--- a/packages/graphql-migrations/README.md
+++ b/packages/graphql-migrations/README.md
@@ -16,12 +16,12 @@ Automatically create and update your database tables from a GraphQL schema.
 
 ### Usage
 
-The `migrate` method creates and updates your tables and columns to match your GraphQL schema.
+The `migrateDB` method creates and updates your tables and columns to match your GraphQL schema.
 
 All the database operations are wrapped in a single transaction, so your database will be fully rolled back to its initial state if an error occurs.
 
 ```ts
-import { migrate } from 'graphql-migrations';
+import { migrateDB } from 'graphql-migrations';
 
 const dbConfig = {
   client: 'pg',
@@ -48,7 +48,7 @@ type Comment {
 }
 `);
 
-migrate(dbConfig, schema, {
+migrateDB(dbConfig, schema, {
   // Additional options
 }).then(() => {
   console.log('Database updated');
@@ -68,7 +68,7 @@ migrate(dbConfig, schema, {
   - `transformColumnName` (default: transform to `lowerCaseFirstCharacter`): transform function for column names.
   - `scalarMap` (default: `null`): Custom scalar mapping..
   - `mapListToJson` (default: `true`): Map scalar lists to JSON column type by default.
-  - `plugins` (default: `[]`): List of graphql-migrate plugins.
+  - `plugins` (default: `[]`): List of graphql-migrations plugins.
   - `debug` (default: `false`): display debugging information and SQL queries.
 
 ### Name transforms
@@ -76,7 +76,7 @@ migrate(dbConfig, schema, {
 You can customise how table and coumn names are transformed before applying to the database with `transformTableName` and `transformColumnName`.
 
 ```ts
-migrate(dbConfig, schema, {
+migrateDB(dbConfig, schema, {
   transformTableName: (name, direction) => {
     if (direction === 'to-db') {
       return name.toLowerCase();

--- a/packages/graphql-migrations/src/index.ts
+++ b/packages/graphql-migrations/src/index.ts
@@ -1,4 +1,4 @@
-export { migrate, MigrateOptions } from './migrate'
+export { migrateDB, MigrateOptions } from './migrate'
 export { generateAbstractDatabase } from './abstract/generateAbstractDatabase'
 export { computeDiff } from './diff/computeDiff'
 export { read } from './connector/read'
@@ -6,7 +6,7 @@ export { write } from './connector/write'
 export { MigratePlugin, WriteParams } from './plugin/MigratePlugin'
 
 export { KnexMigrationProvider } from './production/migrations';
-export { migrate as runGraphqlMigration } from './production/migrations/GraphQLMigrationCreator';
+export { migrateProd } from './production/migrations/GraphQLMigrationCreator';
 export {
   DatabaseInitializationStrategy,
   UpdateDatabaseIfChanges,

--- a/packages/graphql-migrations/src/index.ts
+++ b/packages/graphql-migrations/src/index.ts
@@ -6,7 +6,7 @@ export { write } from './connector/write'
 export { MigratePlugin, WriteParams } from './plugin/MigratePlugin'
 
 export { KnexMigrationProvider } from './production/migrations';
-export { migrateProd } from './production/migrations/GraphQLMigrationCreator';
+export { migrateProduction } from './production/migrations/GraphQLMigrationCreator';
 export {
   DatabaseInitializationStrategy,
   UpdateDatabaseIfChanges,

--- a/packages/graphql-migrations/src/index.ts
+++ b/packages/graphql-migrations/src/index.ts
@@ -6,7 +6,7 @@ export { write } from './connector/write'
 export { MigratePlugin, WriteParams } from './plugin/MigratePlugin'
 
 export { KnexMigrationProvider } from './production/migrations';
-export { migrateProduction } from './production/migrations/GraphQLMigrationCreator';
+export { migrateDBUsingSchema } from './production/migrations/GraphQLMigrationCreator';
 export {
   DatabaseInitializationStrategy,
   UpdateDatabaseIfChanges,

--- a/packages/graphql-migrations/src/migrate.ts
+++ b/packages/graphql-migrations/src/migrate.ts
@@ -64,7 +64,7 @@ export const defaultOptions: MigrateOptions = {
   debug: false,
 }
 
-export async function migrate(
+export async function migrateDB(
   config: Knex.Config,
   schemaText: string,
   options: MigrateOptions = {},

--- a/packages/graphql-migrations/src/production/migrations/GraphQLMigrationCreator.ts
+++ b/packages/graphql-migrations/src/production/migrations/GraphQLMigrationCreator.ts
@@ -11,7 +11,7 @@ import { MigrationProvider } from './MigrationProvider';
 import { SchemaMigration } from './SchemaMigration';
 import { getChanges } from './utils';
 
-export async function migrate(schemaText: string, strategy: DatabaseInitializationStrategy) {
+export async function migrateProd(schemaText: string, strategy: DatabaseInitializationStrategy) {
   const changes = await strategy.init(schemaText);
   return changes;
 }

--- a/packages/graphql-migrations/src/production/migrations/GraphQLMigrationCreator.ts
+++ b/packages/graphql-migrations/src/production/migrations/GraphQLMigrationCreator.ts
@@ -11,7 +11,7 @@ import { MigrationProvider } from './MigrationProvider';
 import { SchemaMigration } from './SchemaMigration';
 import { getChanges } from './utils';
 
-export async function migrateProduction(schemaText: string, strategy: DatabaseInitializationStrategy) {
+export async function migrateDBUsingSchema(schemaText: string, strategy: DatabaseInitializationStrategy) {
   const changes = await strategy.init(schemaText);
   return changes;
 }

--- a/packages/graphql-migrations/src/production/migrations/GraphQLMigrationCreator.ts
+++ b/packages/graphql-migrations/src/production/migrations/GraphQLMigrationCreator.ts
@@ -11,7 +11,7 @@ import { MigrationProvider } from './MigrationProvider';
 import { SchemaMigration } from './SchemaMigration';
 import { getChanges } from './utils';
 
-export async function migrateProd(schemaText: string, strategy: DatabaseInitializationStrategy) {
+export async function migrateProduction(schemaText: string, strategy: DatabaseInitializationStrategy) {
   const changes = await strategy.init(schemaText);
   return changes;
 }


### PR DESCRIPTION
https://github.com/aerogear/graphback/issues/552

Change the public API methods in `graphql-migrations`.


- migrate: migrateDB
- runGraphqlMigration: migrateProduction
