### PR TITLE
chore: Using any as config to not break knex types

### DIFF
--- a/examples/runtime-example/src/runtime.ts
+++ b/examples/runtime-example/src/runtime.ts
@@ -20,7 +20,7 @@ export const createRuntime = async (client: Knex) => {
   const backend = new GraphQLBackendCreator(schemaText, jsonConfig.graphqlCRUD);
   const dbClientProvider = new PgKnexDBDataProvider(client);
 
-  const dbConfig = {
+  const dbConfig: any = {
     client: jsonConfig.db.database,
     connection: jsonConfig.db.dbConfig
   };


### PR DESCRIPTION
## Motivation

This simple fix will allow runtime example to work across different knex versions. 
Package bumps by renovate fixed in other PR will also make sure that we always use the same

Resolves https://github.com/aerogear/graphback/issues/619