### PR TITLE
fix: incorrect return value from offix monogdb data provider

### DIFF
--- a/packages/graphback-runtime-mongodb/src/OffixMongoDBDataProvider.ts
+++ b/packages/graphback-runtime-mongodb/src/OffixMongoDBDataProvider.ts
@@ -39,8 +39,8 @@ export class OffixMongoDBDataProvider<Type = any, GraphbackContext = any> extend
       data.version = data.version + 1;
       // TODO use findOneAndUpdate to check consistency afterwards
       const result = await this.db.collection(this.collectionName).updateOne({ _id: new ObjectId(idField.value) }, { $set: data });
-      if (result) {
-        return queryResult[0];
+      if (result.result.ok) {
+        return data;
       }
     }
 

--- a/packages/graphback-runtime-mongodb/src/OffixMongoDBDataProvider.ts
+++ b/packages/graphback-runtime-mongodb/src/OffixMongoDBDataProvider.ts
@@ -39,7 +39,7 @@ export class OffixMongoDBDataProvider<Type = any, GraphbackContext = any> extend
       data.version = data.version + 1;
       // TODO use findOneAndUpdate to check consistency afterwards
       const result = await this.db.collection(this.collectionName).updateOne({ _id: new ObjectId(idField.value) }, { $set: data });
-      if (result.result.ok) {
+      if (result.result?.ok) {
         return data;
       }
     }


### PR DESCRIPTION
- Fix: `OffixMongoDBDataProvider` was returning the previous value rather than the updated value in the update query.