### PR TITLE
Add bidirectional 1:1 relationship querying

### DIFF
--- a/docs/crud/relationships.md
+++ b/docs/crud/relationships.md
@@ -33,7 +33,7 @@ type User {
 }
 ```
 
-This creates a relationship via a `userId` column in the `profile` table. You can customize the key tracking the relationship with the `key` annotation:
+This creates a unidirectional relationship via a `userId` column in the `profile` table. You can customize the key tracking the relationship with the `key` annotation:
 
 ```graphql
 """
@@ -57,6 +57,25 @@ type User {
 ```
 
 This maps `Profile.user` to `profile.user_id` in the database.
+
+To create a bidirectional one-to-one relationship:
+
+```graphql
+"""
+@model
+"""
+type Profile {
+  id: ID!
+  """
+  @oneToOne key: 'user_id', field: 'profile'
+  """
+  user: User!
+}
+```
+
+This generates a `User.profile` field and allows you to retrieve relation data from both `Profile` and `User` models. 
+
+> NOTE: In this scenario, only `Profile.user` has an associated foreign key field in the database. `User.profile` is a "virtual" relationship field, meaning it only exists at the resolver level.
 
 ### OneToMany
 

--- a/docs/db/migrations.md
+++ b/docs/db/migrations.md
@@ -93,7 +93,7 @@ type User {
 }
 ```
 
-This creates a relationship via a `userId` column in the `profile` table. You can customize the key tracking the relationship with the `key` annotation:
+This creates a unidirectional relationship via a `userId` column in the `profile` table. You can customize the key tracking the relationship with the `key` annotation:
 
 ```graphql
 """
