### PR TITLE
fix: remove deprecation warning from mongo runtime tests

### DIFF
--- a/packages/graphback-runtime-mongodb/tests/MongoDataProviderTest.ts
+++ b/packages/graphback-runtime-mongodb/tests/MongoDataProviderTest.ts
@@ -34,12 +34,12 @@ let context: Context;
 //all tests can run parallel
 beforeEach(async () => {
   const server = new MongoMemoryServer();
-  const client = new MongoClient(await server.getConnectionString())
+  const client = new MongoClient(await server.getConnectionString(), { useUnifiedTopology: true });
   await client.connect();
   const db = client.db('test');
   const provider = new MongoDBDataProvider(modelType, db);
 
-  context = { provider, server }
+  context = { provider, server };
 
   await provider.create({
     text: 'todo',
@@ -51,7 +51,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await context.server.stop()
+  await context.server.stop();
 })
 
 test('Test mongo crud', async () => {


### PR DESCRIPTION
When running the command `yarn test` a below deprecated warning message was printed:

```
(node:75999) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
```

Let's fix the issue by adding the `useUnifiedTopology` options as suggested in the deprecation notice.

/cc @wtrocki @craicoverflow 