### PR TITLE
fix(runtime-knex): add mapping for object clauses

### DIFF
--- a/packages/graphback-codegen-client/tests/__snapshots__/GraphQLClientCreatorTest.ts.snap
+++ b/packages/graphback-codegen-client/tests/__snapshots__/GraphQLClientCreatorTest.ts.snap
@@ -343,8 +343,8 @@ fragment NoteExpandedFields on Note {
     Object {
       "implementation": "
 
-query findNote($filter: NoteFilterUniqueInput) {
-    findNote(filter: $filter) {
+query getNote($filter: NoteFilterUniqueInput) {
+    getNote(filter: $filter) {
       ...NoteExpandedFields
     }
   }
@@ -361,7 +361,7 @@ fragment NoteExpandedFields on Note {
 } 
 
 ",
-      "name": "findNote",
+      "name": "getNote",
     },
     Object {
       "implementation": "
@@ -389,8 +389,8 @@ fragment CommentExpandedFields on Comment {
     Object {
       "implementation": "
 
-query findComment($filter: CommentFilterUniqueInput) {
-    findComment(filter: $filter) {
+query getComment($filter: CommentFilterUniqueInput) {
+    getComment(filter: $filter) {
       ...CommentExpandedFields
     }
   }
@@ -407,7 +407,7 @@ fragment CommentExpandedFields on Comment {
 } 
 
 ",
-      "name": "findComment",
+      "name": "getComment",
     },
   ],
   "subscriptions": Array [
@@ -722,9 +722,9 @@ export const findNotes = gql\`
       "implementation": "import gql from \\"graphql-tag\\"
 import { NoteExpandedFragment } from \\"../fragments/NoteExpanded\\"
 
-export const findNote = gql\`
-  query findNote($filter: NoteFilterUniqueInput) {
-    findNote(filter: $filter) {
+export const getNote = gql\`
+  query getNote($filter: NoteFilterUniqueInput) {
+    getNote(filter: $filter) {
       ...NoteExpandedFields
     }
   }
@@ -732,7 +732,7 @@ export const findNote = gql\`
   \${NoteExpandedFragment}
 \`
 ",
-      "name": "findNote",
+      "name": "getNote",
     },
     Object {
       "implementation": "import gql from \\"graphql-tag\\"
@@ -754,9 +754,9 @@ export const findComments = gql\`
       "implementation": "import gql from \\"graphql-tag\\"
 import { CommentExpandedFragment } from \\"../fragments/CommentExpanded\\"
 
-export const findComment = gql\`
-  query findComment($filter: CommentFilterUniqueInput) {
-    findComment(filter: $filter) {
+export const getComment = gql\`
+  query getComment($filter: CommentFilterUniqueInput) {
+    getComment(filter: $filter) {
       ...CommentExpandedFields
     }
   }
@@ -764,7 +764,7 @@ export const findComment = gql\`
   \${CommentExpandedFragment}
 \`
 ",
-      "name": "findComment",
+      "name": "getComment",
     },
   ],
   "subscriptions": Array [

--- a/packages/graphback-runtime-knex/src/knexQueryMapper.ts
+++ b/packages/graphback-runtime-knex/src/knexQueryMapper.ts
@@ -63,12 +63,14 @@ function where(builder: Knex.QueryBuilder, filter: any, clause?: string) {
   }
 
   // eslint-disable-next-line @typescript-eslint/tslint/config
-  Object.entries(filter).forEach(([key, expr]) => {
+  Object.entries(filter).forEach(([key, expr]: [string, any]) => {
     if ([AND_FIELD, OR_FIELD, NOT_FIELD].includes(key)) {
       if (Array.isArray(expr)) {
         for (const e of expr) {
           builder = where(builder, e, key)
         }
+      } else {
+        builder = where(builder, expr, key)
       }
 
       return

--- a/packages/graphback-runtime-knex/tests/data/KnexDbDataProviderTest.ts
+++ b/packages/graphback-runtime-knex/tests/data/KnexDbDataProviderTest.ts
@@ -245,3 +245,131 @@ type Todo {
 
   expect(todos.length).toEqual(numberOfTodos);
 });
+
+test('or clause as object', async () => {
+  const seedData = [
+    { title: 'one', description: 'one description' },
+    { title: 'two', description: '' },
+    { title: 'three', description: 'three description' }
+  ]
+
+  const { providers } = await setup(`
+"""
+@model
+"""
+type Todo {
+ id: ID!
+ title: String
+ description: String
+}`, { seedData: { todo: seedData } })
+
+  const todos = await providers.Todo.findBy({
+    "title": {
+      "eq": "one"
+    },
+    "or": {
+      "title": {
+        "eq": "three"
+      }
+    }
+  })
+
+  expect(todos).toHaveLength(2)
+});
+
+test('or clause as array', async () => {
+  const seedData = [
+    { title: 'one', description: 'one description' },
+    { title: 'two', description: '' },
+    { title: 'three', description: 'three description' }
+  ]
+
+  const { providers } = await setup(`
+"""
+@model
+"""
+type Todo {
+ id: ID!
+ title: String
+ description: String
+}`, { seedData: { todo: seedData } })
+
+  const todos = await providers.Todo.findBy({
+    "title": {
+      "eq": "one"
+    },
+    "or": [
+      {
+        "title": {
+          "eq": "three"
+        }
+      },
+      {
+        "description": {
+          "eq": ""
+        }
+      }
+    ]
+  })
+
+  expect(todos).toHaveLength(3)
+});
+
+test('and clause', async () => {
+  const seedData = [
+    { title: 'one', description: 'one description' },
+    { title: 'two', description: '' },
+    { title: 'three', description: 'three description' }
+  ]
+
+  const { providers } = await setup(`
+"""
+@model
+"""
+type Todo {
+ id: ID!
+ title: String
+ description: String
+}`, { seedData: { todo: seedData } })
+
+  const todos = await providers.Todo.findBy({
+    "title": {
+      "eq": "two"
+    },
+    "and": {
+      "description": {
+        "eq": " "
+      }
+    }
+  })
+
+  expect(todos).toHaveLength(1)
+});
+
+test('not clause', async () => {
+  const seedData = [
+    { title: 'one', description: 'one description' },
+    { title: 'two', description: '' },
+    { title: 'three', description: 'three description' }
+  ]
+
+  const { providers } = await setup(`
+"""
+@model
+"""
+type Todo {
+ id: ID!
+ title: String
+ description: String
+}`, { seedData: { todo: seedData } })
+
+  const todos = await providers.Todo.findBy({
+    "not": {
+      "description": {
+        "eq": ""
+      }
+    }
+  })
+
+  expect(todos).toHaveLength(2)
+});


### PR DESCRIPTION
AND/OR/NOT clauses can accept a list of filters or a single object, but was only working for list.