### PR TITLE
fix: Force remove id on create

### DIFF
--- a/packages/graphback-runtime-mongodb/src/MongoDBDataProvider.ts
+++ b/packages/graphback-runtime-mongodb/src/MongoDBDataProvider.ts
@@ -17,8 +17,14 @@ export class MongoDBDataProvider<Type = any, GraphbackContext = any> implements 
     this.collectionName = this.tableMap.tableName;
   }
 
-  public async create(data: Type): Promise<Type> {
+  public async create(data: any): Promise<Type> {
     const { idField } = getDatabaseArguments(this.tableMap, data);
+    if (data && data[idField.name]) {
+      // Ignore id passed from client side. In case id is passed it should not be saved
+      // eslint-disable-next-line @typescript-eslint/tslint/config
+      delete data[idField.name];
+    }
+
     const result = await this.db.collection(this.collectionName).insertOne(data);
     if (result && result.ops) {
       result.ops[0][idField.name] = result.ops[0]._id;


### PR DESCRIPTION
Currently, graphback generates only single `InputType` for create and update. 
This means that you can pass id to create. 
While this is not going to be issue for postgress as this value will be ignored and id will be autogenerated for mongo this needs to be managed

Before:
![Screenshot 2020-02-24 at 16 31 22](https://user-images.githubusercontent.com/981838/75171163-1c63dd00-5723-11ea-8f19-5a1442f2a48f.png)
After:
![Screenshot 2020-02-24 at 16 31 47](https://user-images.githubusercontent.com/981838/75171200-2b4a8f80-5723-11ea-9714-bad2117fecfa.png)