@@ -117,6 +117,25 @@ type User {
 ```
 
 This maps `Profile.user` to `profile.user_id` in the database.
+
+To create a bidirectional one-to-one relationship:
+
+```graphql
+"""
+@model
+"""
+type Profile {
+  id: ID!
+  """
+  @oneToOne key: 'user_id', field: 'profile'
+  """
+  user: User!
+}
+```
+
+This generates a `User.profile` field and allows you to retrieve relation data from both `Profile` and `User` models. 
+
+> NOTE: In this scenario, only `Profile.user` has an associated foreign key field in the database. `User.profile` is a "virtual" relationship field, meaning it only exists at the resolver level.
 
 ##### OneToMany
 

--- a/docs/intro/datamodel.md
+++ b/docs/intro/datamodel.md
@@ -104,7 +104,7 @@ type Profile {
 }
 ```
 
-This creates a one-sided relationship between the `Profile` and `User` models.
+This creates a unidirectional relationship between the `Profile` and `User` models.
 
 By default this maps to `profile.userId` in the underlying data source. Yon can customise this by adding `key` to the `@oneToOne` annotation:
 
@@ -120,3 +120,22 @@ type Profile {
   user: User!
 }
 ```
+
+To create a bidirectional one-to-one relationship:
+
+```graphql
+"""
+@model
+"""
+type Profile {
+  id: ID!
+  """
+  @oneToOne key: 'user_id', field: 'profile'
+  """
+  user: User!
+}
+```
+
+This generates a `User.profile` field and allows you to retrieve relation data from both `Profile` and `User` models. 
+
+> NOTE: In this scenario, only `Profile.user` has an associated foreign key field in the database. `User.profile` is a "virtual" relationship field, meaning it only exists at the resolver level.

--- a/integration/mock.graphql
+++ b/integration/mock.graphql
@@ -14,10 +14,6 @@ type Comment {
   id: ID!
   text: String
   description: String
-  """
-  @oneToOne
-  """
-  metadata: CommentMetadata
 }
 
 """
@@ -26,6 +22,10 @@ type Comment {
 type CommentMetadata {
   id: ID!
   opened: Boolean
+  """
+  @oneToOne field: 'metadata'
+  """
+  comment: Comment
 }
 
 type Query {

--- a/integration/tests/__snapshots__/codegen-workflow.ts.snap
+++ b/integration/tests/__snapshots__/codegen-workflow.ts.snap
@@ -6,29 +6,32 @@ type Comment {
   id: ID!
   text: String
   description: String
-  \\"\\"\\"@oneToOne key: 'metadataId'\\"\\"\\"
-  metadata: CommentMetadata
   \\"\\"\\"@manyToOne field: 'comments', key: 'noteId'\\"\\"\\"
   note: Note
+  \\"\\"\\"@oneToOne field: 'comment', key: 'commentId', virtual: true\\"\\"\\"
+  metadata: CommentMetadata
 }
 
 input CommentInput {
   id: ID
   text: String
   description: String
-  metadataId: ID
   noteId: ID
+  commentId: ID
 }
 
 \\"\\"\\"@model\\"\\"\\"
 type CommentMetadata {
   id: ID!
   opened: Boolean
+  \\"\\"\\"@oneToOne field: 'metadata', key: 'commentId'\\"\\"\\"
+  comment: Comment
 }
 
 input CommentMetadataInput {
   id: ID
   opened: Boolean
+  commentId: ID
 }
 
 type Mutation {
@@ -103,6 +106,7 @@ Object {
           "name": "id",
           "nullable": false,
           "type": "increments",
+          "unique": false,
         },
         "title" => Object {
           "annotations": Object {},
@@ -115,6 +119,7 @@ Object {
           "name": "title",
           "nullable": false,
           "type": "string",
+          "unique": false,
         },
         "description" => Object {
           "annotations": Object {},
@@ -127,6 +132,7 @@ Object {
           "name": "description",
           "nullable": true,
           "type": "string",
+          "unique": false,
         },
       },
       "columns": Array [
@@ -139,6 +145,7 @@ Object {
           "name": "id",
           "nullable": false,
           "type": "increments",
+          "unique": false,
         },
         Object {
           "annotations": Object {},
@@ -151,6 +158,7 @@ Object {
           "name": "title",
           "nullable": false,
           "type": "string",
+          "unique": false,
         },
         Object {
           "annotations": Object {},
@@ -163,6 +171,7 @@ Object {
           "name": "description",
           "nullable": true,
           "type": "string",
+          "unique": false,
         },
       ],
       "comment": undefined,
@@ -190,6 +199,7 @@ Object {
           "name": "id",
           "nullable": false,
           "type": "increments",
+          "unique": false,
         },
         "text" => Object {
           "annotations": Object {},
@@ -202,6 +212,7 @@ Object {
           "name": "text",
           "nullable": true,
           "type": "string",
+          "unique": false,
         },
         "description" => Object {
           "annotations": Object {},
@@ -214,21 +225,7 @@ Object {
           "name": "description",
           "nullable": true,
           "type": "string",
-        },
-        "metadata" => Object {
-          "annotations": Object {},
-          "args": Array [],
-          "comment": undefined,
-          "defaultValue": undefined,
-          "foreign": Object {
-            "columnName": "id",
-            "field": "id",
-            "tableName": "commentmetadata",
-            "type": "CommentMetadata",
-          },
-          "name": "metadataId",
-          "nullable": true,
-          "type": "integer",
+          "unique": false,
         },
         "note" => Object {
           "annotations": Object {},
@@ -244,6 +241,7 @@ Object {
           "name": "noteId",
           "nullable": true,
           "type": "integer",
+          "unique": false,
         },
       },
       "columns": Array [
@@ -256,6 +254,7 @@ Object {
           "name": "id",
           "nullable": false,
           "type": "increments",
+          "unique": false,
         },
         Object {
           "annotations": Object {},
@@ -268,6 +267,7 @@ Object {
           "name": "text",
           "nullable": true,
           "type": "string",
+          "unique": false,
         },
         Object {
           "annotations": Object {},
@@ -280,21 +280,7 @@ Object {
           "name": "description",
           "nullable": true,
           "type": "string",
-        },
-        Object {
-          "annotations": Object {},
-          "args": Array [],
-          "comment": undefined,
-          "defaultValue": undefined,
-          "foreign": Object {
-            "columnName": "id",
-            "field": "id",
-            "tableName": "commentmetadata",
-            "type": "CommentMetadata",
-          },
-          "name": "metadataId",
-          "nullable": true,
-          "type": "integer",
+          "unique": false,
         },
         Object {
           "annotations": Object {},
@@ -310,6 +296,7 @@ Object {
           "name": "noteId",
           "nullable": true,
           "type": "integer",
+          "unique": false,
         },
       ],
       "comment": undefined,
@@ -337,6 +324,7 @@ Object {
           "name": "id",
           "nullable": false,
           "type": "increments",
+          "unique": false,
         },
         "opened" => Object {
           "annotations": Object {},
@@ -347,6 +335,23 @@ Object {
           "name": "opened",
           "nullable": true,
           "type": "boolean",
+          "unique": false,
+        },
+        "comment" => Object {
+          "annotations": Object {},
+          "args": Array [],
+          "comment": undefined,
+          "defaultValue": undefined,
+          "foreign": Object {
+            "columnName": "id",
+            "field": "id",
+            "tableName": "comment",
+            "type": "Comment",
+          },
+          "name": "commentId",
+          "nullable": true,
+          "type": "integer",
+          "unique": true,
         },
       },
       "columns": Array [
@@ -359,6 +364,7 @@ Object {
           "name": "id",
           "nullable": false,
           "type": "increments",
+          "unique": false,
         },
         Object {
           "annotations": Object {},
@@ -369,6 +375,23 @@ Object {
           "name": "opened",
           "nullable": true,
           "type": "boolean",
+          "unique": false,
+        },
+        Object {
+          "annotations": Object {},
+          "args": Array [],
+          "comment": undefined,
+          "defaultValue": undefined,
+          "foreign": Object {
+            "columnName": "id",
+            "field": "id",
+            "tableName": "comment",
+            "type": "Comment",
+          },
+          "name": "commentId",
+          "nullable": true,
+          "type": "integer",
+          "unique": true,
         },
       ],
       "comment": undefined,
@@ -382,7 +405,14 @@ Object {
           "name": "commentmetadata_pkey",
         },
       ],
-      "uniques": Array [],
+      "uniques": Array [
+        Object {
+          "columns": Array [
+            "commentId",
+          ],
+          "name": "commentmetadata_commentId_unique",
+        },
+      ],
     },
   },
   "tables": Array [
@@ -398,6 +428,7 @@ Object {
           "name": "id",
           "nullable": false,
           "type": "increments",
+          "unique": false,
         },
         "title" => Object {
           "annotations": Object {},
@@ -410,6 +441,7 @@ Object {
           "name": "title",
           "nullable": false,
           "type": "string",
+          "unique": false,
         },
         "description" => Object {
           "annotations": Object {},
@@ -422,6 +454,7 @@ Object {
           "name": "description",
           "nullable": true,
           "type": "string",
+          "unique": false,
         },
       },
       "columns": Array [
@@ -434,6 +467,7 @@ Object {
           "name": "id",
           "nullable": false,
           "type": "increments",
+          "unique": false,
         },
         Object {
           "annotations": Object {},
@@ -446,6 +480,7 @@ Object {
           "name": "title",
           "nullable": false,
           "type": "string",
+          "unique": false,
         },
         Object {
           "annotations": Object {},
@@ -458,6 +493,7 @@ Object {
           "name": "description",
           "nullable": true,
           "type": "string",
+          "unique": false,
         },
       ],
       "comment": undefined,
@@ -485,6 +521,7 @@ Object {
           "name": "id",
           "nullable": false,
           "type": "increments",
+          "unique": false,
         },
         "text" => Object {
           "annotations": Object {},
@@ -497,6 +534,7 @@ Object {
           "name": "text",
           "nullable": true,
           "type": "string",
+          "unique": false,
         },
         "description" => Object {
           "annotations": Object {},
@@ -509,21 +547,7 @@ Object {
           "name": "description",
           "nullable": true,
           "type": "string",
-        },
-        "metadata" => Object {
-          "annotations": Object {},
-          "args": Array [],
-          "comment": undefined,
-          "defaultValue": undefined,
-          "foreign": Object {
-            "columnName": "id",
-            "field": "id",
-            "tableName": "commentmetadata",
-            "type": "CommentMetadata",
-          },
-          "name": "metadataId",
-          "nullable": true,
-          "type": "integer",
+          "unique": false,
         },
         "note" => Object {
           "annotations": Object {},
@@ -539,6 +563,7 @@ Object {
           "name": "noteId",
           "nullable": true,
           "type": "integer",
+          "unique": false,
         },
       },
       "columns": Array [
@@ -551,6 +576,7 @@ Object {
           "name": "id",
           "nullable": false,
           "type": "increments",
+          "unique": false,
         },
         Object {
           "annotations": Object {},
@@ -563,6 +589,7 @@ Object {
           "name": "text",
           "nullable": true,
           "type": "string",
+          "unique": false,
         },
         Object {
           "annotations": Object {},
@@ -575,21 +602,7 @@ Object {
           "name": "description",
           "nullable": true,
           "type": "string",
-        },
-        Object {
-          "annotations": Object {},
-          "args": Array [],
-          "comment": undefined,
-          "defaultValue": undefined,
-          "foreign": Object {
-            "columnName": "id",
-            "field": "id",
-            "tableName": "commentmetadata",
-            "type": "CommentMetadata",
-          },
-          "name": "metadataId",
-          "nullable": true,
-          "type": "integer",
+          "unique": false,
         },
         Object {
           "annotations": Object {},
@@ -605,6 +618,7 @@ Object {
           "name": "noteId",
           "nullable": true,
           "type": "integer",
+          "unique": false,
         },
       ],
       "comment": undefined,
@@ -632,6 +646,7 @@ Object {
           "name": "id",
           "nullable": false,
           "type": "increments",
+          "unique": false,
         },
         "opened" => Object {
           "annotations": Object {},
@@ -642,6 +657,23 @@ Object {
           "name": "opened",
           "nullable": true,
           "type": "boolean",
+          "unique": false,
+        },
+        "comment" => Object {
+          "annotations": Object {},
+          "args": Array [],
+          "comment": undefined,
+          "defaultValue": undefined,
+          "foreign": Object {
+            "columnName": "id",
+            "field": "id",
+            "tableName": "comment",
+            "type": "Comment",
+          },
+          "name": "commentId",
+          "nullable": true,
+          "type": "integer",
+          "unique": true,
         },
       },
       "columns": Array [
@@ -654,6 +686,7 @@ Object {
           "name": "id",
           "nullable": false,
           "type": "increments",
+          "unique": false,
         },
         Object {
           "annotations": Object {},
@@ -664,6 +697,23 @@ Object {
           "name": "opened",
           "nullable": true,
           "type": "boolean",
+          "unique": false,
+        },
+        Object {
+          "annotations": Object {},
+          "args": Array [],
+          "comment": undefined,
+          "defaultValue": undefined,
+          "foreign": Object {
+            "columnName": "id",
+            "field": "id",
+            "tableName": "comment",
+            "type": "Comment",
+          },
+          "name": "commentId",
+          "nullable": true,
+          "type": "integer",
+          "unique": true,
         },
       ],
       "comment": undefined,
@@ -677,7 +727,14 @@ Object {
           "name": "commentmetadata_pkey",
         },
       ],
-      "uniques": Array [],
+      "uniques": Array [
+        Object {
+          "columns": Array [
+            "commentId",
+          ],
+          "name": "commentmetadata_commentId_unique",
+        },
+      ],
     },
   ],
 }

--- a/integration/tests/codegen-workflow.ts
+++ b/integration/tests/codegen-workflow.ts
@@ -45,7 +45,7 @@ beforeAll(async (done) => {
     const { models } = require('../output/resolvers/models');
 
     const pubSub = new PubSub();
-    const context = createKnexPGCRUDRuntimeServices(models, schema, knex, pubSub);
+    const context = createKnexPGCRUDRuntimeServices(models, schema, knex as any, pubSub);
 
     const server = new ApolloServer({
         typeDefs: await projectConfig.getSchema('DocumentNode'),
@@ -77,29 +77,29 @@ async function seedDatabase(db: Knex) {
         }
     ]);
 
-    await db('commentmetadata').insert([
-        {
-            opened: true
-        },
-        {
-            opened: false
-        }
-    ])
-
     await db('comment').insert([
         {
             text: 'Note A Comment',
             description: 'Note A Comment Description',
-            noteId: 1,
-            metadataId: 1
+            noteId: 1
         },
         {
             text: 'Note A Comment 2',
             description: 'Note A Comment Description',
-            noteId: 1,
-            metadataId: 2
+            noteId: 1
         }
     ]);
+
+     await db('commentmetadata').insert([
+        {
+            opened: true,
+            commentId: 1
+        },
+        {
+            opened: false,
+            commentId: 2
+        }
+    ])
 }
 
 const getConfig = async () => {

--- a/packages/graphback-codegen-resolvers/src/templates/createResolvers.ts
+++ b/packages/graphback-codegen-resolvers/src/templates/createResolvers.ts
@@ -16,7 +16,10 @@ function createRelationshipResolvers(relationships: FieldRelationshipMetadata[])
 
         if (relationship.kind === 'oneToMany') {
             resolverOutput = oneToManyTemplate(relationTypeName, relationship.relationForeignKey, relationIdField.name)
-        } else if (relationship.kind === 'oneToOne' || relationship.kind === 'manyToOne') {
+        } else if (relationship.kind === 'oneToOne' && relationship.virtual) {
+            const idField = getPrimaryKey(relationship.owner);
+            resolverOutput = oneToOneTemplate(relationTypeName, idField.name, relationship.relationForeignKey)
+        } else if (relationship.kind === 'manyToOne' || relationship.kind === 'oneToOne') {
             resolverOutput = oneToOneTemplate(relationTypeName, relationship.relationForeignKey, relationIdField.name)
         }
 

--- a/packages/graphback-codegen-resolvers/tests/__snapshots__/GraphQLResolverCreatorTest.ts.snap
+++ b/packages/graphback-codegen-resolvers/tests/__snapshots__/GraphQLResolverCreatorTest.ts.snap
@@ -10,17 +10,17 @@ Object {
     pubSub: {
       publishCreate: true,
       publishUpdate: true,
-      publishDelete: true
-    }
+      publishDelete: true,
+    },
   },
   {
     name: \\"Comment\\",
     pubSub: {
       publishCreate: true,
       publishUpdate: true,
-      publishDelete: true
-    }
-  }
+      publishDelete: true,
+    },
+  },
 ]
 
 module.exports = { models }
@@ -39,15 +39,15 @@ exports = {
   Note: {
     comments: (parent, args, context) => {
       return context.Comment.batchLoadData(\\"noteId\\", parent.id, context)
-    }
+    },
   },
 
   Comment: {
     noteComment: (parent, args, context) => {
       return context.Note.findBy({ id: parent.noteId }).then(
-        results => results[0]
+        (results) => results[0]
       )
-    }
+    },
   },
 
   Query: {
@@ -64,7 +64,7 @@ exports = {
     },
     findAllComments: (parent, args, context) => {
       return context.Comment.findAll(args)
-    }
+    },
   },
 
   Mutation: {
@@ -85,41 +85,41 @@ exports = {
     },
     deleteComment: (parent, args, context) => {
       return context.Comment.delete(args.input, context)
-    }
+    },
   },
 
   Subscription: {
     newNote: {
       subscribe: (parent, args, context) => {
         return context.Note.subscribeToCreate(args, context)
-      }
+      },
     },
     updatedNote: {
       subscribe: (parent, args, context) => {
         return context.Note.subscribeToUpdate(args, context)
-      }
+      },
     },
     deletedNote: {
       subscribe: (parent, args, context) => {
         return context.Note.subscribeToDelete(args, context)
-      }
+      },
     },
     newComment: {
       subscribe: (parent, args, context) => {
         return context.Comment.subscribeToCreate(args, context)
-      }
+      },
     },
     updatedComment: {
       subscribe: (parent, args, context) => {
         return context.Comment.subscribeToUpdate(args, context)
-      }
+      },
     },
     deletedComment: {
       subscribe: (parent, args, context) => {
         return context.Comment.subscribeToDelete(args, context)
-      }
-    }
-  }
+      },
+    },
+  },
 }
 ",
   },
@@ -136,17 +136,17 @@ Object {
     pubSub: {
       publishCreate: true,
       publishUpdate: true,
-      publishDelete: true
-    }
+      publishDelete: true,
+    },
   },
   {
     name: \\"Comment\\",
     pubSub: {
       publishCreate: true,
       publishUpdate: true,
-      publishDelete: true
-    }
-  }
+      publishDelete: true,
+    },
+  },
 ]
 ",
   },
@@ -163,15 +163,15 @@ export default {
   Note: {
     comments: (parent, args, context) => {
       return context.Comment.batchLoadData(\\"noteId\\", parent.id, context)
-    }
+    },
   },
 
   Comment: {
     noteComment: (parent, args, context) => {
       return context.Note.findBy({ id: parent.noteId }).then(
-        results => results[0]
+        (results) => results[0]
       )
-    }
+    },
   },
 
   Query: {
@@ -188,7 +188,7 @@ export default {
     },
     findAllComments: (parent, args, context) => {
       return context.Comment.findAll(args)
-    }
+    },
   },
 
   Mutation: {
@@ -209,41 +209,41 @@ export default {
     },
     deleteComment: (parent, args, context) => {
       return context.Comment.delete(args.input, context)
-    }
+    },
   },
 
   Subscription: {
     newNote: {
       subscribe: (parent, args, context) => {
         return context.Note.subscribeToCreate(args, context)
-      }
+      },
     },
     updatedNote: {
       subscribe: (parent, args, context) => {
         return context.Note.subscribeToUpdate(args, context)
-      }
+      },
     },
     deletedNote: {
       subscribe: (parent, args, context) => {
         return context.Note.subscribeToDelete(args, context)
-      }
+      },
     },
     newComment: {
       subscribe: (parent, args, context) => {
         return context.Comment.subscribeToCreate(args, context)
-      }
+      },
     },
     updatedComment: {
       subscribe: (parent, args, context) => {
         return context.Comment.subscribeToUpdate(args, context)
-      }
+      },
     },
     deletedComment: {
       subscribe: (parent, args, context) => {
         return context.Comment.subscribeToDelete(args, context)
-      }
-    }
-  }
+      },
+    },
+  },
 }
 ",
   },

--- a/packages/graphback-core/src/relationships/relationshipHelpers.ts
+++ b/packages/graphback-core/src/relationships/relationshipHelpers.ts
@@ -7,7 +7,11 @@ import { RelationshipAnnotation } from './RelationshipMetadataBuilder';
  * 
  * @param description field description
  */
-export function parseRelationshipAnnotation(description: string = ''): RelationshipAnnotation | undefined {
+export function parseRelationshipAnnotation(description?: string): RelationshipAnnotation | undefined {
+    if (!description) {
+        return undefined;
+    }
+    
     const relationshipKinds = ['oneToMany', 'oneToOne', 'manyToOne'];
 
     for (const kind of relationshipKinds) {
@@ -97,7 +101,9 @@ export const mergeDescriptionWithRelationshipAnnotation = (generatedDescription:
         const relationshipDescription = getRelationshipAnnotationString(description);
         const parsedAnnotation = parseRelationshipAnnotation(description);
 
-        if (parsedAnnotation && parsedAnnotation.key) {
+        if (!parsedAnnotation) {
+            descriptionLines.push(description);
+        } else if (parsedAnnotation.key) {
             descriptionLines.push(relationshipDescription);
             break;
         }
@@ -133,23 +139,13 @@ export function buildModifiedRelationshipsFieldObject(model: ModelDefinition) {
 }
 
 /**
- * Generic template for relationship annotations
+ * Template for relationship annotations
  * 
  * @param relationshipKind 
  * @param fieldName 
  * @param columnKey 
+ * @param virtual
  */
-export const relationshipFieldDescriptionTemplate = (relationshipKind: 'oneToOne' | 'oneToMany' | 'manyToOne', fieldName: string, columnKey: string): string => {
-    return `@${relationshipKind} field: '${fieldName}', key: '${columnKey}'`;
-}
-
-/**
- * Template for one-to-one relationship annotations
- * 
- * @param relationshipKind 
- * @param fieldName 
- * @param columnKey 
- */
-export const relationshipOneToOneFieldDescriptionTemplate = (relationshipKind: 'oneToOne' | 'oneToMany' | 'manyToOne', columnKey: string): string => {
-    return `@${relationshipKind} key: '${columnKey}'`;
+export const relationshipFieldDescriptionTemplate = (relationshipKind: 'oneToOne' | 'oneToMany' | 'manyToOne', columnKey: string, field?: string, virtual?: boolean): string => {
+    return `@${relationshipKind}${field ? ` field: '${field}', `: ' '}key: '${columnKey}'${virtual ? `, virtual: true` : ''}`;
 }

--- a/packages/graphback-core/tests/__snapshots__/RelationshipMetadataBuilderTest.ts.snap
+++ b/packages/graphback-core/tests/__snapshots__/RelationshipMetadataBuilderTest.ts.snap
@@ -1,5 +1,169 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should build bidirectional one-to-one relationship metadata from one-to-one field 1`] = `
+"[
+ {
+  \\"kind\\": \\"oneToOne\\",
+  \\"owner\\": \\"Address\\",
+  \\"ownerField\\": {
+   \\"type\\": \\"User!\\",
+   \\"description\\": \\"@oneToOne field: 'address', key: 'residentId'\\",
+   \\"args\\": [],
+   \\"astNode\\": {
+    \\"kind\\": \\"FieldDefinition\\",
+    \\"description\\": {
+     \\"kind\\": \\"StringValue\\",
+     \\"value\\": \\"@oneToOne field: 'address'\\",
+     \\"block\\": true,
+     \\"loc\\": {
+      \\"start\\": 180,
+      \\"end\\": 230
+     }
+    },
+    \\"name\\": {
+     \\"kind\\": \\"Name\\",
+     \\"value\\": \\"resident\\",
+     \\"loc\\": {
+      \\"start\\": 239,
+      \\"end\\": 247
+     }
+    },
+    \\"arguments\\": [],
+    \\"type\\": {
+     \\"kind\\": \\"NonNullType\\",
+     \\"type\\": {
+      \\"kind\\": \\"NamedType\\",
+      \\"name\\": {
+       \\"kind\\": \\"Name\\",
+       \\"value\\": \\"User\\",
+       \\"loc\\": {
+        \\"start\\": 249,
+        \\"end\\": 253
+       }
+      },
+      \\"loc\\": {
+       \\"start\\": 249,
+       \\"end\\": 253
+      }
+     },
+     \\"loc\\": {
+      \\"start\\": 249,
+      \\"end\\": 254
+     }
+    },
+    \\"directives\\": [],
+    \\"loc\\": {
+     \\"start\\": 180,
+     \\"end\\": 254
+    }
+   },
+   \\"name\\": \\"resident\\",
+   \\"isDeprecated\\": false
+  },
+  \\"relationType\\": \\"User\\",
+  \\"relationFieldName\\": \\"address\\",
+  \\"relationForeignKey\\": \\"residentId\\"
+ },
+ {
+  \\"kind\\": \\"oneToOne\\",
+  \\"owner\\": \\"User\\",
+  \\"ownerField\\": {
+   \\"name\\": \\"address\\",
+   \\"description\\": \\"@oneToOne field: 'resident', key: 'residentId', virtual: true\\",
+   \\"type\\": \\"Address\\",
+   \\"args\\": [],
+   \\"extensions\\": []
+  },
+  \\"relationType\\": \\"Address\\",
+  \\"relationFieldName\\": \\"resident\\",
+  \\"relationForeignKey\\": \\"residentId\\",
+  \\"virtual\\": true
+ }
+]"
+`;
+
+exports[`should build generated bidirectional one-to-one relationship metadata from one-to-one field 1`] = `
+"[
+ {
+  \\"kind\\": \\"oneToOne\\",
+  \\"owner\\": \\"Address\\",
+  \\"ownerField\\": {
+   \\"type\\": \\"User!\\",
+   \\"description\\": \\"@oneToOne field: 'address', key: 'residentId'\\",
+   \\"args\\": [],
+   \\"astNode\\": {
+    \\"kind\\": \\"FieldDefinition\\",
+    \\"description\\": {
+     \\"kind\\": \\"StringValue\\",
+     \\"value\\": \\"@oneToOne field: 'address'\\",
+     \\"block\\": true,
+     \\"loc\\": {
+      \\"start\\": 180,
+      \\"end\\": 230
+     }
+    },
+    \\"name\\": {
+     \\"kind\\": \\"Name\\",
+     \\"value\\": \\"resident\\",
+     \\"loc\\": {
+      \\"start\\": 239,
+      \\"end\\": 247
+     }
+    },
+    \\"arguments\\": [],
+    \\"type\\": {
+     \\"kind\\": \\"NonNullType\\",
+     \\"type\\": {
+      \\"kind\\": \\"NamedType\\",
+      \\"name\\": {
+       \\"kind\\": \\"Name\\",
+       \\"value\\": \\"User\\",
+       \\"loc\\": {
+        \\"start\\": 249,
+        \\"end\\": 253
+       }
+      },
+      \\"loc\\": {
+       \\"start\\": 249,
+       \\"end\\": 253
+      }
+     },
+     \\"loc\\": {
+      \\"start\\": 249,
+      \\"end\\": 254
+     }
+    },
+    \\"directives\\": [],
+    \\"loc\\": {
+     \\"start\\": 180,
+     \\"end\\": 254
+    }
+   },
+   \\"name\\": \\"resident\\",
+   \\"isDeprecated\\": false
+  },
+  \\"relationType\\": \\"User\\",
+  \\"relationFieldName\\": \\"address\\",
+  \\"relationForeignKey\\": \\"residentId\\"
+ },
+ {
+  \\"kind\\": \\"oneToOne\\",
+  \\"owner\\": \\"User\\",
+  \\"ownerField\\": {
+   \\"name\\": \\"address\\",
+   \\"description\\": \\"@oneToOne field: 'resident', key: 'residentId', virtual: true\\",
+   \\"type\\": \\"Address\\",
+   \\"args\\": [],
+   \\"extensions\\": []
+  },
+  \\"relationType\\": \\"Address\\",
+  \\"relationFieldName\\": \\"resident\\",
+  \\"relationForeignKey\\": \\"residentId\\",
+  \\"virtual\\": true
+ }
+]"
+`;
+
 exports[`should build one-to-many and many-to-one relationships from both fields 1`] = `
 "[
  {
@@ -136,32 +300,32 @@ exports[`should build one-to-many and many-to-one relationships from both fields
 ]"
 `;
 
-exports[`should build one-to-one relationship metadata from one-to-one field 1`] = `
+exports[`should build unidirectional one-to-one relationship metadata from one-to-one field 1`] = `
 "[
  {
   \\"kind\\": \\"oneToOne\\",
   \\"owner\\": \\"Address\\",
   \\"ownerField\\": {
    \\"type\\": \\"User!\\",
-   \\"description\\": \\"@oneToOne key: 'residentId'\\",
+   \\"description\\": \\"@oneToOne field: 'address', key: 'resident_id'\\",
    \\"args\\": [],
    \\"astNode\\": {
     \\"kind\\": \\"FieldDefinition\\",
     \\"description\\": {
      \\"kind\\": \\"StringValue\\",
-     \\"value\\": \\"@oneToOne\\",
+     \\"value\\": \\"@oneToOne field: 'address', key: 'resident_id'\\",
      \\"block\\": true,
      \\"loc\\": {
-      \\"start\\": 180,
-      \\"end\\": 213
+      \\"start\\": 205,
+      \\"end\\": 275
      }
     },
     \\"name\\": {
      \\"kind\\": \\"Name\\",
      \\"value\\": \\"resident\\",
      \\"loc\\": {
-      \\"start\\": 222,
-      \\"end\\": 230
+      \\"start\\": 284,
+      \\"end\\": 292
      }
     },
     \\"arguments\\": [],
@@ -173,31 +337,79 @@ exports[`should build one-to-one relationship metadata from one-to-one field 1`]
        \\"kind\\": \\"Name\\",
        \\"value\\": \\"User\\",
        \\"loc\\": {
-        \\"start\\": 232,
-        \\"end\\": 236
+        \\"start\\": 294,
+        \\"end\\": 298
        }
       },
       \\"loc\\": {
-       \\"start\\": 232,
-       \\"end\\": 236
+       \\"start\\": 294,
+       \\"end\\": 298
       }
      },
      \\"loc\\": {
-      \\"start\\": 232,
-      \\"end\\": 237
+      \\"start\\": 294,
+      \\"end\\": 299
      }
     },
     \\"directives\\": [],
     \\"loc\\": {
-     \\"start\\": 180,
-     \\"end\\": 237
+     \\"start\\": 205,
+     \\"end\\": 299
     }
    },
    \\"name\\": \\"resident\\",
    \\"isDeprecated\\": false
   },
   \\"relationType\\": \\"User\\",
-  \\"relationForeignKey\\": \\"residentId\\"
+  \\"relationFieldName\\": \\"address\\",
+  \\"relationForeignKey\\": \\"resident_id\\"
+ },
+ {
+  \\"kind\\": \\"oneToOne\\",
+  \\"owner\\": \\"User\\",
+  \\"ownerField\\": {
+   \\"type\\": \\"Address\\",
+   \\"description\\": \\"@oneToOne field: 'resident', key: 'resident_id', virtual: true\\",
+   \\"args\\": [],
+   \\"astNode\\": {
+    \\"kind\\": \\"FieldDefinition\\",
+    \\"name\\": {
+     \\"kind\\": \\"Name\\",
+     \\"value\\": \\"address\\",
+     \\"loc\\": {
+      \\"start\\": 89,
+      \\"end\\": 96
+     }
+    },
+    \\"arguments\\": [],
+    \\"type\\": {
+     \\"kind\\": \\"NamedType\\",
+     \\"name\\": {
+      \\"kind\\": \\"Name\\",
+      \\"value\\": \\"Address\\",
+      \\"loc\\": {
+       \\"start\\": 98,
+       \\"end\\": 105
+      }
+     },
+     \\"loc\\": {
+      \\"start\\": 98,
+      \\"end\\": 105
+     }
+    },
+    \\"directives\\": [],
+    \\"loc\\": {
+     \\"start\\": 89,
+     \\"end\\": 105
+    }
+   },
+   \\"name\\": \\"address\\",
+   \\"isDeprecated\\": false
+  },
+  \\"relationType\\": \\"Address\\",
+  \\"relationFieldName\\": \\"resident\\",
+  \\"relationForeignKey\\": \\"resident_id\\",
+  \\"virtual\\": true
  }
 ]"
 `;

