### PR TITLE
fix: allow creating item in Postgres when all fields are automatically filled by database

### DIFF
--- a/packages/graphback-core/src/db/dataMapper.ts
+++ b/packages/graphback-core/src/db/dataMapper.ts
@@ -1,38 +1,38 @@
 import { ModelTableMap } from './buildModelTableMap';
 
 export interface TableDataMap {
-    idField?: TableID
-    table?: string
-    data?: any
-    fieldMap?: any
+  idField?: TableID
+  table?: string
+  data?: any
+  fieldMap?: any
 }
 
 export interface TableID {
-    name: string
-    value?: any
+  name: string
+  value?: any
 }
 
 function getTableId(idField: string, data: any): TableID {
-    if (!idField) { return undefined };
+  if (!idField) { return undefined };
 
-    let value: any;
-    if (data && data[idField]) {
-        value = data[idField];
-    }
+  let value: any;
+  if (data && data[idField]) {
+    value = data[idField];
+  }
 
-    return {
-        name: idField,
-        value
-    }
+  return {
+    name: idField,
+    value
+  }
 }
 
 export const getDatabaseArguments = (modelMap: ModelTableMap, data?: any, fieldMap?: any): TableDataMap => {
-    const idField = modelMap.idField;
+  const idField = modelMap.idField;
 
-    //TODO: Map fields to custom db names
+  //TODO: Map fields to custom db names
 
-    return {
-        idField: getTableId(idField, data),
-        data
-    }
+  return {
+    idField: getTableId(idField, data),
+    data: data || {}
+  }
 }

--- a/packages/graphback-core/tests/dataMapperTest.ts
+++ b/packages/graphback-core/tests/dataMapperTest.ts
@@ -4,7 +4,7 @@ import { buildModelTableMap } from '../src/db/buildModelTableMap';
 import { getDatabaseArguments } from '../src/db/dataMapper';
 
 test('should map to default ID field', () => {
-    const schema = buildSchema(`
+  const schema = buildSchema(`
     """
     @model
     """
@@ -14,23 +14,23 @@ test('should map to default ID field', () => {
         email: String
     }`);
 
-    const userModel = schema.getType("User") as GraphQLObjectType;
+  const userModel = schema.getType("User") as GraphQLObjectType;
 
-    const modelTableMap = buildModelTableMap(userModel);
+  const modelTableMap = buildModelTableMap(userModel);
 
-    const data = {
-        id: 1,
-        email: 'johndoe@gmail.com',
-        name: 'John Doe',
-    }
+  const data = {
+    id: 1,
+    email: 'johndoe@gmail.com',
+    name: 'John Doe',
+  }
 
-    const args = getDatabaseArguments(modelTableMap, data);
+  const args = getDatabaseArguments(modelTableMap, data);
 
-    expect(args.idField).toEqual({ name: 'id', value: 1 })
+  expect(args.idField).toEqual({ name: 'id', value: 1 })
 });
 
 test('should map to default custom ID field from annotations', () => {
-    const schema = buildSchema(`
+  const schema = buildSchema(`
     """
     @model
     """
@@ -43,17 +43,37 @@ test('should map to default custom ID field from annotations', () => {
         email: String
     }`);
 
-    const userModel = schema.getType("User") as GraphQLObjectType;
+  const userModel = schema.getType("User") as GraphQLObjectType;
 
-    const modelTableMap = buildModelTableMap(userModel);
+  const modelTableMap = buildModelTableMap(userModel);
 
-    const data = {
-        id: 1,
-        email: 'johndoe@gmail.com',
-        name: 'John Doe',
-    }
+  const data = {
+    id: 1,
+    email: 'johndoe@gmail.com',
+    name: 'John Doe',
+  }
 
-    const args = getDatabaseArguments(modelTableMap, data);
+  const args = getDatabaseArguments(modelTableMap, data);
 
-    expect(args.idField).toEqual({ name: 'email', value: 'johndoe@gmail.com' })
+  expect(args.idField).toEqual({ name: 'email', value: 'johndoe@gmail.com' })
+});
+
+test('should map undefined data to an empty object', () => {
+  const schema = buildSchema(`
+    """
+    @model
+    """
+    type User {
+        id: ID!
+    }`);
+
+  const userModel = schema.getType("User") as GraphQLObjectType;
+
+  const modelTableMap = buildModelTableMap(userModel);
+
+  const data = undefined;
+
+  const args = getDatabaseArguments(modelTableMap, data);
+
+  expect(args).toEqual({ data: {} })
 });


### PR DESCRIPTION
Fixes https://github.com/aerogear/graphback/issues/1088

When a mutation is sent with no fields, Graphback tries to insert `undefined` into the database.

This is a problem because if the fields are automatically added (by a DEFAULT value or if it is an incrementing field), Graphback does not construct the insert query correctly and the operation fails.

This maps `undefined` mutation data to an empty object.

## Verification

See https://github.com/aerogear/graphback/issues/1088