### PR TITLE
docs(db): add link to relationships docs

### DIFF
--- a/docs/database-schema-migrations.md
+++ b/docs/database-schema-migrations.md
@@ -88,7 +88,7 @@ type Note {
 }
 ```
 
-> NOTE: The field name must match that of the related type. Support for custom field names is coming soon.
+> NOTE: See [relationships](./relationships) for how to customise foreign key field names.
 
 #### Default field value
 


### PR DESCRIPTION
## What

Documentation was not up to date and provided inaccurate information. Added a link to the relationships documentation to show how to customise foreign key field names.