### PR TITLE
Implement New CRUD spec for mongo

### DIFF
--- a/packages/graphback-runtime-knex/src/KnexDBDataProvider.ts
+++ b/packages/graphback-runtime-knex/src/KnexDBDataProvider.ts
@@ -137,7 +137,7 @@ export class KnexDBDataProvider<Type = any, GraphbackContext = any> implements G
         }
       }
       query = query.offset(page.offset)
-      // console.log('page desu: ', page)
+
       if (page.hasOwnProperty("limit")) {
         if (page.limit <= 0) {
           throw new Error("Please use a limit of greater than 0 in queries")

--- a/packages/graphback-runtime-mongodb/package.json
+++ b/packages/graphback-runtime-mongodb/package.json
@@ -39,7 +39,8 @@
     "@graphback/runtime": "0.12.0",
     "@types/mongodb": "3.5.14",
     "dataloader": "2.0.0",
-    "graphql-subscriptions": "1.1.0"
+    "graphql-subscriptions": "1.1.0",
+    "mquery": "^3.2.2"
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0",

--- a/packages/graphback-runtime-mongodb/src/buildQuery.ts
+++ b/packages/graphback-runtime-mongodb/src/buildQuery.ts
@@ -30,7 +30,7 @@ const add:{ [x: string]: (op: string) => AddMethod }= {
             op = mopify(op);
             return (builder, field, value) => {
                 let q = {};
-                q[field] = { op: value};
+                q[field] = { [op]: value};
                 return builder.or(q);
             }
         } else {

--- a/packages/graphback-runtime-mongodb/src/buildQuery.ts
+++ b/packages/graphback-runtime-mongodb/src/buildQuery.ts
@@ -1,0 +1,159 @@
+import * as mquery from 'mquery';
+import { Collection } from 'mongodb';
+
+const AND_FIELD = 'and';
+const OR_FIELD = 'or';
+const NOT_FIELD = 'not';
+
+type AddMethod = (builder, key: string, value: any) => any;
+
+// Map for adding ops to a query
+const add:{ [x: string]: (op: string) => AddMethod }= {
+    [`${NOT_FIELD}`]: (op: string) => {
+        const notMap = {
+            in: 'nin',
+            nin: 'in',
+            between: 'nbetween',
+            nbetween: 'between',
+            lt: 'ge',
+            ge: 'lt',
+            le: 'gt',
+            gt: 'le',
+            eq: 'ne',
+            ne: 'eq'
+        };
+        op = notMap[op];
+        return methodMapping[op];
+    },
+    [`${OR_FIELD}`]: (op: string) => {
+        if (!["between", "nbetween"].includes(op)) {
+            op = mopify(op);
+            return (builder, field, value) => {
+                let q = {};
+                q[field] = { op: value};
+                return builder.or(q);
+            }
+        } else {
+            return (builder: any, field: string, values: [any, any]) => {
+                let q = {};
+                values.sort();
+                if (op === "between") {
+                    q[field] = {
+                        $gte: values[0],
+                        $lte: values[1],
+                    };
+                } else if (op === "nbetween") {
+                    q[field] = {
+                        $lt: values[0],
+                        $gt: values[1],
+                    };
+                }
+                return builder.or(q);
+            }
+        }
+    },
+    [`${AND_FIELD}`]: (op: string) => {
+        return methodMapping[op];
+    }
+}
+
+// convert schema ops to mongodb ops
+function mopify(op: string): string {
+    switch(op) {
+        case 'ge':
+            return '$gte';
+        case 'le':
+            return '$lte';
+        default:
+            return `$${op}`;
+    }
+}
+
+const methodMapping: { [x: string]: AddMethod } = {
+    in: (builder, key: String, set: Array<any>) => {
+        return builder.where(key).in(set);
+    },
+    nin: (builder, key: String, set: Array<any>) => {
+        return builder.where(key).nin(set);
+    },
+    between: (builder, key: String, values: [any, any]) => {
+        values.sort();
+        return builder.where(key).gte(values[0]).lte(values[1]);
+    },
+    nbetween: (builder, key: String, values: [any, any]) => {
+        values.sort();
+        return builder.where(key).lt(values[0]).gt(values[1]);
+    },
+    lt: (builder, key: String, value: any) => {
+        return builder.where(key).lt(value);
+    },
+    le: (builder, key: String, value: any) => {
+        return builder.where(key).lte(value);
+    },
+    gt: (builder, key: String, value: any) => {
+        return builder.where(key).gt(value);
+    },
+    ge: (builder, key: String, value: any) => {
+        return builder.where(key).gte(value);
+    },
+    eq: (builder, key: String, value: any) => {
+        return builder.where(key).eq(value);
+    },
+    ne: (builder, key: String, value: any) => {
+        return builder.where(key).ne(value);
+    },
+};
+
+
+function where(builder: any, filter: any, clause?: string) {
+    if (!filter) {
+        return builder;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/tslint/config
+    Object.entries(filter).forEach(([key, expr]) => {
+        if ([AND_FIELD, OR_FIELD].includes(key)) {
+
+            // mquery().or/and
+            if (Array.isArray(expr)) {
+                for(const e of expr) {
+                    builder = where(builder, e, key)
+                }
+            }
+
+            return;
+        } else if (key === NOT_FIELD) {
+            builder =  where(builder, expr, key);
+        }
+
+        // eslint-disable-next-line @typescript-eslint/tslint/config
+        // eslint-disable-next-line no-shadow
+        Object.entries(expr).forEach((exprEntry: [any, any]) => {
+            if (Object.keys(methodMapping).includes(exprEntry[0])) {
+                // This is read like Add or between/Add not eq
+                const addMethod = add[clause || AND_FIELD](exprEntry[0]);
+                // It adds that operator to the query
+                builder = addMethod(builder, key, exprEntry[1]);
+            } else if (exprEntry[0] === 'contains') {
+                const addMethod = add[clause || AND_FIELD]('eq');
+                builder = addMethod(builder, key, new RegExp(`${exprEntry[1]}`, 'g'))
+            } else if (exprEntry[0] === 'startsWith') {
+                const addMethod = add[clause || AND_FIELD]('eq');
+                builder = addMethod(builder, key, new RegExp(`^${exprEntry[1]}`, 'g'))
+            } else if (exprEntry[0] === 'endsWith') {
+                const addMethod = add[clause || AND_FIELD]('eq');
+                builder = addMethod(builder, key, new RegExp(`${exprEntry[1]}$`, 'g'))
+            } else {
+                throw Error(`Not supported operator: ${exprEntry[0]}`);
+            }
+        });
+    });
+
+    return builder;
+}
+
+export function buildQuery(collection: Collection, filter: any): any {
+    const builder = where(mquery(collection), filter);
+
+    return builder;
+}

--- a/packages/graphback-runtime-mongodb/tests/MongoDataProviderTest.ts
+++ b/packages/graphback-runtime-mongodb/tests/MongoDataProviderTest.ts
@@ -113,7 +113,9 @@ test('find first 1 todo(s) excluding first todo', async () => {
 test('find Todo by text', async () => {
   const all = await context.provider.findAll();
   const todos: Todo[] = await context.provider.findBy({
-    text: all[0].text,
+    text: {
+      eq: all[0].text
+    },
   });
   expect(todos.length).toBeGreaterThan(0);
 });
@@ -125,7 +127,7 @@ test('find Todo by text, limit defaults to complete set', async () => {
       text,
     });
   }
-  const todos: Todo[] = await context.provider.findBy({ text }, { offset: 0 });
+  const todos: Todo[] = await context.provider.findBy({ text: { eq: text } }, { offset: 0 });
   expect(todos.length).toEqual(11);
 });
 
@@ -136,7 +138,7 @@ test('find by text offset defaults to 0', async () => {
       text,
     });
   }
-  const todos = await context.provider.findBy({ text }, { limit: 1 });
+  const todos = await context.provider.findBy({ text: { eq: text } }, { limit: 1 });
   expect(todos[0].text).toEqual(text);
 });
 
@@ -148,7 +150,7 @@ test('find first 1 todos by text', async () => {
     });
   }
 
-  const todos = await context.provider.findBy({ text } , { limit: 1, offset: 0});
+  const todos = await context.provider.findBy({ text: { eq: text } } , { limit: 1, offset: 0});
   expect(todos.length).toEqual(1);
   expect(todos[0].text).toEqual(text);
 });


### PR DESCRIPTION
The mquery syntax is mostly similar to mongodb native driver queries with some sugar added, All of find, delete, update queries are still present, with the exception of a insert query. So with this, MongoDataProvider uses mquery for all operations except 'create'. I also noticed that we don't test the batchRead operation, which I also changed to use mquery, so if possible I would like to write a test for it just to be safe?