### PR TITLE
refactor: minor changes to runtime initialization

### DIFF
--- a/packages/graphback-core/src/plugin/GraphbackPluginEngine.ts
+++ b/packages/graphback-core/src/plugin/GraphbackPluginEngine.ts
@@ -4,13 +4,21 @@ import { GraphbackGlobalConfig } from './GraphbackGlobalConfig';
 import { GraphbackPlugin } from './GraphbackPlugin';
 
 /**
+ * options for the GraphbackPluginEngine
+ */
+export interface GraphBackPluginEngineOptions {
+    schema: GraphQLSchema | string
+    config: GraphbackGlobalConfig
+    plugins: GraphbackPlugin[]
+}
+/**
  * Allows to execute chain of plugins that create resources. 
  * Common use case is to decorate GraphQL schema with additional 
  * actions and generate files like resolvers and database access logic
  * 
  * Usage:
  * ```js
- * const engine = GraphbackPluginEngine(schema);
+ * const engine = GraphbackPluginEngine({ schema });
  * engine.registerPlugin(plugin);
  * printSchema(engine.createResources());
  * ```
@@ -20,8 +28,8 @@ export class GraphbackPluginEngine {
     private plugins: GraphbackPlugin[]
     private metadata: GraphbackCoreMetadata;
 
-    public constructor(schema: GraphQLSchema | string, config: GraphbackGlobalConfig) {
-        this.plugins = [];
+    public constructor({ schema, config, plugins }: GraphBackPluginEngineOptions) {
+        this.plugins = plugins || [];
         if (!schema) {
             throw new Error("Plugin engine requires schema");
         }

--- a/packages/graphback/src/GraphbackConfig.ts
+++ b/packages/graphback/src/GraphbackConfig.ts
@@ -1,0 +1,17 @@
+import { ClientGeneratorPluginConfig } from '@graphback/codegen-client';
+import { ResolverGeneratorPluginConfig } from "@graphback/codegen-resolvers"
+import { SchemaCRUDPluginConfig } from '@graphback/codegen-schema';
+import { GraphbackCRUDGeneratorConfig } from '@graphback/core';
+
+/**
+ * Global configuration for Graphback ecosystem that represents each plugin 
+ */
+export interface GraphbackConfig {
+  crud?: GraphbackCRUDGeneratorConfig
+  //Plugins configuration
+  plugins?: {
+    ResolversCRUD?: ResolverGeneratorPluginConfig
+    SchemaCRUD?: SchemaCRUDPluginConfig
+    ClientCRUD?: ClientGeneratorPluginConfig
+  } | any
+}

--- a/packages/graphback/src/GraphbackRuntime.ts
+++ b/packages/graphback/src/GraphbackRuntime.ts
@@ -1,7 +1,8 @@
-import { GraphbackPluginEngine, ModelDefinition } from '@graphback/core';
+import { GraphbackPluginEngine, ModelDefinition, GraphbackCoreMetadata } from '@graphback/core';
 import { GraphbackCRUDService, LayeredRuntimeResolverCreator, GraphbackPubSubModel } from '@graphback/runtime';
 import { GraphQLSchema } from 'graphql';
-import { GraphbackGenerator, GraphbackGeneratorConfig } from './GraphbackGenerator';
+import { loadPlugins } from './loadPlugins';
+import { GraphbackConfig } from './GraphbackConfig';
 
 /**
  * GraphbackRuntime
@@ -9,9 +10,22 @@ import { GraphbackGenerator, GraphbackGeneratorConfig } from './GraphbackGenerat
  * Automatically generate your database structure resolvers and queries from graphql types.
  * See README for examples
  */
