### PR TITLE
fix: undefined var name in PgKnexDBDataProvider

### DIFF
--- a/packages/graphback-runtime-knex/src/PgKnexDBDataProvider.ts
+++ b/packages/graphback-runtime-knex/src/PgKnexDBDataProvider.ts
@@ -25,6 +25,6 @@ export class PgKnexDBDataProvider<Type = any, GraphbackContext = any> extends Kn
         if (dbResult && dbResult[0]) {
             return dbResult[0]
         }
-        throw new NoDataError(`Cannot create ${name}`);
+        throw new NoDataError(`Cannot create ${this.tableName}`);
     }
 }


### PR DESCRIPTION
- fixed a variable name that wasn't defined in the class that was causing issues with jest code coverate