### PR TITLE
fix: accept globs and array of globs for model option in config

### DIFF
--- a/docs/intro/config.md
+++ b/docs/intro/config.md
@@ -33,8 +33,9 @@ documents: ./client/src/graphql/**/*.graphql
 extensions:
   # Graphback configuration
   graphback:
-    ##  Location to file that is contains GraphQL schema that will be processed by Graphback
-    model: ./model
+    ##  Path to file that contains GraphQL schema that will be processed by Graphback
+    ## Can be an array of paths too
+    model: ./model/**/*.graphql
     ## Global flags for CRUD methods that will be used in plugins
     crud:
       create: true

--- a/docs/plugins/introduction.md
+++ b/docs/plugins/introduction.md
@@ -22,7 +22,7 @@ Example configuration:
   # Graphback configuration
   graphback:
     ##  Input schema
-    model: ./model
+    model: ./model/**/*.graphql
     ## Global configuration for CRUD generator
     crud:
       create: true

--- a/packages/graphback-cli/src/components/generate.ts
+++ b/packages/graphback-cli/src/components/generate.ts
@@ -76,7 +76,7 @@ export const generateUsingPlugins = async (cliFlags: CliFlags) => {
  */
 function getModelPath(baseDir: string, model: string | Array<string>): string | Array<string> {
   if (typeof model === 'string' && existsSync(model) && lstatSync(model).isDirectory()) {
-    return join(baseDir, model, '/**/*.graphql')
+    return join(baseDir, model, '/*.graphql')
   } else if (typeof model === 'string') {
     return join(baseDir, model)
   } else if (Array.isArray(model)) {

--- a/packages/graphback-cli/src/templates/configTemplates.ts
+++ b/packages/graphback-cli/src/templates/configTemplates.ts
@@ -74,7 +74,7 @@ export const createConfig = async (database: string, client: boolean) => {
     documents: './client/src/graphql/**/*.graphql',
     extensions: {
       graphback: {
-        "model": "./model",
+        "model": "./model/**/*.graphql",
         "crud": {
           "create": true,
           "update": true,

--- a/templates/ts-apollo-fullstack/.graphqlrc.yml
+++ b/templates/ts-apollo-fullstack/.graphqlrc.yml
@@ -6,7 +6,7 @@ extensions:
   # Graphback configuration
   graphback:
     ##  Input schema
-    model: ./model
+    model: ./model/**/*.graphql
     ## Global configuration for CRUD generator
     crud:
       create: true

--- a/templates/ts-apollo-runtime-backend/.graphqlrc.yml
+++ b/templates/ts-apollo-runtime-backend/.graphqlrc.yml
@@ -3,7 +3,7 @@ extensions:
   # Graphback configuration
   graphback:
     ##  Input schema
-    model: ./model
+    model: ./model/**/*.graphql
     ## Global configuration for CRUD generator
     crud:
       create: true


### PR DESCRIPTION
fixes: https://github.com/aerogear/graphback/issues/977

For backwards compatibility specifying a dir like `./model` will still work as it did before, but it also means you can supply globs or arrays. For example, the following are both valid now.

```yaml
extensions:
  # Graphback configuration
  graphback:
    ##  Input schema
    model: ./model/**/*.graphql
```

```yaml
extensions:
  # Graphback configuration
  graphback:
    ##  Input schema
    model:
      - ./model/comment.graphql
     - ./model/note.graphql
```

There is also a custom [`loadSchema` function in graphql-serve](https://github.com/aerogear/graphback/blob/master/packages/graphql-serve/src/loadSchema.ts#L12-L24) which I am more than happy to update too if you think it's worth it