--- a/packages/graphql-migrations/src/abstract/TableColumn.ts
+++ b/packages/graphql-migrations/src/abstract/TableColumn.ts
@@ -32,4 +32,5 @@ export interface TableColumn {
   nullable: boolean
   foreign: ForeignKey | null
   defaultValue: any
+  unique?: boolean
 }

--- a/packages/graphql-migrations/tests/specs/__snapshots__/abstract-database.ts.snap
+++ b/packages/graphql-migrations/tests/specs/__snapshots__/abstract-database.ts.snap
@@ -14,6 +14,7 @@ Array [
         "name": "id",
         "nullable": false,
         "type": "increments",
+        "unique": false,
       },
       "name" => Object {
         "annotations": Object {
@@ -28,6 +29,7 @@ Array [
         "name": "name",
         "nullable": false,
         "type": "string",
+        "unique": false,
       },
       "email" => Object {
         "annotations": Object {},
@@ -40,6 +42,7 @@ Array [
         "name": "email",
         "nullable": false,
         "type": "string",
+        "unique": false,
       },
       "score" => Object {
         "annotations": Object {},
@@ -50,6 +53,7 @@ Array [
         "name": "score",
         "nullable": true,
         "type": "integer",
+        "unique": false,
       },
       "scores" => Object {
         "annotations": Object {
@@ -62,6 +66,7 @@ Array [
         "name": "scores",
         "nullable": true,
         "type": "json",
+        "unique": false,
       },
     },
     "columns": Array [
@@ -74,6 +79,7 @@ Array [
         "name": "id",
         "nullable": false,
         "type": "increments",
+        "unique": false,
       },
       Object {
         "annotations": Object {
@@ -88,6 +94,7 @@ Array [
         "name": "name",
         "nullable": false,
         "type": "string",
+        "unique": false,
       },
       Object {
         "annotations": Object {},
@@ -100,6 +107,7 @@ Array [
         "name": "email",
         "nullable": false,
         "type": "string",
+        "unique": false,
       },
       Object {
         "annotations": Object {},
@@ -110,6 +118,7 @@ Array [
         "name": "score",
         "nullable": true,
         "type": "integer",
+        "unique": false,
       },
       Object {
         "annotations": Object {
@@ -122,6 +131,7 @@ Array [
         "name": "scores",
         "nullable": true,
         "type": "json",
+        "unique": false,
       },
     ],
     "comment": "A user.",
@@ -149,6 +159,7 @@ Array [
         "name": "id",
         "nullable": false,
         "type": "increments",
+        "unique": false,
       },
       "user" => Object {
         "annotations": Object {},
@@ -164,6 +175,7 @@ Array [
         "name": "userId",
         "nullable": false,
         "type": "integer",
+        "unique": false,
       },
       "created" => Object {
         "annotations": Object {
@@ -178,6 +190,7 @@ Array [
         "name": "created",
         "nullable": false,
         "type": "datetime",
+        "unique": false,
       },
       "title" => Object {
         "annotations": Object {},
@@ -190,6 +203,7 @@ Array [
         "name": "title",
         "nullable": false,
         "type": "string",
+        "unique": false,
       },
       "content" => Object {
         "annotations": Object {
@@ -202,6 +216,7 @@ Array [
         "name": "content",
         "nullable": false,
         "type": "text",
+        "unique": false,
       },
     },
     "columns": Array [
@@ -214,6 +229,7 @@ Array [
         "name": "id",
         "nullable": false,
         "type": "increments",
+        "unique": false,
       },
       Object {
         "annotations": Object {},
@@ -229,6 +245,7 @@ Array [
         "name": "userId",
         "nullable": false,
         "type": "integer",
+        "unique": false,
       },
       Object {
         "annotations": Object {
@@ -243,6 +260,7 @@ Array [
         "name": "created",
         "nullable": false,
         "type": "datetime",
+        "unique": false,
       },
       Object {
         "annotations": Object {},
@@ -255,6 +273,7 @@ Array [
         "name": "title",
         "nullable": false,
         "type": "string",
+        "unique": false,
       },
       Object {
         "annotations": Object {
@@ -267,6 +286,7 @@ Array [
         "name": "content",
         "nullable": false,
         "type": "text",
+        "unique": false,
       },
     ],
     "comment": undefined,
@@ -301,6 +321,7 @@ Array [
         "name": "usersId",
         "nullable": true,
         "type": "integer",
+        "unique": false,
       },
       "sharedMessagesId" => Object {
         "annotations": Object {
@@ -318,6 +339,7 @@ Array [
         "name": "sharedMessagesId",
         "nullable": true,
         "type": "integer",
+        "unique": false,
       },
     },
     "columns": Array [
@@ -337,6 +359,7 @@ Array [
         "name": "usersId",
         "nullable": true,
         "type": "integer",
+        "unique": false,
       },
       Object {
         "annotations": Object {
@@ -354,6 +377,7 @@ Array [
         "name": "sharedMessagesId",
         "nullable": true,
         "type": "integer",
+        "unique": false,
       },
     ],
     "comment": "[Auto] Join table between User.sharedMessages and Message.users",
@@ -394,6 +418,7 @@ Array [
         "name": "idId",
         "nullable": false,
         "type": "integer",
+        "unique": false,
       },
       "idId_other" => Object {
         "annotations": Object {},
@@ -409,6 +434,7 @@ Array [
         "name": "idId_other",
         "nullable": false,
         "type": "integer",
+        "unique": false,
       },
     },
     "columns": Array [
@@ -426,6 +452,7 @@ Array [
         "name": "idId",
         "nullable": false,
         "type": "integer",
+        "unique": false,
       },
       Object {
         "annotations": Object {},
@@ -441,6 +468,7 @@ Array [
         "name": "idId_other",
         "nullable": false,
         "type": "integer",
+        "unique": false,
       },
     ],
     "comment": "[Auto] Join table between User.contacts and User.contacts",


### PR DESCRIPTION
Closes https://github.com/aerogear/graphback/issues/930

## Overview

This PR makes bidirectional one-to-one relationship querying possible by generating a "virtual" relationship field on the other model.

This is completely optional and backwards compatible. It is still possible to have unidirectional relationships in the same way as before. 

The addition of a `field` key on `oneToOne` annotations signifies a bidirectional 1:1 relationship.

## Verification

Define your data model (below) and run `graphback generate`, then `graphback db` and start your server.

```gql
"""
@model
"""
type User {
  id: ID!
  name: String
}

"""@model"""
type Address {
  id: ID!
  description: String
  """
  @oneToOne field: 'address'
  """
  resident: User!
}
``` 

Check your database structure; only the `address` table should have a foreign key.

Run these mutations and queries in order:

```gql
mutation createUser {
  createUser(input:{name:"John Doe"}) {
    name
    id
  }
}

mutation createAddress {
  createAddress(input:{description:"Address for John Doe", residentId:1}) {
    id
    description
  }
}

query findAddresses {
  findAllAddresses {
    id
    description
    resident {
      id
      name
    }
  }
}

query findUsers {
  findAllUsers {
    id
    name
    address {
      id
      description
    }
  }
}
```

## Tasks

- [x] Add unique constraint to one-to-one fields in graphql-migrations
- [x] Generate "virtual" one to one field to enable querying from both models in relationship.
- [x] Generate additional resolver for virtual relationship fetching
- [x] Add tests
- [x] Update integration tests
- [x] Update documentation