### PR TITLE
fix: generate files relative to `.graphqlrc` file

### DIFF
--- a/packages/graphback-codegen-client/src/ClientCRUDPlugin.ts
+++ b/packages/graphback-codegen-client/src/ClientCRUDPlugin.ts
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import { GraphbackCoreMetadata, GraphbackPlugin } from '@graphback/core'
 import { writeDocumentsToFilesystem } from './helpers/writeDocuments';
 import { createClientDocumentsGQL, createClientDocumentsGqlComplete, createClientDocumentsTS } from './templates'

--- a/packages/graphback-codegen-resolvers/src/ResolverGeneratorPlugin.ts
+++ b/packages/graphback-codegen-resolvers/src/ResolverGeneratorPlugin.ts
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import { GraphbackCoreMetadata, GraphbackPlugin } from '@graphback/core';
 import { OutputFileSystem } from './GeneratorModel';
 import { GeneratorResolversFormat } from './GeneratorResolversFormat';


### PR DESCRIPTION
Fixes https://github.com/aerogear/graphback/issues/1083

This fix supplies the working directory (relative to the `.graphqlrc` file) to each plugin `createResources` method, so that the files can be written to the directory relative to the config.