### PR TITLE
Use column name transform

### DIFF
--- a/packages/graphql-migrations/src/abstract/generateAbstractDatabase.ts
+++ b/packages/graphql-migrations/src/abstract/generateAbstractDatabase.ts
@@ -434,8 +434,7 @@ class AbstractDatabaseBuilder {
     const annotations: any = parseAnnotations('db', oneToManyRelationship.description || null);
 
     const field: GraphQLField<any, any> = {
-      // TODO: Use defaultColumnNameTransform
-      name: annotations.oneToMany || lowerCaseFirstChar(oneToManyRelationship.relation.name),
+      name: annotations.oneToMany || this.transformColumnName(oneToManyRelationship.relation.name, 'to-db'),
       type: oneToManyRelationship.relation,
       description: oneToManyRelationship.description,
       args: [],


### PR DESCRIPTION
This change uses the `this.transformColumnName` instead of `lowerCaseFirstChar` to transform the column name. when creating mapping a one-to-many relationship.

`this.transformColumnName` should be used at all times for column name transformation as it ensures a common transformer is used. This is configurable at the point of instantiation.