### PR TITLE
fix: add typings to custom resolvers

### DIFF
--- a/packages/graphback-codegen-resolvers/src/ResolverGeneratorPlugin.ts
+++ b/packages/graphback-codegen-resolvers/src/ResolverGeneratorPlugin.ts
@@ -1,5 +1,4 @@
-import { GraphbackCoreMetadata, GraphbackPlugin, ModelDefinition } from '@graphback/core';
-import { GraphQLSchema } from 'graphql';
+import { GraphbackCoreMetadata, GraphbackPlugin } from '@graphback/core';
 import { createRootResolversIndex } from './formatters/apollo';
 import { generateCRUDResolvers, generateCustomCRUDResolvers } from './output/createResolvers';
 import { createCustomOutputResolvers, createOutputResolvers, OutputResolvers } from './output/outputResolvers';
@@ -78,7 +77,7 @@ export class ResolverGeneratorPlugin extends GraphbackPlugin {
         const customResolvers = generateCustomCRUDResolvers(schema, models, generatedResolvers);
 
         const generatedResolverGroup = createOutputResolvers(generatedResolvers, this.pluginConfig);
-        const customResolverGroup = createCustomOutputResolvers(customResolvers, this.pluginConfig.format);
+        const customResolverGroup = createCustomOutputResolvers(customResolvers, this.pluginConfig);
         const rootResolverIndex = createRootResolversIndex(this.pluginConfig.format);
 
         return {

--- a/packages/graphback-codegen-resolvers/src/formatters/apollo/jsResolverFormatter.ts
+++ b/packages/graphback-codegen-resolvers/src/formatters/apollo/jsResolverFormatter.ts
@@ -6,6 +6,14 @@ export const resolverFileTemplateJS = (name: string, outputResolvers: string[]) 
     }`
 }
 
+export const blankResolverJS = (resolverType: string, name: string, output: string) => {
+    return `export default {
+        ${resolverType}: {
+            ${name}: ${output}
+        }
+    }`;
+}
+
 export const createResolversIndexJS = (resolverNames: string[], exportName: string = 'resolvers'): string => {
     const imports = resolverNames.map((name: string) => {
         return `const { ${name}Resolvers } = require('./${name}')`;

--- a/packages/graphback-codegen-resolvers/src/formatters/apollo/resolverFormatter.ts
+++ b/packages/graphback-codegen-resolvers/src/formatters/apollo/resolverFormatter.ts
@@ -1,6 +1,6 @@
 import { ResolverGeneratorPluginConfig } from '../../ResolverGeneratorPlugin';
-import { createCustomResolversIndexJS, createResolversIndexJS as createResolversIndexJS, resolverFileTemplateJS as resolverJSFileTemplate, rootResolversIndexJS } from './jsResolverFormatter';
-import { createResolversIndexTS, resolverFileTemplateTS as resolverTSFileTemplate, rootResolversIndexTS } from './tsResolverFormatter';
+import { blankResolverJS, createCustomResolversIndexJS, createResolversIndexJS as createResolversIndexJS, resolverFileTemplateJS as resolverJSFileTemplate, rootResolversIndexJS } from './jsResolverFormatter';
+import { blankResolverTS, createResolversIndexTS, resolverFileTemplateTS as resolverTSFileTemplate, rootResolversIndexTS } from './tsResolverFormatter';
 
 const mapResolverKeyValueTemplates = (resolvers: any) => {
     const resolverNames = Object.keys(resolvers);
@@ -12,12 +12,15 @@ const mapResolverKeyValueTemplates = (resolvers: any) => {
     });
 }
 
-export const createBlankResolverTemplate = (resolverType: string, name: string, output: string) => {
-    return `export default {
-        ${resolverType}: {
-            ${name}: ${output}
-        }
-    }`;
+export const createBlankResolverTemplate = (resolverType: string, name: string, output: string, options: ResolverGeneratorPluginConfig) => {
+    switch (options.format) {
+        case 'js':
+            return blankResolverJS(resolverType, name, output);
+        case 'ts':
+            return blankResolverTS(resolverType, name, output, options);
+        default:
+            throw new Error(`"${options.format}" resolvers are not supported`);
+    }
 }
 
 function createResolverFileTemplate(name: string, outputResolvers: string[], options: ResolverGeneratorPluginConfig) {

--- a/packages/graphback-codegen-resolvers/src/formatters/apollo/tsResolverFormatter.ts
+++ b/packages/graphback-codegen-resolvers/src/formatters/apollo/tsResolverFormatter.ts
@@ -9,17 +9,22 @@ export const resolvers = [${groups.map((name: string) => `...${name}Resolvers`)}
 }
 
 export const resolverFileTemplateTS = (outputResolvers: string[], options: ResolverGeneratorPluginConfig) => {
-    let resolverType = '';
-    let typedImports = '';
-    if (options.types) {
-        resolverType = ` as ${options.types.resolverRootType};\n`;
-        typedImports = `import { ${options.types.resolverRootType} } from "${options.types.resolverRootLocation}";\n`;
-    }
+    const { typedImports, resolverType } = getTypedImports(options);
 
     return `
     ${runtimeImportTemplate}\n${typedImports}\nexport default {
       ${outputResolvers.join(',\n\n\t')}  
     }${resolverType}`
+}
+
+export const blankResolverTS = (resolverType: string, name: string, output: string, options: ResolverGeneratorPluginConfig) => {
+    const { typedImports, resolverType: resolverTypeAs } = getTypedImports(options);
+
+    return `${typedImports}\nexport default {
+        ${resolverType}: {
+            ${name}: ${output}
+        }
+    }${resolverTypeAs}`;
 }
 
 export const createResolversIndexTS = (resolverNames: string[], exportName: string = 'resolvers'): string => {
@@ -44,4 +49,15 @@ export const createCustomResolversIndexTS = (resolverNames: string[], exportName
     return `${imports}
 
     export const ${exportName} = [${importNames.join(', ')}];`;
+}
+
+function getTypedImports(options: ResolverGeneratorPluginConfig) {
+    let resolverType = '';
+    let typedImports = '';
+    if (options.types) {
+        resolverType = ` as ${options.types.resolverRootType};\n`;
+        typedImports = `import { ${options.types.resolverRootType} } from "${options.types.resolverRootLocation}";\n`;
+    }
+
+    return { typedImports, resolverType };
 }

--- a/packages/graphback-codegen-resolvers/src/output/outputResolvers.ts
+++ b/packages/graphback-codegen-resolvers/src/output/outputResolvers.ts
@@ -56,7 +56,7 @@ const groupResolversByResolverType = (resolversByType: any): { Query: any; Mutat
 }
 
 // TODO: Enable custom resolvers using default CRUD names
-export const createCustomOutputResolvers = (resolverTypes: any, format: string): OutputResolverGroup => {
+export const createCustomOutputResolvers = (resolverTypes: any, options: ResolverGeneratorPluginConfig): OutputResolverGroup => {
     const resolverGroup: OutputResolverGroup = { resolvers: [] };
 
     const resolvers = groupResolversByResolverType(resolverTypes);
@@ -66,7 +66,7 @@ export const createCustomOutputResolvers = (resolverTypes: any, format: string):
 
         for (const fieldName of Object.keys(resolverFields)) {
             const resolverValue = resolverFields[fieldName];
-            const resolverOutput = createBlankResolverTemplate(resolverType, fieldName, resolverValue);
+            const resolverOutput = createBlankResolverTemplate(resolverType, fieldName, resolverValue, options);
 
             const outputResolver = {
                 name: fieldName,
@@ -77,7 +77,7 @@ export const createCustomOutputResolvers = (resolverTypes: any, format: string):
         }
     }
 
-    resolverGroup.index = createCustomResolversIndex(resolverGroup.resolvers.map((r: ResolverOutputDefinition) => r.name), 'customResolvers', format);
+    resolverGroup.index = createCustomResolversIndex(resolverGroup.resolvers.map((r: ResolverOutputDefinition) => r.name), 'customResolvers', options.format);
 
     return resolverGroup;
 }


### PR DESCRIPTION
Custom TypeScript resolvers did not include import typings from codegen.

## Verification

1. Add a custom query in data model.
2. Generate resolvers.
3. Run `yarn graphql generate`.
3. Check custom resolvers. They should import `generated-types`.