### PR TITLE
fix: generate subscriptions when both config values are true

### DIFF
--- a/packages/graphback-codegen-schema/src/plugin/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/plugin/SchemaCRUDPlugin.ts
@@ -117,7 +117,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     }
 
     private createSubscriptions(model: ModelDefinition, subscriptionTypes: any, modelInputType: GraphQLInputObjectType) {
-        if (model.crudOptions.subCreate) {
+        if (model.crudOptions.subCreate && model.crudOptions.create) {
              // FIXME name of the field should be comming using `getFieldName` helper
             subscriptionTypes[`new${model.graphqlType.name}`] = {
                 type: GraphQLNonNull(model.graphqlType),
@@ -128,7 +128,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
                 }
             };
         }
-        if (model.crudOptions.subUpdate) {
+        if (model.crudOptions.subUpdate && model.crudOptions.update) {
              // FIXME name of the field should be comming using `getFieldName` helper
             subscriptionTypes[`updated${model.graphqlType.name}`] = {
                 type: GraphQLNonNull(model.graphqlType),
@@ -139,7 +139,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
                 }
             };
         }
-        if (model.crudOptions.subDelete) {
+        if (model.crudOptions.subDelete && model.crudOptions.delete) {
             subscriptionTypes[`deleted${model.graphqlType.name}`] = {
                 type: GraphQLNonNull(model.graphqlType),
                 args: {


### PR DESCRIPTION
## What

Subscriptions should not be generated if the CRUD config value for that operation type is `false`.

Example: `@crud.delete: false` and `@crud.subDelete: true` should not create the delete subscription.

From documentation: 

> **Note**: For subscriptions, the user needs to change the value of the respective operations to true. For example, changing subDelete to true won't work unless, delete is true.

## Verification

```gql
""" 
@crud.delete: false 
"""
type Note {
  id: ID!
  title: String
}
```

Run `generate` with the model above. Neither a `deletedNote` subscription or a `deleteNote` mutation will be generated.