### PR TITLE
fix(Apollo+Postgres+Runtime): add missing dependency

### DIFF
--- a/templates/ts-apollo-mongodb-runtime-backend/src/index.ts
+++ b/templates/ts-apollo-mongodb-runtime-backend/src/index.ts
@@ -4,8 +4,8 @@ import { ApolloServer } from "apollo-server-express"
 import cors from "cors"
 import express from "express"
 import http from "http"
-import { createRuntime } from './runtime'
 import { printSchema } from 'graphql'
+import { createRuntime } from './runtime'
 
 async function start() {
   const app = express()
@@ -15,16 +15,10 @@ async function start() {
   // connect to db
   const { schema, resolvers } = await createRuntime();
 
-  const apolloConfig = {
+  const apolloServer = new ApolloServer({
     typeDefs: printSchema(schema),
-    resolvers,
-    playground: true,
-    resolverValidationOptions: {
-      requireResolversForResolveType: false
-    }
-  }
-
-  const apolloServer = new ApolloServer(apolloConfig)
+    resolvers
+  })
 
   apolloServer.applyMiddleware({ app })
 
@@ -36,4 +30,4 @@ async function start() {
   })
 }
 
-start()
+start().catch((err: any) => console.log(err))

--- a/templates/ts-apollo-runtime-backend/package.json
+++ b/templates/ts-apollo-runtime-backend/package.json
@@ -17,6 +17,7 @@
     "dotenv": "8.2.0",
     "express": "4.17.1",
     "graphback": "0.12.0",
+    "@graphback/runtime-knex": "0.12.0",
     "graphql": "14.6.0",
     "graphql-config": "3.0.0",
     "graphql-migrations": "0.12.0",

--- a/templates/ts-apollo-runtime-backend/src/index.ts
+++ b/templates/ts-apollo-runtime-backend/src/index.ts
@@ -4,8 +4,8 @@ import { ApolloServer } from "apollo-server-express"
 import cors from "cors"
 import express from "express"
 import http from "http"
-import { createRuntime } from './runtime'
 import { printSchema } from 'graphql'
+import { createRuntime } from './runtime'
 
 const app = express()
 
@@ -14,16 +14,10 @@ app.use(cors())
 // connect to db
 const { schema, resolvers } = createRuntime();
 
-const apolloConfig = {
+const apolloServer = new ApolloServer({
   typeDefs: printSchema(schema),
-  resolvers,
-  playground: true,
-  resolverValidationOptions: {
-    requireResolversForResolveType: false
-  }
-}
-
-const apolloServer = new ApolloServer(apolloConfig)
+  resolvers
+})
 
 apolloServer.applyMiddleware({ app })
 


### PR DESCRIPTION
The Apollo PostgreSQL Runtime template is missing `@graphback/runtime-knex` which is required to create data sources and start the server.