### PR TITLE
Change `findX` argument `filter` to `fields`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -24,8 +24,7 @@ in the root of your project folder under the `generation` key. The default confi
     "delete": false,
     "subCreate": false,
     "subUpdate": false,
-    "subDelete": false,
-    "disableGen": false,
+    "subDelete": false
   }
 }
 ```
@@ -70,7 +69,6 @@ All config options can be replicated by specifying the `@crud.` prefix
 @crud.subCreate: true
 @crud.subUpdate: true
 @crud.subDelete: true
-@crud.disableGen: true
 ```
 
 You can use these annotations to have more control over individual elements. For example:
@@ -85,8 +83,3 @@ type Note {
 will create the `delete` mutation for `Note` type.
 
 > **Note**: Annotations override the configuration flags to `true`
-
-#### `@crud.disableGen`
-
-User can use this directive to disable CRUD operation generation for that type. Applying this directive will not create any 
-`Query`/`Mutation`/`Subscription` for that type.

--- a/examples/generator-fullstack/model/datamodel.graphql
+++ b/examples/generator-fullstack/model/datamodel.graphql
@@ -1,28 +1,31 @@
-""" @model """
+"""
+@model
+"""
 type Note {
   id: ID!
-  """
-  @db.type: 'string'
-  @db.length: 100
-  """
   title: String!
-  """
-  @db.type: 'text'
-  """
+
   description: String
   """
   @db.oneToMany: 'commentNote'
   """
   comments: [Comment]!
+  likes: Number
 }
 
 """
-@crud.disableGen
+@model
 """
 type Comment {
   id: ID!
-  """
-  @db.type: 'text'
-  """
-  description: String
+  text: String
+  author: String
+}
+
+type Query {
+  mostLikedNote: Note!
+}
+
+type Mutation {
+  likeNote: Note!
 }

--- a/examples/generator-fullstack/model/datamodel.graphql
+++ b/examples/generator-fullstack/model/datamodel.graphql
@@ -10,7 +10,7 @@ type Note {
   @db.oneToMany: 'commentNote'
   """
   comments: [Comment]!
-  likes: Number
+  likes: Int
 }
 
 """

--- a/examples/runtime-example/graphback.json
+++ b/examples/runtime-example/graphback.json
@@ -18,8 +18,7 @@
     "delete": true,
     "subCreate": true,
     "subUpdate": true,
-    "subDelete": true,
-    "disableGen": false
+    "subDelete": true
   },
   "folders": {
     "model": "./model",

--- a/packages/graphback-cli/src/templates/configTemplates.ts
+++ b/packages/graphback-cli/src/templates/configTemplates.ts
@@ -25,11 +25,6 @@ const databases = [
   'sqlite3'
 ]
 
-const generationConfig = {
-
-  "disableGen": false
-}
-
 export const chooseDatabase = async (): Promise<string> => {
   const { database } = await ask({
     type: 'list',

--- a/packages/graphback-codegen-client/src/templates/gqlCompleteTemplates.ts
+++ b/packages/graphback-codegen-client/src/templates/gqlCompleteTemplates.ts
@@ -70,9 +70,6 @@ export const createQueries = (types: ModelDefinition[]) => {
   const queries = []
 
   types.forEach((t: ModelDefinition) => {
-    if (t.crudOptions.disableGen) {
-      return;
-    }
     if (t.crudOptions.find) {
       queries.push({
         name: getFieldName(t.graphqlType.name, GraphbackOperationType.FIND),
@@ -95,9 +92,6 @@ const createMutations = (types: ModelDefinition[]) => {
   const mutations = []
 
   types.forEach((t: ModelDefinition) => {
-    if (t.crudOptions.disableGen) {
-      return;
-    }
     if (t.crudOptions.create) {
       mutations.push({
         name: getFieldName(t.graphqlType.name, GraphbackOperationType.CREATE),
@@ -127,9 +121,6 @@ const createSubscriptions = (types: ModelDefinition[]) => {
   const subscriptions = []
 
   types.forEach((t: ModelDefinition) => {
-    if (t.crudOptions.disableGen) {
-      return;
-    }
     const name = t.graphqlType.name;
     if (t.crudOptions.create && t.crudOptions.subCreate) {
       const operation = getSubscriptionName(name, GraphbackOperationType.CREATE);

--- a/packages/graphback-codegen-client/src/templates/gqlTemplates.ts
+++ b/packages/graphback-codegen-client/src/templates/gqlTemplates.ts
@@ -103,9 +103,6 @@ export const createQueries = (types: ModelDefinition[]) => {
   const queries = []
 
   types.forEach((t: ModelDefinition) => {
-    if (t.crudOptions.disableGen) {
-      return;
-    }
 
     if (t.crudOptions.find) {
       queries.push({
@@ -129,9 +126,6 @@ const createMutations = (types: ModelDefinition[]) => {
   const mutations = []
 
   types.forEach((t: ModelDefinition) => {
-    if (t.crudOptions.disableGen) {
-      return;
-    }
     if (t.crudOptions.create) {
       mutations.push({
         name: getFieldName(t.graphqlType.name, GraphbackOperationType.CREATE),
@@ -162,9 +156,6 @@ const createSubscriptions = (types: ModelDefinition[]) => {
 
   
   types.forEach((t: ModelDefinition) => {
-    if (t.crudOptions.disableGen) {
-      return;
-    }
     const name = t.graphqlType.name;
     if (t.crudOptions.create && t.crudOptions.subCreate) {
       const operation = getSubscriptionName(name, GraphbackOperationType.CREATE);

--- a/packages/graphback-codegen-client/src/templates/gqlTemplates.ts
+++ b/packages/graphback-codegen-client/src/templates/gqlTemplates.ts
@@ -35,7 +35,7 @@ export const findAllQuery = (t: GraphQLObjectType) => {
 export const findQuery = (t: GraphQLObjectType) => {
   const fieldName = getFieldName(t.name, GraphbackOperationType.FIND)
 
-  return `query ${fieldName}($filter: NoteFilter!) {
+  return `query ${fieldName}($filter: ${t.name}Filter!) {
     ${fieldName}(filter: $filter) {
       ...${ t.name}ExpandedFields
     }

--- a/packages/graphback-codegen-client/src/templates/gqlTemplates.ts
+++ b/packages/graphback-codegen-client/src/templates/gqlTemplates.ts
@@ -35,8 +35,8 @@ export const findAllQuery = (t: GraphQLObjectType) => {
 export const findQuery = (t: GraphQLObjectType) => {
   const fieldName = getFieldName(t.name, GraphbackOperationType.FIND)
 
-  return `query ${fieldName}($filter: ${t.name}Filter!) {
-    ${fieldName}(filter: $filter) {
+  return `query ${fieldName}($fields: ${t.name}Fields!) {
+    ${fieldName}(fields: $fields) {
       ...${ t.name}ExpandedFields
     }
   }`

--- a/packages/graphback-codegen-client/src/templates/tsTemplates.ts
+++ b/packages/graphback-codegen-client/src/templates/tsTemplates.ts
@@ -119,9 +119,7 @@ export const createQueriesTS = (types: ModelDefinition[]) => {
   const queries = []
 
   types.forEach((model: ModelDefinition) => {
-    if (model.crudOptions.disableGen) {
-      return;
-    }
+
     const t = model.graphqlType;
     const imports = `import gql from "graphql-tag"
 import { ${t.name}ExpandedFragment } from "../fragments/${t.name}Expanded"`
@@ -148,10 +146,6 @@ export const createMutationsTS = (types: ModelDefinition[]) => {
   const mutations = []
 
   types.forEach((model: ModelDefinition) => {
-    if (model.crudOptions.disableGen) {
-      return;
-    }
-
     const t = model.graphqlType;
     const imports = `import gql from "graphql-tag"
 import { ${t.name}Fragment } from "../fragments/${t.name}"`
@@ -185,9 +179,6 @@ export const createSubscriptionsTS = (types: ModelDefinition[]) => {
   const subscriptions = []
 
   types.forEach((model: ModelDefinition) => {
-    if (model.crudOptions.disableGen) {
-      return;
-    }
     const t = model.graphqlType;
     const name = model.graphqlType.name;
     const imports = `import gql from "graphql-tag"

--- a/packages/graphback-codegen-resolvers/src/formatters/apollo/resolverFormatter.ts
+++ b/packages/graphback-codegen-resolvers/src/formatters/apollo/resolverFormatter.ts
@@ -1,3 +1,4 @@
+import * as prettier from 'prettier';
 import { ResolverGeneratorPluginConfig } from '../../ResolverGeneratorPlugin';
 import { createCustomResolversIndexJS, createResolversIndexJS as createResolversIndexJS, resolverFileTemplateJS as resolverJSFileTemplate, rootResolversIndexJS } from './jsResolverFormatter';
 import { createResolversIndexTS, resolverFileTemplateTS as resolverTSFileTemplate, rootResolversIndexTS } from './tsResolverFormatter';
@@ -20,16 +21,7 @@ export const createBlankResolverTemplate = (resolverType: string, name: string, 
     }`;
 }
 
-function createResolverFileTemplate(name: string, outputResolvers: string[], options: ResolverGeneratorPluginConfig) {
-    switch (options.format) {
-        case 'js':
-            return resolverJSFileTemplate(name, outputResolvers);
-        case 'ts':
-            return resolverTSFileTemplate(outputResolvers, options);
-        default:
-            throw new Error(`"${options.format}" resolvers are not supported`);
-    }
-}
+
 
 export const createResolverTemplate = (name: string, typeResolvers: { Query: any, Mutation: any, Subscription: any }, options: ResolverGeneratorPluginConfig) => {
     const mutations = mapResolverKeyValueTemplates(typeResolvers.Mutation)
@@ -60,12 +52,23 @@ export const createResolverTemplate = (name: string, typeResolvers: { Query: any
     return createResolverFileTemplate(name, outputResolvers, options);
 }
 
+function createResolverFileTemplate(name: string, outputResolvers: string[], options: ResolverGeneratorPluginConfig) {
+    switch (options.format) {
+        case 'js':
+            return formatDocumentJS(resolverJSFileTemplate(name, outputResolvers));
+        case 'ts':
+            return formatDocumentTs(resolverTSFileTemplate(outputResolvers, options));
+        default:
+            throw new Error(`"${options.format}" resolvers are not supported`);
+    }
+}
+
 export const createResolversIndex = (resolverNames: string[], exportName: string = 'resolvers', format: string): string => {
     switch (format) {
         case 'js':
-            return createResolversIndexJS(resolverNames, exportName);
+            return formatDocumentJS(createResolversIndexJS(resolverNames, exportName));
         case 'ts':
-            return createResolversIndexTS(resolverNames, exportName);
+            return formatDocumentTs(createResolversIndexTS(resolverNames, exportName));
         default:
             throw new Error(`"${format}" resolver format not supported.`)
     }
@@ -74,9 +77,9 @@ export const createResolversIndex = (resolverNames: string[], exportName: string
 export const createCustomResolversIndex = (resolverNames: string[], exportName: string = 'resolvers', format: string): string => {
     switch (format) {
         case 'js':
-            return createCustomResolversIndexJS(resolverNames, exportName);
+            return formatDocumentJS(createCustomResolversIndexJS(resolverNames, exportName));
         case 'ts':
-            return createResolversIndexTS(resolverNames, exportName);
+            return formatDocumentTs(createResolversIndexTS(resolverNames, exportName));
         default:
             throw new Error(`"${format}" resolver format not supported.`)
     }
@@ -85,10 +88,32 @@ export const createCustomResolversIndex = (resolverNames: string[], exportName: 
 export const createRootResolversIndex = (format: string, groups: string[] = ['generated', 'custom']) => {
     switch (format) {
         case 'js':
-            return rootResolversIndexJS(groups);
+            return formatDocumentJS(rootResolversIndexJS(groups));
         case 'ts':
-            return rootResolversIndexTS(groups);
+            return formatDocumentTs(rootResolversIndexTS(groups));
         default:
             throw new Error(`"${format}" resolver format not supported.`)
+    }
+}
+
+function formatDocumentJS(contents: string) {
+    try {
+        return prettier.format(contents, { semi: false, parser: 'babel' });
+    } catch (e) {
+        // tslint:disable-next-line: no-console
+        console.log("Cannot format resolvers implementation", e)
+
+        return contents;
+    }
+}
+
+function formatDocumentTs(contents: string) {
+    try {
+        return prettier.format(contents, { semi: false, parser: 'typescript' });
+    } catch (e) {
+        // tslint:disable-next-line: no-console
+        console.log("Cannot format resolvers implementation", e)
+
+        return contents;
     }
 }

--- a/packages/graphback-codegen-resolvers/src/output/createResolvers.ts
+++ b/packages/graphback-codegen-resolvers/src/output/createResolvers.ts
@@ -7,9 +7,6 @@ export function generateCRUDResolvers(models: ModelDefinition[]) {
     const outputResolvers = {};
 
     for (const { graphqlType, crudOptions } of models) {
-        if (crudOptions.disableGen) {
-            continue;
-        }
 
         const typeResolvers = {
             Query: createQueries(graphqlType, crudOptions),
@@ -55,9 +52,6 @@ export function generateCustomCRUDResolvers(schema: GraphQLSchema, models: Model
 
 export function createMutations(modelType: GraphQLObjectType, crudOptions: GraphbackCRUDGeneratorConfig) {
     const mutations = {};
-    if (crudOptions.disableGen) {
-        return mutations;
-    }
 
     const tableName = getTableOrColumnName(modelType);
     const modelName = modelType.name;
@@ -81,9 +75,6 @@ export function createMutations(modelType: GraphQLObjectType, crudOptions: Graph
 
 export function createQueries(modelType: GraphQLObjectType, crudOptions: GraphbackCRUDGeneratorConfig) {
     const queries = {};
-    if (crudOptions.disableGen) {
-        return queries;
-    }
 
     const tableName = getTableOrColumnName(modelType);
     const modelName = modelType.name;
@@ -102,9 +93,6 @@ export function createQueries(modelType: GraphQLObjectType, crudOptions: Graphba
 
 export function createSubscriptions(modelType: GraphQLObjectType, crudOptions: GraphbackCRUDGeneratorConfig) {
     const subscriptions = {};
-    if (crudOptions.disableGen) {
-        return subscriptions;
-    }
 
     const tableName = getTableOrColumnName(modelType);
     const modelName = modelType.name;

--- a/packages/graphback-codegen-resolvers/src/writer/writeResolvers.ts
+++ b/packages/graphback-codegen-resolvers/src/writer/writeResolvers.ts
@@ -1,21 +1,10 @@
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import * as prettier from 'prettier';
+
 import { OutputResolvers, ResolverOutputDefinition } from '../output/outputResolvers';
 import { ResolverGeneratorPluginConfig } from '../ResolverGeneratorPlugin';
 
-// TODO: Move code formatting 
-// TODO BROKEN for JS. THis should be part of the resolver formatter.
-function formatDocument(contents: string) {
-    try {
-        return prettier.format(contents, { semi: false, parser: 'typescript' });
-    } catch (e) {
-        // tslint:disable-next-line: no-console
-        console.log("Cannot format resolvers implementation", e)
 
-        return contents;
-    }
-}
 
 export function writeResolvers(outputResolvers: OutputResolvers, options: ResolverGeneratorPluginConfig) {
     // TODO (this should be configurable
@@ -25,18 +14,18 @@ export function writeResolvers(outputResolvers: OutputResolvers, options: Resolv
     createFolders(customResolversPath, generatedResolversPath);
 
     outputResolvers.generated.resolvers.forEach((resolverDefinition: ResolverOutputDefinition) => {
-        writeFileSync(`${generatedResolversPath}/${resolverDefinition.name}.${options.format}`, formatDocument(resolverDefinition.output));
+        writeFileSync(`${generatedResolversPath}/${resolverDefinition.name}.${options.format}`, resolverDefinition.output);
     });
-    writeFileSync(`${generatedResolversPath}/index.${options.format}`, formatDocument(outputResolvers.generated.index));
+    writeFileSync(`${generatedResolversPath}/index.${options.format}`, outputResolvers.generated.index);
 
     outputResolvers.custom.resolvers.forEach((resolverDefinition: ResolverOutputDefinition) => {
         const fileName = `${customResolversPath}/${resolverDefinition.name}.${options.format}`;
         if (!existsSync(fileName)) {
-            writeFileSync(fileName, formatDocument(resolverDefinition.output));
+            writeFileSync(fileName, resolverDefinition.output);
         }
     });
-    writeFileSync(`${customResolversPath}/index.${options.format}`, formatDocument(outputResolvers.custom.index));
-    writeFileSync(`${options.outputPath}/index.${options.format}`, formatDocument(outputResolvers.index));
+    writeFileSync(`${customResolversPath}/index.${options.format}`, outputResolvers.custom.index);
+    writeFileSync(`${options.outputPath}/index.${options.format}`, outputResolvers.index);
 }
 
 function createFolders(generatedResolversPath: string, customResolversPath: string) {

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -1,6 +1,6 @@
 import { getBaseType, getFieldName, getSubscriptionName, GraphbackCoreMetadata, GraphbackOperationType, GraphbackPlugin, ModelDefinition } from '@graphback/core'
 import { mergeSchemas } from "@graphql-toolkit/schema-merging"
-import { existsSync, fstat, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { GraphQLField, GraphQLID, GraphQLInputObjectType, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, isObjectType } from 'graphql';
 import { resolve } from 'path';
 import { gqlSchemaFormatter, jsSchemaFormatter, tsSchemaFormatter } from './writer/schemaFormatters';
@@ -257,7 +257,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
             queryTypes[operation] = {
                 type: GraphQLNonNull(GraphQLList(model.graphqlType)),
                 args: {
-                    filter: {
+                    fields: {
                         type: modelInputType,
                     },
                 }

--- a/packages/graphback-core/src/plugin/GraphbackCRUDGeneratorConfig.ts
+++ b/packages/graphback-core/src/plugin/GraphbackCRUDGeneratorConfig.ts
@@ -18,6 +18,4 @@ export interface GraphbackCRUDGeneratorConfig {
     subUpdate?: boolean;
     // Generate subscription for delete operation
     subDelete?: boolean;
-    // Disable codegen
-    disableGen?: boolean;
 }

--- a/packages/graphback-core/src/plugin/GraphbackCoreMetadata.ts
+++ b/packages/graphback-core/src/plugin/GraphbackCoreMetadata.ts
@@ -14,7 +14,6 @@ const defaultCRUDGeneratorConfig = {
     "subCreate": true,
     "subUpdate": true,
     "subDelete": true,
-    "disableGen": false
 }
 
 /**

--- a/packages/graphback-runtime/src/resolvers/LayeredRuntimeResolverGen.ts
+++ b/packages/graphback-runtime/src/resolvers/LayeredRuntimeResolverGen.ts
@@ -33,9 +33,6 @@ export class LayeredRuntimeResolverGenerator {
       Subscription: {}
     };
     for (const resolverElement of this.models) {
-      if (resolverElement.crudOptions.disableGen) {
-        continue;
-      }
       // TODO this should use mapping
       const objectName = resolverElement.graphqlType.name.toLowerCase();
       if (resolverElement.crudOptions.create) {


### PR DESCRIPTION
## What

Generated schema `findX` query has a `filter` argument which should be `fields`. Generated resolvers still use `fields`, which cannot be found. This changes references of `filter` to `fields`.

## Tasks

- [x] Change `filter` to `fields` in schema 
- [x]  Change `filter` to `fields` in client queries.
- [x] Fix invalid scalar in model.