### PR TITLE
fix: dbmigrations extension configuration indent

### DIFF
--- a/templates/ts-apollo-fullstack/.graphqlrc.yml
+++ b/templates/ts-apollo-fullstack/.graphqlrc.yml
@@ -28,13 +28,13 @@ extensions:
         graphback-resolvers:
           format: ts
           outputPath: ./server/src/resolvers
-    ## Knex DB Migration config
-    dbmigrations:
-      ## See knex.js for db specific config format
-      client: pg
-      connection:
-        user: postgresql
-        password: postgres
-        database: users
-        host: localhost
-        port: 55432
+  ## Knex DB Migration config
+  dbmigrations:
+    ## See knex.js for db specific config format
+    client: pg
+    connection:
+      user: postgresql
+      password: postgres
+      database: users
+      host: localhost
+      port: 55432


### PR DESCRIPTION
The `dbmigrations`extension configuration in `ts-apollo-fullstack` had the wrong indentation. It was under `graphback`, not as its own extension.