### PR TITLE
Add husky and commitlint to ensure commits follow conventional commit

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "Mono repository for Graphback project",
   "main": "index.js",
   "devDependencies": {
+    "@commitlint/cli": "^8.3.5",
+    "@commitlint/config-conventional": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "2.34.0",
     "@typescript-eslint/eslint-plugin-tslint": "2.34.0",
     "@typescript-eslint/parser": "2.34.0",
@@ -17,6 +19,7 @@
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "4.0.2",
     "eslint-plugin-unicorn": "18.0.1",
+    "husky": "^4.2.5",
     "lerna": "3.21.0",
     "npm-run-all": "4.1.5",
     "nyc": "15.0.1",
@@ -65,6 +68,11 @@
     "templates/ts-react-apollo-client",
     "integration"
   ],
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aerogear/graphback.git"


### PR DESCRIPTION
We are using conventional commits but not strict about it and typos can sneak in. I want us to enforce it so that we can eventually generated changelogs from commits

https://www.conventionalcommits.org/en/v1.0.0/