### PR TITLE
fix: set default value as undefined instead of null

### DIFF
--- a/packages/graphql-migrations/src/abstract/Table.ts
+++ b/packages/graphql-migrations/src/abstract/Table.ts
@@ -2,7 +2,7 @@ import { TableColumn } from './TableColumn'
 
 export interface Table {
   name: string
-  comment: string | null
+  comment: string | undefined
   annotations: any
   columns: TableColumn[]
   columnMap: Map<string, TableColumn>
@@ -13,16 +13,16 @@ export interface Table {
 
 export interface TableIndex {
   columns: string[]
-  name: string | null
-  type: string | null
+  name: string | undefined
+  type: string | undefined
 }
 
 export interface TablePrimary {
   columns: string[]
-  name: string | null
+  name: string | undefined
 }
 
 export interface TableUnique {
   columns: string[]
-  name: string | null
+  name: string | undefined
 }

--- a/packages/graphql-migrations/src/abstract/TableColumn.ts
+++ b/packages/graphql-migrations/src/abstract/TableColumn.ts
@@ -17,19 +17,19 @@ export type TableColumnType =
   'uuid'
 
 export interface ForeignKey {
-  type: string | null
-  field: string | null
-  tableName: string | null
-  columnName: string | null
+  type: string | undefined
+  field: string | undefined
+  tableName: string | undefined
+  columnName: string | undefined
 }
 
 export interface TableColumn {
   name: string
-  comment: string | null
+  comment: string | undefined
   annotations: any
   type: string
   args: any[]
   nullable: boolean
-  foreign: ForeignKey | null
+  foreign: ForeignKey | undefined
   defaultValue: any
 }

--- a/packages/graphql-migrations/src/abstract/generateAbstractDatabase.ts
+++ b/packages/graphql-migrations/src/abstract/generateAbstractDatabase.ts
@@ -426,8 +426,7 @@ class AbstractDatabaseBuilder {
       args: args || [],
       nullable: !notNull,
       foreign,
-      // eslint-disable-next-line no-null/no-null
-      defaultValue: annotations.default !== null ? annotations.default : null,
+      defaultValue: annotations.default,
     }
   }
 

--- a/packages/graphql-migrations/src/diff/Operation.ts
+++ b/packages/graphql-migrations/src/diff/Operation.ts
@@ -42,7 +42,7 @@ export interface TableRenameOperation extends Operation {
 export interface TableCommentSetOperation extends Operation {
   type: 'table.comment.set'
   table: string
-  comment: string | null
+  comment: string | undefined
 }
 
 export interface TableDropOperation extends Operation {
@@ -54,15 +54,15 @@ export interface TableIndexCreateOperation extends Operation {
   type: 'table.index.create'
   table: string
   columns: string[]
-  indexName: string | null
-  indexType: string | null
+  indexName: string | undefined
+  indexType: string | undefined
 }
 
 export interface TableIndexDropOperation extends Operation {
   type: 'table.index.drop'
   table: string
   columns: string[]
-  indexName: string | null
+  indexName: string | undefined
 }
 
 export interface TablePrimarySetOperation extends Operation {
@@ -76,14 +76,14 @@ export interface TableUniqueCreateOperation extends Operation {
   type: 'table.unique.create'
   table: string
   columns: string[]
-  indexName: string | null
+  indexName: string | undefined
 }
 
 export interface TableUniqueDropOperation extends Operation {
   type: 'table.unique.drop'
   table: string
   columns: string[]
-  indexName: string | null
+  indexName: string | undefined
 }
 
 export interface TableForeignCreateOperation extends Operation {
@@ -106,7 +106,7 @@ export interface ColumnCreateOperation extends Operation {
   column: string
   columnType: string
   args: any[]
-  comment: string | null
+  comment: string | undefined
   nullable: boolean
   defaultValue: any
 }
@@ -117,7 +117,7 @@ export interface ColumnAlterOperation extends Operation {
   column: string
   columnType: string
   args: any[]
-  comment: string | null
+  comment: string | undefined
   nullable: boolean
   defaultValue: any
 }

--- a/packages/graphql-migrations/src/util/comments.ts
+++ b/packages/graphql-migrations/src/util/comments.ts
@@ -1,3 +1,3 @@
-export function escapeComment(comment: string | null) {
+export function escapeComment(comment: string | undefined) {
   return comment ? comment.replace(/'/g, `''`).replace(/\n\s*/g, '\n').trim() : undefined
 }

--- a/packages/graphql-migrations/src/util/getIndexes.ts
+++ b/packages/graphql-migrations/src/util/getIndexes.ts
@@ -35,11 +35,12 @@ order by
   }),
 }
 
+// eslint-disable-next-line import/no-default-export
 export default async function(
   knex: Knex,
   tableName: string,
   schemaName: string,
-): Promise<{ indexName: string, columnNames: string[], type: string | null }[]> {
+): Promise<{ indexName: string, columnNames: string[], type: string | undefined }[]> {
   const query = queries[knex.client.config.client]
   if (!query) {
     console.warn(`${knex.client.config.client} column index not supported`)

--- a/packages/graphql-migrations/src/util/transformDefaultValue.ts
+++ b/packages/graphql-migrations/src/util/transformDefaultValue.ts
@@ -1,6 +1,7 @@
 //eslint-disable-next-line import/no-default-export
 export default function(value: any) {
-  if (value === 'NULL::character varying') { return undefined }
+  // eslint-disable-next-line no-null/no-null
+  if (value === 'NULL::character varying' || value === null) { return undefined }
 
   return value
 }


### PR DESCRIPTION
graphql-migrations generates a slightly different abstract database when comparing the existing database to the schema. One sets defaultValue on columns to undefined, and the other uses null. Because of this it is repeating the same migration operations every time.

## Verification

Run graphql-migrations on an already up to date database. The number of operations should be 0.