### PR TITLE
fix: Remove major oudated elements from docs

### DIFF
--- a/docs/crud/crudruntime.md
+++ b/docs/crud/crudruntime.md
@@ -23,7 +23,6 @@ Graphback provides following implementations of GraphbackCRUDService
 
 Graphback provides following implementations of GraphbackDataProvider
 
-- KnexDBDataProvider (`@graphback/runtime-knex`)
 - PgKnexDBDataProvider (PostgreSQL version from `@graphback/runtime-knex`)
 - MongoDBDataProvider (`@graphback/runtime-mongodb`)
 
@@ -57,10 +56,12 @@ findAllComments: (parent, args, context) => {
 Graphback plugin will generate `createContext.ts` file that creates instances of your model.
 Developers can modify them and point them to the different datasources without using code generation.
 
-To use runtime developers need to call `createCRUDResolversRuntimeContext` from `createContext.ts` when creating their GraphQL Server:
+To use runtime developers need to call respective helper from the runtime-knex or runtime-mongodb libraries.
+For example:
 
 ```ts
-   const context = createCRUDResolversRuntimeContext({ schema, db, pubSub });
+  import { createKnexPGCRUDRuntimeServices } from "@graphback/runtime-knex"
+   const context = createKnexPGCRUDRuntimeServices(models, schema, db, pubSub);
     const apolloServer = new ApolloServer({
         typeDefs: typeDefs,
         resolvers,

--- a/docs/crud/crudspec.md
+++ b/docs/crud/crudspec.md
@@ -53,8 +53,8 @@ input NoteInput {
 }
 
 type Query {
-  findAllNotes: [Note]!
-  findNotes(fields: NoteInput): [Note]!
+  findAllNotes(limit: Int, offset: Int): [Note]!
+  findNotes(fields: NoteInput, limit: Int, offset: Int): [Note]!
 } 
 
 type Mutation {

--- a/docs/crud/mapping.md
+++ b/docs/crud/mapping.md
@@ -13,12 +13,9 @@ For example:
 """ @model """
 type Note {
   id: ID!
-  """ @db.name: note_title """
   title: String!
   description: String!
-  comment: [Comment!]!
 }
-
 ```
 
-For more information please refer to [`migrations documentation`](/docs/migrations.
+For more information please refer to [`migrations documentation`](/docs/migrations).

--- a/docs/crud/relationships.md
+++ b/docs/crud/relationships.md
@@ -4,7 +4,7 @@ title: Model Relationships
 sidebar_label: Model Relationships
 ---
 
-> NOTE: This document is still in progress
+> NOTE: This document is outdated and needs more work
 
 ## Database Relationships
 

--- a/docs/db/datasources.md
+++ b/docs/db/datasources.md
@@ -15,7 +15,7 @@ Our runtime supports following datasources
 
 ### Migrations
 
-Graphback provides out of the box database migrations for Postgress.
+Graphback provides out of the box database migrations for PostgreSQL.
 Developers can edit their schema and their changes will be replicated into the database.
 
 > NOTE: Database migrations are not supported for MongoDB

--- a/docs/db/datasources.md
+++ b/docs/db/datasources.md
@@ -5,16 +5,17 @@ title: Data Sources
 
 ## Data Sources
 
-Graphback allows you to work with different database systems and other data sources, according to your needs.
-Graphback provides support to multiple databases when performing migrations.
+Graphback allows you to work with different database systems and other data sources.
+Graphback provides support to multiple databases.
 
-Our migration engine is based on Knex.js and we are actively supporting and testing the following database systems:
+Our runtime supports following datasources
 
-- PostgreSQL (Using Knex.js)
-- MySQL (Using Knex.js) 
-- SQLite (No database fields mapping supported)
-- MongoDB (No database fields mapping supported)
-early version based on MongoDriver - @graphback/runtime-mongodb
+- PostgreSQL (@graphback/runtime-knex)
+- MongoDB  (@graphback/runtime-mongodb)
 
-This databases are supported for relational database schema migration. 
-Graphback `CRUD Runtime abstraction` allows developers to use any type of datasource.
+### Migrations
+
+Graphback provides out of the box database migrations for Postgress.
+Developers can edit their schema and their changes will be replicated into the database.
+
+> NOTE: Database migrations are not supported for MongoDB

--- a/docs/intro/config.md
+++ b/docs/intro/config.md
@@ -58,19 +58,18 @@ extensions:
         graphback-resolvers:
           format: ts
           outputPath: ./server/src/resolvers
-    ## Knex DB Migration config that can be also used in application
-    ## In order to connect to the database
-    ## Please do not connect it to shared database as Graphback will automatically 
-    ## execute dlls statements that can affect other applications.
-    dbmigrations:
-      ## See knex.js for db specific config format
-      client: pg
-      connection:
-        user: postgresql
-        password: postgres
-        database: users
-        host: localhost
-        port: 55432
+  ## graphql-migration config that can be also used in application
+  ## Please do not connect it to shared database as Graphback will automatically 
+  ## execute dlls statements that can affect other applications.
+  dbmigrations:
+    ## See knex.js for db specific config format
+    client: pg
+    connection:
+      user: postgresql
+      password: postgres
+      database: users
+      host: localhost
+      port: 55432
         
 
 ```

--- a/docs/plugins/graphback-resolvers.md
+++ b/docs/plugins/graphback-resolvers.md
@@ -37,7 +37,7 @@ import { createKnexPGCRUDRuntimeServices } from "@graphback/runtime-knex"
 
   const context = createKnexPGCRUDRuntimeServices(models, schema, db, pubSub);
   const apolloServer = new ApolloServer({
-      typeDefs: typeDefs,
+      typeDefs,
       resolvers,
       context,
       playground: true,

--- a/docs/plugins/graphback-resolvers.md
+++ b/docs/plugins/graphback-resolvers.md
@@ -33,13 +33,15 @@ Minimalistic example of the Apollo Server based GraphQL server will look as foll
 ```ts
 import resolvers from './resolvers/resolvers';
 import schema from './schema/schema';
+import { createKnexPGCRUDRuntimeServices } from "@graphback/runtime-knex"
 
-const context = createCRUDResolversRuntimeContext({ schema, db, pubSub });
-const apolloServer = new ApolloServer({
-  typeDefs: schema,
-  resolvers,
-  context,
-});
+  const context = createKnexPGCRUDRuntimeServices(models, schema, db, pubSub);
+  const apolloServer = new ApolloServer({
+      typeDefs: typeDefs,
+      resolvers,
+      context,
+      playground: true,
+  })
 ```
 
 Please refer to ts-apollo-fullstack app for fully functional example:

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,8 +8,7 @@ title: Releases
 This file contains changes and migration steps for the Graphback project. 
 Please follow individual releases for more information.
 
-
-# 0.12.0
+# 0.11.0
 
 New features and changes documented in blog post: 
 https://medium.com/@wtr/graphback-plugin-based-realtime-database-generator-78f4f608b81e
@@ -21,11 +20,6 @@ Breaking changes:
 - BREAKING: CRUDService api was changed to support per entity model
 - BREAKING: Runtime API was changed. Graphback package exports now GraphbackRuntime class to create runtime layer.
 - BREAKING: @model annotation is required for type to use generation
-
-# 0.11.0
-
-### Graphback
-
 - BREAKING: Removed GraphbackBackend and related interfaces.
 
 - BREAKING: Removed Production migrations engine

--- a/templates/ts-apollo-fullstack/server/src/resolvers/createContext.ts
+++ b/templates/ts-apollo-fullstack/server/src/resolvers/createContext.ts
@@ -1,6 +1,0 @@
-import { GraphQLSchema } from "graphql"
-
-export const createCRUDResolversRuntimeContext = (input: { schema: GraphQLSchema, db: any, pubSub: any }) => {
-
-  return {}
-}


### PR DESCRIPTION
Update critical elements of the docs. 

Generally our docs needs another major refurb because datasources might change the workflow. For example there is no need to use graphback db with mongo 