### PR TITLE
chore: use yarn in release script

### DIFF
--- a/scripts/prepareRelease.sh
+++ b/scripts/prepareRelease.sh
@@ -3,13 +3,12 @@ echo "Preparing release"
 
 set -e
 
-npm install	
-npm run bootstrap	
-npm run build
+yarn	
+yarn build
 
 # don't run in CI
 if [ ! "$CI" = true ]; then
-  lerna publish --skip-git --force-publish=* --skip-npm
+  yarn lerna publish --skip-git --force-publish=* --skip-npm
 fi
 
 echo "Repository is ready for release."

--- a/scripts/release-procedure.adoc
+++ b/scripts/release-procedure.adoc
@@ -16,7 +16,18 @@ A small amount of preparation needs to take place before this process kicks off.
 
 === How to Prepare a Release
 
-Ensure the git repo is clean and there are no outstanding changes. Then check out a new branch.
+Ensure the Git repository is clean and there are no outstanding changes.
+
+Next, check to ensure that `templates-release` branch is up to date with `master`. In the following example `upstream` = `git@github.com:aerogear/graphback.git`.
+
+[source, sh]
+--
+git checkout templates-release
+git reset --hard upstream/master
+git push -f
+--
+
+Once this is complete you can check out a new branch.
 
 [source, bash]
 --


### PR DESCRIPTION
- The `prepareReleash.sh` script assumes you have lerna installed globally. This changes it to use the local package.
- Change also switches from npm to yarn.
- Update release procedure documentation to instruct user to update `templates-release` branch.

