### PR TITLE
Allow to override subscription mapping

### DIFF
--- a/packages/graphback-runtime/README.md
+++ b/packages/graphback-runtime/README.md
@@ -37,6 +37,6 @@ that will be used for GraphQL subscriptions. For example:
 
 ```typescript
     protected subscriptionTopicMapping(triggerType: GraphbackOperationType, objectName: string) {
-        return `namespace/${tiggerType}_${objectName}`.toUpperCase();
+        return `namespace/${triggerType}_${objectName}`.toUpperCase();
     }
 ```

--- a/packages/graphback-runtime/README.md
+++ b/packages/graphback-runtime/README.md
@@ -36,7 +36,7 @@ https://github.com/aerogear/graphback/tree/master/templates/ts-apollo-fullstack
 that will be used for GraphQL subscriptions. For example:
 
 ```typescript
-    protected subscriptionTopicMapping(tiggerType: GraphbackOperationType, objectName: string) {
+    protected subscriptionTopicMapping(triggerType: GraphbackOperationType, objectName: string) {
         return `namespace/${tiggerType}_${objectName}`.toUpperCase();
     }
 ```

--- a/packages/graphback-runtime/README.md
+++ b/packages/graphback-runtime/README.md
@@ -29,3 +29,14 @@ By default resolver layer will based on the `CRUDService` field attached to cont
 
 See example app:
 https://github.com/aerogear/graphback/tree/master/templates/ts-apollo-fullstack
+
+## Using different topics
+
+`CRUDService.subscriptionTopicMapping` method allows developers to override default publish subscribe topics
+that will be used for GraphQL subscriptions. For example:
+
+```typescript
+    protected subscriptionTopicMapping(tiggerType: GraphbackOperationType, objectName: string) {
+        return `namespace/${tiggerType}_${objectName}`.toUpperCase();
+    }
+```

--- a/packages/graphback-runtime/src/service/CRUDService.ts
+++ b/packages/graphback-runtime/src/service/CRUDService.ts
@@ -138,7 +138,7 @@ export class CRUDService<T = any> implements GraphbackCRUDService<T>  {
      * Provides way to map runtime topics for subscriptions for specific types and object names
      */
     protected subscriptionTopicMapping(triggerType: GraphbackOperationType, objectName: string) {
-        return `${tiggerType}_${objectName}`.toUpperCase();
+        return `${triggerType}_${objectName}`.toUpperCase();
     }
 
     private buildEventPayload(action: string, result: any) {

--- a/packages/graphback-runtime/src/service/CRUDService.ts
+++ b/packages/graphback-runtime/src/service/CRUDService.ts
@@ -137,7 +137,7 @@ export class CRUDService<T = any> implements GraphbackCRUDService<T>  {
     /**
      * Provides way to map runtime topics for subscriptions for specific types and object names
      */
-    protected subscriptionTopicMapping(tiggerType: GraphbackOperationType, objectName: string) {
+    protected subscriptionTopicMapping(triggerType: GraphbackOperationType, objectName: string) {
         return `${tiggerType}_${objectName}`.toUpperCase();
     }
 

--- a/packages/graphback-runtime/src/service/subscriptionTopicMapping.ts
+++ b/packages/graphback-runtime/src/service/subscriptionTopicMapping.ts
@@ -1,7 +1,0 @@
-import { GraphbackOperationType } from "@graphback/core"
-/**
- * Provides way to map runtime topics for subscriptions for specific types and object names
- */
-export const subscriptionTopicMapping = (tiggerType: GraphbackOperationType, objectName: string) => {
-    return `${tiggerType}_${objectName}`.toUpperCase();
-}


### PR DESCRIPTION
To incorporate AMQ cases we should be able to use different subscription topics. 
Follow up will be done in data sync starter to build up namespaced topics.

This change is not causing any side impacts. We just move things around.
Fixes https://github.com/aerogear/graphback/issues/945