### PR TITLE
fix: add ability to nest or/not queries

### DIFF
--- a/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
+++ b/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
@@ -29,8 +29,7 @@ export const FloatScalarInputType = new GraphQLInputObjectType({
     ge: { type: GraphQLFloat },
     gt: { type: GraphQLFloat },
     in: { type: GraphQLList(GraphQLFloat) },
-    between: { type: GraphQLList(GraphQLFloat) },
-    // exists: { type: GraphQLBoolean }
+    between: { type: GraphQLList(GraphQLFloat) }
   }
 })
 
@@ -44,8 +43,7 @@ export const IntScalarInputType = new GraphQLInputObjectType({
     ge: { type: GraphQLInt },
     gt: { type: GraphQLInt },
     in: { type: GraphQLList(GraphQLInt) },
-    between: { type: GraphQLList(GraphQLInt) },
-    // exists: { type: GraphQLBoolean }
+    between: { type: GraphQLList(GraphQLInt) }
   }
 })
 
@@ -62,8 +60,6 @@ export const StringScalarInputType = new GraphQLInputObjectType({
     contains: { type: GraphQLString },
     startsWith: { type: GraphQLString },
     endsWith: { type: GraphQLString }
-    // exists: { type: GraphQLBoolean }
-    // TODO: size
   }
 })
 
@@ -71,9 +67,7 @@ export const BooleanScalarInputType = new GraphQLInputObjectType({
   name: BooleanScalarInputTypeName,
   fields: {
     ne: { type: GraphQLBoolean },
-    eq: { type: GraphQLBoolean },
-    // exists: { type: GraphQLBoolean }
-    // TODO: Where not null
+    eq: { type: GraphQLBoolean }
   }
 })
 
@@ -90,8 +84,6 @@ export const IDScalarInputType = new GraphQLInputObjectType({
     contains: { type: GraphQLID },
     startsWith: { type: GraphQLID },
     endsWith: { type: GraphQLID }
-    // exists: { type: GraphQLBoolean }
-    // TODO: size
   }
 })
 
@@ -156,10 +148,10 @@ export const buildFilterInputType = (modelType: GraphQLObjectType) => {
         type: `[${inputTypeName}]`
       },
       or: {
-        type: `${inputTypeName}`
+        type: `[${inputTypeName}]`
       },
       not: {
-        type: `[${inputTypeName}]`
+        type: `${inputTypeName}`
       }
     }
   });

--- a/packages/graphback-runtime-knex/tests/data/KnexDbDataProviderTest.ts
+++ b/packages/graphback-runtime-knex/tests/data/KnexDbDataProviderTest.ts
@@ -338,7 +338,7 @@ type Todo {
     },
     "and": {
       "description": {
-        "eq": " "
+        "eq": ""
       }
     }
   })
@@ -418,4 +418,94 @@ type Todo {
   const todos = await providers.Todo.findBy({ text: { eq: text } }, { field: 'id' });
 
   expect(todos[0].id).toEqual(1);
+});
+
+test('get todos with field value in a range', async () => {
+  const { providers } = await setup(
+    `"""
+@model
+"""
+type Todo {
+ id: ID!
+ items: Int
+}`, {
+    seedData: {
+      todo: [
+        {
+          items: 1,
+        },
+        {
+          items: 2,
+        },
+        {
+          items: 3
+        },
+        {
+          items: 4
+        },
+        {
+          items: 5
+        },
+        {
+          items: 6
+        },
+        {
+          items: 8
+        }
+      ]
+    }
+  })
+
+  const todos = await providers.Todo.findBy({ items: { between: [2, 6] } });
+
+  expect(todos).toHaveLength(5);
+
+  const todoItems = todos.map((t: any) => t.items)
+
+  expect(todoItems).toEqual([2, 3, 4, 5, 6])
+});
+
+test('get todos with field value not in a range', async () => {
+  const { providers } = await setup(
+    `"""
+@model
+"""
+type Todo {
+ id: ID!
+ items: Int
+}`, {
+    seedData: {
+      todo: [
+        {
+          items: 1,
+        },
+        {
+          items: 2,
+        },
+        {
+          items: 3
+        },
+        {
+          items: 4
+        },
+        {
+          items: 5
+        },
+        {
+          items: 6
+        },
+        {
+          items: 8
+        }
+      ]
+    }
+  })
+
+  const todos = await providers.Todo.findBy({ not: { items: { between: [2, 6] } } });
+
+  expect(todos).toHaveLength(2);
+
+  const todoItems = todos.map((t: any) => t.items)
+
+  expect(todoItems).toEqual([1, 8])
 });

--- a/packages/graphback-runtime/src/service/CRUDService.ts
+++ b/packages/graphback-runtime/src/service/CRUDService.ts
@@ -83,7 +83,7 @@ export class CRUDService<T = any> implements GraphbackCRUDService<T>  {
   }
 
   //tslint:disable-next-line: no-any
-  public async findBy(filter: AdvancedFilter, orderBy: GraphbackOrderBy, page: GraphbackPage, context?: any): Promise<ResultList<T>> {
+  public async findBy(filter: AdvancedFilter, orderBy?: GraphbackOrderBy, page?: GraphbackPage, context?: any): Promise<ResultList<T>> {
     this.logger.log(`querying object ${this.modelName} with filter ${JSON.stringify(filter)}`)
 
     const items = await this.db.findBy(filter, orderBy, page, context);


### PR DESCRIPTION
## Tasks

- There was an issue when nested and/or/not operators - it only worked one level deep - this fixes that.
- Add ability to perform filtering by checking if a field is null/non-null
- This also adds ability to filter between ranges.

## Verification

To filter results on a null field:

```graphql
query findNotes {
  findNotes(filter: {items:{eq:null}}) {
    items {
      id
      title
      items
    }
  }
}
```

To perform nested operator filtering (or -> not):

```graphql
query findNotes {
  findNotes(filter: {items:{eq:null}, or:{not:{id:{eq:null}}}}) {
    items {
      id
      title
      items
    }
  }
}
```