### PR TITLE
Added option for mongodb in graphback config

### DIFF
--- a/packages/graphback-cli/package.json
+++ b/packages/graphback-cli/package.json
@@ -13,7 +13,7 @@
   "author": "wtrocki@redhat.com",
   "scripts": {
     "clean": "rimraf coverage dist types",
-    "build": "tsc && ncp ./src/templates/resources ./dist/templates/",
+    "build": "tsc && ncp ./src/templates/resources ./dist/templates/resuorces",
     "cmdinit": "ts-node ./dist/index.js init test",
     "watch": "tsc -w",
     "lint": "eslint -t stylish --project \"tsconfig.json\"",

--- a/packages/graphback-cli/package.json
+++ b/packages/graphback-cli/package.json
@@ -13,7 +13,7 @@
   "author": "wtrocki@redhat.com",
   "scripts": {
     "clean": "rimraf coverage dist types",
-    "build": "tsc && cp -Rf ./src/templates/resources ./dist/templates/resources",
+    "build": "tsc && ncp ./src/templates/resources ./dist/templates/",
     "cmdinit": "ts-node ./dist/index.js init test",
     "watch": "tsc -w",
     "lint": "eslint -t stylish --project \"tsconfig.json\"",
@@ -45,6 +45,7 @@
     "@types/yargs": "15.0.3",
     "ava": "2.4.0",
     "lint-staged": "10.0.7",
+    "ncp": "^2.0.0",
     "rimraf": "3.0.2",
     "ts-node": "8.6.2",
     "tsutils": "3.17.1",

--- a/packages/graphback-cli/src/components/config.ts
+++ b/packages/graphback-cli/src/components/config.ts
@@ -13,11 +13,12 @@ export async function installDependencies(database: string): Promise<void> {
   await execa('npm', ['i'])
   if (database === 'pg') {
     await execa('npm', ['i', '-S', 'pg'])
-  } else if (database === 'sqlite3') {
-    await execa('npm', ['i', '-S', 'sqlite3'])
+    await execa('npm', ['i', '-S', '@graphback/runtime-knex'])
+  } else if (database === 'MongoDB') {
+    await execa('npm', ['i', '-S', 'mongodb'])
+    await execa('npm', ['i', '-S', '@graphback/runtime-mongo'])
   }
   //Using opiniated layer
-  await execa('npm', ['i', '-S', '@graphback/runtime-knex'])
 }
 
 function postSetupMessage(): string {

--- a/packages/graphback-cli/src/components/config.ts
+++ b/packages/graphback-cli/src/components/config.ts
@@ -18,7 +18,6 @@ export async function installDependencies(database: string): Promise<void> {
     await execa('npm', ['i', '-S', 'mongodb'])
     await execa('npm', ['i', '-S', '@graphback/runtime-mongo'])
   }
-  //Using opiniated layer
 }
 
 function postSetupMessage(): string {

--- a/packages/graphback-cli/src/components/db.ts
+++ b/packages/graphback-cli/src/components/db.ts
@@ -35,10 +35,10 @@ export const createDBResources = async (cliFlags: { project?: string }): Promise
       process.exit(0)
     }
 
-    // if (dbMigrationConfig.client === 'sqlite3') {
-    //   logInfo(`SQLLite database will need to be recreated from scratch with every migration. Please manually remove/backup existing SQLLite database file before migration`);
-    //   await execa('touch', [dbMigrationConfig.connection.filename])
-    // }
+    if (dbMigrationConfig.client === 'sqlite3') {
+      logInfo(`SQLLite database will need to be recreated from scratch with every migration. Please manually remove/backup existing SQLLite database file before migration`);
+      await execa('touch', [dbMigrationConfig.connection.filename])
+    }
 
     const migrateOptions: MigrateOptions = {
       //Do not perform delete operations on tables

--- a/packages/graphback-cli/src/components/db.ts
+++ b/packages/graphback-cli/src/components/db.ts
@@ -12,7 +12,7 @@ const handleError = (err: { code: string; message: string; }): void => {
     logError(err.message)
   }
   process.exit(0)
-};
+}; 
 
 export const createDBResources = async (cliFlags: { project?: string }): Promise<any> => {
   let databaseOperations: any;
@@ -35,10 +35,10 @@ export const createDBResources = async (cliFlags: { project?: string }): Promise
       process.exit(0)
     }
 
-    if (dbMigrationConfig.client === 'sqlite3') {
-      logInfo(`SQLLite database will need to be recreated from scratch with every migration. Please manually remove/backup existing SQLLite database file before migration`);
-      await execa('touch', [dbMigrationConfig.connection.filename])
-    }
+    // if (dbMigrationConfig.client === 'sqlite3') {
+    //   logInfo(`SQLLite database will need to be recreated from scratch with every migration. Please manually remove/backup existing SQLLite database file before migration`);
+    //   await execa('touch', [dbMigrationConfig.connection.filename])
+    // }
 
     const migrateOptions: MigrateOptions = {
       //Do not perform delete operations on tables

--- a/packages/graphback-cli/src/templates/configTemplates.ts
+++ b/packages/graphback-cli/src/templates/configTemplates.ts
@@ -15,7 +15,7 @@ const getConfig = (database: string) => {
   if (database === 'pg') {
     return [readFileSync(`${configFilesPath}/postgres.json`, 'utf8'), readFileSync(`${dockerFilesPath}/postgres.yml`, 'utf8')]
   } else if (database === 'MongoDB') {
-    return [readFileSync(`${configFilesPath}/mongodb.json`, 'utf8'), readFileSync(`${dockerFilesPath}/mongodb.yml`, 'utf8')]
+    return ["", readFileSync(`${dockerFilesPath}/mongodb.yml`, 'utf8')]
   } else if (database === 'sqlite3') {
     return [readFileSync(`${configFilesPath}/sqlite3.json`, 'utf8'), undefined]
   } else {
@@ -26,7 +26,6 @@ const getConfig = (database: string) => {
 const databases = [
   'PostgreSQL',
   'MongoDB'
-  // 'sqlite3'
 ]
 
 export const chooseDatabase = async (): Promise<string> => {
@@ -69,7 +68,8 @@ export const createConfig = async (database: string, client: boolean) => {
 
   const dockerComposePath = `${process.cwd()}/docker-compose.yml`;
   const [dbConfig, dockerCompose] = getConfig(database);
-  const graphqlConfigJSON = {
+
+  const graphqlConfig: IGraphQLConfig = {
     schema: './src/schema/*.graphql',
     documents: './client/src/graphql/**/*.graphql',
     extensions: {
@@ -100,13 +100,11 @@ export const createConfig = async (database: string, client: boolean) => {
   };
 
   if(database === "pg") {
-    graphqlConfigJSON.extensions.graphback['dbMigrations'] = {
+    graphqlConfig.extensions.graphback.dbmigrations = {
       "connection": JSON.parse(dbConfig),
       "client": database
     };
   }
-
-  const graphqlConfig: IGraphQLConfig = graphqlConfigJSON;
 
   if (client) {
     //Add client extension

--- a/packages/graphback-cli/src/templates/configTemplates.ts
+++ b/packages/graphback-cli/src/templates/configTemplates.ts
@@ -14,16 +14,20 @@ const dockerFilesPath = `${__dirname}/resources/docker`
 const getConfig = (database: string) => {
   if (database === 'pg') {
     return [readFileSync(`${configFilesPath}/postgres.json`, 'utf8'), readFileSync(`${dockerFilesPath}/postgres.yml`, 'utf8')]
-  } else if (database === 'sqlite3') {
-    return [readFileSync(`${configFilesPath}/sqlite3.json`, 'utf8'), undefined]
+  } else if (database === 'MongoDB') {
+    return [readFileSync(`${configFilesPath}/mongodb.json`, 'utf8'), readFileSync(`${dockerFilesPath}/mongodb.yml`, 'utf8')]
   } else {
     return undefined
   }
+  // else if (database === 'sqlite3') {
+  //   return [readFileSync(`${configFilesPath}/sqlite3.json`, 'utf8'), undefined]
+  // } 
 }
 
 const databases = [
   'PostgreSQL',
-  'sqlite3'
+  'MongoDB'
+  // 'sqlite3'
 ]
 
 export const chooseDatabase = async (): Promise<string> => {

--- a/packages/graphback-cli/src/templates/configTemplates.ts
+++ b/packages/graphback-cli/src/templates/configTemplates.ts
@@ -16,12 +16,11 @@ const getConfig = (database: string) => {
     return [readFileSync(`${configFilesPath}/postgres.json`, 'utf8'), readFileSync(`${dockerFilesPath}/postgres.yml`, 'utf8')]
   } else if (database === 'MongoDB') {
     return [readFileSync(`${configFilesPath}/mongodb.json`, 'utf8'), readFileSync(`${dockerFilesPath}/mongodb.yml`, 'utf8')]
+  } else if (database === 'sqlite3') {
+    return [readFileSync(`${configFilesPath}/sqlite3.json`, 'utf8'), undefined]
   } else {
     return undefined
   }
-  // else if (database === 'sqlite3') {
-  //   return [readFileSync(`${configFilesPath}/sqlite3.json`, 'utf8'), undefined]
-  // } 
 }
 
 const databases = [
@@ -70,7 +69,7 @@ export const createConfig = async (database: string, client: boolean) => {
 
   const dockerComposePath = `${process.cwd()}/docker-compose.yml`;
   const [dbConfig, dockerCompose] = getConfig(database);
-  const graphqlConfig: IGraphQLConfig = {
+  const graphqlConfigJSON = {
     schema: './src/schema/*.graphql',
     documents: './client/src/graphql/**/*.graphql',
     extensions: {
@@ -95,14 +94,19 @@ export const createConfig = async (database: string, client: boolean) => {
             "format": "ts",
             "outputPath": "./src/resolvers"
           }
-        },
-      },
-      dbmigrations: {
-        "connection": JSON.parse(dbConfig),
-        "client": database
+        }
       }
     }
   };
+
+  if(database === "pg") {
+    graphqlConfigJSON.extensions.graphback['dbMigrations'] = {
+      "connection": JSON.parse(dbConfig),
+      "client": database
+    };
+  }
+
+  const graphqlConfig: IGraphQLConfig = graphqlConfigJSON;
 
   if (client) {
     //Add client extension

--- a/packages/graphback-cli/src/templates/resources/config/mongodb.json
+++ b/packages/graphback-cli/src/templates/resources/config/mongodb.json
@@ -1,0 +1,7 @@
+{
+  "user": "mongodb",
+  "password": "mongo",
+  "database": "users",
+  "host": "127.0.0.1",
+  "port": 27017
+}

--- a/packages/graphback-cli/src/templates/resources/config/mongodb.json
+++ b/packages/graphback-cli/src/templates/resources/config/mongodb.json
@@ -1,7 +1,0 @@
-{
-  "user": "mongodb",
-  "password": "mongo",
-  "database": "users",
-  "host": "127.0.0.1",
-  "port": 27017
-}

--- a/packages/graphback-cli/src/templates/resources/docker/mongodb.yml
+++ b/packages/graphback-cli/src/templates/resources/docker/mongodb.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  mongodb:
+        image: mongo:latest
+        container_name: "mongodb"
+        environment:
+          - MONGO_DATA_DIR=/data/db
+          - MONGO_LOG_DIR=/dev/null
+          - MONGO_INITDB_DATABASE=users
+          - MONGO_INITDB_ROOT_USERNAME=mongodb
+          - MONGO_INITDB_ROOT_PASSWORD=mongo
+        volumes:
+          - ./data/db:/data/db
+        ports:
+            - 27017:27017
+        command: mongod

--- a/packages/graphback-runtime-mongodb/package.json
+++ b/packages/graphback-runtime-mongodb/package.json
@@ -50,10 +50,10 @@
     "@graphback/runtime": "0.11.0-rc3",
     "@types/mongodb": "3.3.16",
     "dataloader": "2.0.0",
-    "graphql-subscriptions": "1.1.0",
-    "mongodb": "3.5.3"
+    "graphql-subscriptions": "1.1.0"
   },
   "peerDependencies": {
-    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0",
+    "mongodb": "3.5.3"
   }
 }


### PR DESCRIPTION
Addresses #757 
Updates - 
1. Added the option of MongoDB (and removed the option of sqlite3) in graphback config command 
2. Added the files mongodb.yml and mongodb.json for docker-compose of mongodb 
3. Added - Installing different runtime package based on the choice - @graphback/runtime-mongo or @graphback/runtime-knex 
Command `graphback db` failed with - 
`knex: Unknown configuration option 'client' value MongoDB. Note that it is case-sensitive, check documentation for supported values.` 
@ankitjena pointed out the reason for it.
Working on it.