### PR TITLE
fix: add missing @types/glob in runtime examples

### DIFF
--- a/examples/runtime-example/package.json
+++ b/examples/runtime-example/package.json
@@ -24,6 +24,7 @@
     "pg": "7.17.1"
   },
   "devDependencies": {
+    "@types/glob": "7.1.1",
     "@types/graphql": "14.2.3",
     "@types/node-fetch": "2.5.4",
     "ts-node": "8.6.2",


### PR DESCRIPTION
Without this the example was failing with `src/loadSchema.ts:2:26 - error TS7016: Could not find a
declaration file for module 'glob'`

/cc @wtrocki 