### PR TITLE
fix: runtime was not using dbmigrations config

### DIFF
--- a/templates/ts-apollo-runtime-backend/src/db.ts
+++ b/templates/ts-apollo-runtime-backend/src/db.ts
@@ -12,10 +12,10 @@ export const getGraphbackConfig = async () => {
 
 export const getMigrateConfig = async () => {
     const config = await loadConfig({
-        extensions: [() => ({ name: 'graphback' })]
+        extensions: [() => ({ name: 'dbmigrations' })]
     });
 
-    const conf = await config.getDefault().extension('graphback');
+    const conf = await config.getDefault().extension('dbmigrations');
     return conf;
 }
 

--- a/templates/ts-apollo-runtime-backend/src/runtime.ts
+++ b/templates/ts-apollo-runtime-backend/src/runtime.ts
@@ -3,7 +3,6 @@ import { GraphbackRuntime, ModelDefinition, GraphbackGeneratorConfig } from 'gra
 import { createKnexPGCRUDRuntimeServices } from '@graphback/runtime-knex'
 import { migrateDB } from 'graphql-migrations';
 import { PubSub } from 'graphql-subscriptions';
-import * as Knex from 'knex';
 import { createDB, getGraphbackConfig, getMigrateConfig } from './db'
 import { loadSchema } from './loadSchema';
 import { buildSchema } from 'graphql';


### PR DESCRIPTION
The runtime app was trying to load config from `graphback` config extension.