### PR TITLE
fix: Include examples for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,11 +3,26 @@
     "config:base",
     ":pinAllExceptPeerDependencies"
   ],
-  "groupName":"all",
-  "ignoreDeps": ["chalk"],
+  "groupName": "all",
+  "ignoreDeps": [
+    "chalk"
+  ],
+  "pathRules": [
+    {
+      "paths": [
+        "examples/**"
+      ],
+      "extends": [
+        "config:base",
+        ":pinAllExceptPeerDependencies"
+      ]
+    }
+  ],
   "packageRules": [
     {
-      "packageNames": ["graphql"],
+      "packageNames": [
+        "graphql"
+      ],
       "versionStrategy": "widen"
     }
   ]


### PR DESCRIPTION
Trying to test it. Not sure if that will work. basically this should cover rules for the path and override defaults from renovate