-export class GraphbackRuntime extends GraphbackGenerator {
-  public constructor(schema: GraphQLSchema | string, config: GraphbackGeneratorConfig) {
-    super(schema, config);
+export class GraphbackRuntime {
+  protected config: GraphbackConfig;
+  protected schema: string | GraphQLSchema;
+  protected metadata: GraphbackCoreMetadata;
+
+  public constructor(schema: GraphQLSchema | string, config: GraphbackConfig) {
+    this.schema = schema;
+    this.config = config;
+
+    const plugins = loadPlugins(this.config.plugins);
+    const pluginEngine = new GraphbackPluginEngine({
+      schema: this.schema, 
+      plugins,
+      config: { crudMethods: this.config.crud }
+    });
+    this.metadata = pluginEngine.createSchema();
   }
 
   /**
@@ -21,19 +35,17 @@ export class GraphbackRuntime extends GraphbackGenerator {
    * You can use one of the datasource helpers to create services
    */
   public buildRuntime(services: { [key: string]: GraphbackCRUDService } = {}) {
-    const metadata = this.getMetadata();
-    const models = metadata.getModelDefinitions();
+    const models = this.metadata.getModelDefinitions();
     const runtimeResolversCreator = new LayeredRuntimeResolverCreator(models, services);
 
-    return { schema: metadata.getSchema(), resolvers: runtimeResolversCreator.generate() }
+    return { schema: this.metadata.getSchema(), resolvers: runtimeResolversCreator.generate() }
   }
 
   /**
    * Get models for creation of the datasource
    */
   public getDataSourceModels() {
-    const metadata = this.getMetadata();
-    const models = metadata.getModelDefinitions();
+    const models = this.metadata.getModelDefinitions();
 
     return models.reduce((pubSubModels: any, model: ModelDefinition) => {
       const pubSubModel: GraphbackPubSubModel = {
@@ -50,13 +62,7 @@ export class GraphbackRuntime extends GraphbackGenerator {
     }, []);
   }
 
-
-  public getMetadata() {
-    const pluginEngine = new GraphbackPluginEngine(this.schema, { crudMethods: this.config.crud })
-
-    this.initializePlugins(pluginEngine)
-    const metadata = pluginEngine.createSchema();
-
-    return metadata
+  public getMetaData() {
+    return this.metadata;
   }
 }

--- a/packages/graphback/src/GraphbackRuntime.ts
+++ b/packages/graphback/src/GraphbackRuntime.ts
@@ -62,7 +62,7 @@ export class GraphbackRuntime {
     }, []);
   }
 
-  public getMetaData() {
+  public getMetadata() {
     return this.metadata;
   }
 }

--- a/packages/graphback/src/index.ts
+++ b/packages/graphback/src/index.ts
@@ -1,4 +1,5 @@
 export * from '@graphback/core'
 export * from '@graphback/runtime'
+export * from './GraphbackConfig'
 export * from './GraphbackGenerator'
 export * from './GraphbackRuntime'

--- a/packages/graphback/src/loadPlugins.ts
+++ b/packages/graphback/src/loadPlugins.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { GraphbackPlugin } from "@graphback/core";
+
+export function loadPlugins(pluginConfig: any): GraphbackPlugin[] {
+  const pluginInstances = [];
+  for (const pluginLabel of Object.keys(pluginConfig)) {
+    let pluginName = pluginLabel;
+    if (pluginLabel.startsWith('graphback-')) {
+      // Internal graphback plugins needs rename
+      pluginName = pluginLabel.replace('graphback-', '@graphback/codegen-');
+    }
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const plugin = require(pluginName);
+      if (plugin.Plugin) {
+        const config = pluginConfig[pluginLabel];
+        pluginInstances.push(new plugin.Plugin(config));
+      }
+      else {
+        //tslint:disable-next-line: no-console
+        console.log(`${pluginName} plugin is not exporting 'Plugin' class`);
+      }
+    }
+    catch (e) {
+      //tslint:disable-next-line: no-console
+      console.log(`${pluginName} plugin missing in package.json`, e);
+    }
+  }
+
+  return pluginInstances;
+}


### PR DESCRIPTION
This PR introduces some minor refactoring of the runtime and core packages, without making any changes to functionality. There are more areas that can be improved but I figured it would be nice to do things in smaller easy to digest PRs.

* GraphbackGenerator `initializePlugins` refactored into pure `loadPlugins` function. Instead of passing the plugin engine into it just to call `registerPlugin` we just return an array of initialized plugins which can then be passed into `GraphbackPluginEngine`. I've left the `registerPlugin` function just in case.
* `GraphbackRuntime` no longer extends `GraphbackGenerator`. The only reason it was doing that was to call `initializePlugins` which is not longer needed.
* `GraphbackRuntime` used to call `this.getMetaData()` in multiple places which would create the plugin engine and `require` and create the plugins each time. This seemed wasteful and unnecessary. Instead the plugin engine is created once. the `getMetaData` function is still there but it just returns the already created metadata.
* Renamed `GraphbackGeneratorConfig` to `GraphbackConfig` and moved to its own file. This is still used both by the generator and the runtime classes.
