### PR TITLE
fix: initialized state variables

### DIFF
--- a/templates/ts-apollo-fullstack/client/src/App.tsx
+++ b/templates/ts-apollo-fullstack/client/src/App.tsx
@@ -6,8 +6,8 @@ const App: React.FC = () => {
   const allNotes = useFindAllNotesQuery();
   allNotes.startPolling(2000);
   const [createNote] = useCreateNoteMutation();
-  const [newNoteTitle, setNewNoteTitle] = useState();
-  const [newNoteDescription, setNewNoteDescription] = useState();
+  const [newNoteTitle, setNewNoteTitle] = useState("");
+  const [newNoteDescription, setNewNoteDescription] = useState("");
   return (
     <div>
       <fieldset>


### PR DESCRIPTION
It addresses the issue #791 
The two state variables were initialized to empty strings.