### PR TITLE
Compare ID values as strings

### DIFF
--- a/packages/graphback-runtime/src/data/KnexDBDataProvider.ts
+++ b/packages/graphback-runtime/src/data/KnexDBDataProvider.ts
@@ -83,7 +83,7 @@ export class KnexDBDataProvider<Type = any, GraphbackContext = any> implements G
     if (dbResult) {
 
       const resultsById = ids.map((id: string) => dbResult.filter((data: any) => {
-        return data[relationField] === Number(id)
+        return data[relationField].toString() === id.toString();
       }))
 
       return resultsById as [Type[]];


### PR DESCRIPTION
## What

When Knex queries a database a nunber may be returned as a string, so in order to check if "1" === 1 we should make them a common data-type.