### PR TITLE
fix: fix type error in runtime example & improve runtime-example docs

### DIFF
--- a/examples/runtime-example/README.md
+++ b/examples/runtime-example/README.md
@@ -66,8 +66,17 @@ The project has been created using `graphback`. Run the project using the follow
   },
   "database": "sqlite3"
 },
+```
+
+- Define your schema in the `model/runtime.graphql` file. Or use the default:
 
 ```
+type User {
+  id: ID!
+  name: String
+}
+```
+
 - Start the server (for the first time)
 ```
 npm run develop

--- a/examples/runtime-example/README.md
+++ b/examples/runtime-example/README.md
@@ -27,7 +27,7 @@ Then developers can create runtime instance:
 
 See [`./runtime.ts`](https://github.com/aerogear/graphback/blob/master/examples/runtime-example/src/runtime.ts#L32) for a fully functional example.
 
-### Running example
+### Running example (postgres)
 
 The project has been created using `graphback`. Run the project using the following steps. 
 - Start the database
@@ -35,13 +35,49 @@ The project has been created using `graphback`. Run the project using the follow
 docker-compose up -d
 ```
 
-- create database
+- Define your schema in the `model/runtime.graphql` file. Or use the default:
+
 ```
-graphback db
-```
-- Start the server
-```
-npm start
+type User {
+  id: ID!
+  name: String
+}
 ```
 
-Enjoy runtime app
+- Start the server
+```
+npm run develop
+```
+
+Or, if using yarn
+
+```
+yarn develop
+```
+
+### Running example (sqlite)
+
+The project has been created using `graphback`. Run the project using the following steps. 
+- Modify the db json object in the `graphback.json` config file. For an in-memory database, use the below config as-is, alternatively replace `:in-memory:` with the desired filename.
+```
+"db": {
+  "dbConfig": {
+    "filename": ":in-memory:"
+  },
+  "database": "sqlite3"
+},
+
+```
+- Start the server (for the first time)
+```
+npm run develop
+```
+Or, if using yarn
+```
+yarn develop
+```
+
+If the server is being re-run, modify the `src/runtime.ts` and comment out the `migrateDb` function, since it will not be possible to re-migrate the database with sqllite3.
+
+
+Enjoy the runtime app

--- a/examples/runtime-example/README.md
+++ b/examples/runtime-example/README.md
@@ -27,7 +27,7 @@ Then developers can create runtime instance:
 
 See [`./runtime.ts`](https://github.com/aerogear/graphback/blob/master/examples/runtime-example/src/runtime.ts#L32) for a fully functional example.
 
-### Running example (postgres)
+### Running example using Postgres database
 
 The project has been created using `graphback`. Run the project using the following steps. 
 - Start the database
@@ -55,7 +55,7 @@ Or, if using yarn
 yarn develop
 ```
 
-### Running example (sqlite)
+### Running example using SQLite database
 
 The project has been created using `graphback`. Run the project using the following steps. 
 - Modify the db json object in the `graphback.json` config file. For an in-memory database, use the below config as-is, alternatively replace `:in-memory:` with the desired filename.
@@ -66,6 +66,22 @@ The project has been created using `graphback`. Run the project using the follow
   },
   "database": "sqlite3"
 },
+```
+
+- Next modify the `runtime.ts` file and change the `PGKnexDataProvider` to `KnexDBDataProvider`.
+```
+...
+
+import {
+  ...
+  KnexDBDataProvider
+} from 'graphback'
+
+...
+
+const dbClientProvider = new KnexDBDataProvider(client);
+
+...
 ```
 
 - Define your schema in the `model/runtime.graphql` file. Or use the default:
@@ -86,7 +102,7 @@ Or, if using yarn
 yarn develop
 ```
 
-If the server is being re-run, modify the `src/runtime.ts` and comment out the `migrateDb` function, since it will not be possible to re-migrate the database with sqllite3.
+If the server is being re-run, modify the `src/runtime.ts` and comment out the `migrateDb` function, since it will not be possible to re-migrate the database with SQLite3.
 
 
 Enjoy the runtime app

--- a/examples/runtime-example/src/runtime.ts
+++ b/examples/runtime-example/src/runtime.ts
@@ -14,7 +14,7 @@ import { loadSchema } from './loadSchema';
  * Method used to create runtime schema
  * It will be part of of the integration tests
  */
-export const createRuntime = async (client: Knex) => {
+export const createRuntime = async (client: any) => {
   const schemaText = loadSchema(jsonConfig.folders.model);
 
   const backend = new GraphQLBackendCreator(schemaText, jsonConfig.graphqlCRUD);


### PR DESCRIPTION
- fix the type error in the `runtime.ts` file in the runtime-example app, as discussed in the standup this morning.
- improve the docs to include the correct steps for starting up the server and add instructions for using sqllite 3 in the runtime-example app
