### PR TITLE
docs: update the url pointing to a fully functional runtime creation example

### DIFF
--- a/examples/runtime-example/README.md
+++ b/examples/runtime-example/README.md
@@ -25,7 +25,7 @@ Then developers can create runtime instance:
     console.log(runtime.schema,  runtime.resolvers)
 ```    
 
-See [`./runtime.ts`](https://github.com/aerogear/graphback/blob/master/example/runtime/src/runtime.ts#L30) for a fully functional example.
+See [`./runtime.ts`](https://github.com/aerogear/graphback/blob/master/examples/runtime-example/src/runtime.ts#L32) for a fully functional example.
 
 ### Running example
 


### PR DESCRIPTION
The provided link was not working. 

I am not sure about the pointed line number in use in this PR (line 32). Is this the correct one?  

@wtrocki 