### PR TITLE
docs: type should be string

### DIFF
--- a/packages/graphql-migrations/README.md
+++ b/packages/graphql-migrations/README.md
@@ -33,7 +33,7 @@ const dbConfig = {
   },
 };
 
-const schema = buildSchema(`
+const schema = `
 type Note {
   id: ID!
   title: String!
@@ -46,7 +46,7 @@ type Comment {
   description: String
   note: Note!
 }
-`);
+`;
 
 migrateDB(dbConfig, schema, {
   // Additional options


### PR DESCRIPTION
The `schema` type in `migrateDB` is string, docs used `GraphQLSchema`.