### PR TITLE
fix: return db as any

### DIFF
--- a/templates/ts-apollo-fullstack/server/src/db.ts
+++ b/templates/ts-apollo-fullstack/server/src/db.ts
@@ -20,5 +20,5 @@ export const createDB = async () => {
     // connect to db
     const db = Knex(dbmigrations)
 
-    return db
+    return db as any
 }


### PR DESCRIPTION
Error in fullstack server template: 

```
TSError: ⨯ Unable to compile TypeScript:
src/graphql.ts(20,69): error TS2345: Argument of type 'import("/home/ephelan/code/aerogear/graphback/templates/ts-apollo-fullstack/node_modules/knex/types/index")<any, any[]>' is not assignable to parameter of type 'Knex<any, any[]>'.
  Types of property 'raw' are incompatible.
    Type 'import("/home/ephelan/code/aerogear/graphback/templates/ts-apollo-fullstack/node_modules/knex/types/index").RawBuilder<any, any>' is not assignable to type 'import("/home/ephelan/code/aerogear/graphback/node_modules/knex/types/index").RawBuilder<any, any>'.
      Types of parameters 'value' and 'value' are incompatible.
```

This fixes that.

@wtrocki I believe this was fixed before, do you know why it is back?