### PR TITLE
[Docs]: update badge reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ Licensed under the APLv2.
 [typescript-30]: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html
 [nodejs]: https://nodejs.org/dist/latest-v8.x/docs/api/
 [license]: https://github.com/wtrocki/graphql-resolver-gen/blob/master/LICENSE
-[prs]: http://makeapullrequest.com
+[prs]: ./CONTRIBUTING.md


### PR DESCRIPTION
It makes much sense for the respective badge lead to contributing guidelines instead.