### PR TITLE
fix(resolvers): export generated code

### DIFF
--- a/packages/graphback-codegen-resolvers/src/templates/resolverWrapper.ts
+++ b/packages/graphback-codegen-resolvers/src/templates/resolverWrapper.ts
@@ -17,7 +17,7 @@ export const resolverFileTemplateTS = (outputResolvers: string[], options: Resol
 }
 
 export const resolverFileTemplateJS = (outputResolvers: string[], options: ResolverGeneratorPluginConfig) => {
-    return `${topNote}\n\n exports = {
+    return `${topNote}\n\n module.exports = {
       ${outputResolvers.join('\n\n')}  
     }`
 }


### PR DESCRIPTION
## What

The generated resolvers JavaScript file was not exporting the resolver object.