### PR TITLE
fix: add root types to schema only when fields exist

### DIFF
--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -64,7 +64,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
         };
 
         const schemaComposer = new SchemaComposer(schema)
-        
+
         this.buildSchemaForModels(schemaComposer, models);
 
         this.buildSchemaModelRelationships(schemaComposer, models);
@@ -120,10 +120,15 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
             subscriptionTypes = this.createSubscriptions(model, subscriptionTypes, modelInputType);
         }
 
-
-        schemaComposer.Query.addFields(queryTypes);
-        schemaComposer.Mutation.addFields(mutationTypes);
-        schemaComposer.Subscription.addFields(subscriptionTypes);
+        if (Object.keys(queryTypes).length) {
+            schemaComposer.Query.addFields(queryTypes);
+        }
+        if (Object.keys(mutationTypes).length) {
+            schemaComposer.Mutation.addFields(mutationTypes);
+        }
+        if (Object.keys(subscriptionTypes).length) {
+            schemaComposer.Subscription.addFields(subscriptionTypes);
+        }
     }
 
     protected createInputTypes(model: ModelDefinition) {


### PR DESCRIPTION
When subscription are globally disabled in the `.graphqlrc` file then the generated schema will add an incomplete Subscription object to the schema:

```gql
type Subscription
```

This change checks for empty root types before adding to schema