### PR TITLE
fix: runtime schema generation when model contains an enum

### DIFF
--- a/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
+++ b/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
@@ -1,4 +1,4 @@
-import { GraphQLInputObjectType, GraphQLFloat, GraphQLList, GraphQLBoolean, GraphQLInt, GraphQLString, GraphQLID, GraphQLEnumType, GraphQLObjectType, GraphQLNonNull, GraphQLField, getNamedType, isScalarType, GraphQLInputFieldMap, GraphQLScalarType, GraphQLNamedType, GraphQLInputField, isSpecifiedScalarType } from "graphql";
+import { GraphQLInputObjectType, GraphQLFloat, GraphQLList, GraphQLBoolean, GraphQLInt, GraphQLString, GraphQLID, GraphQLEnumType, GraphQLObjectType, GraphQLNonNull, GraphQLField, getNamedType, isScalarType, GraphQLInputFieldMap, GraphQLScalarType, GraphQLNamedType, GraphQLInputField, isSpecifiedScalarType, isEnumType } from "graphql";
 import { GraphbackOperationType, getInputTypeName, getInputFieldName, getInputFieldType, isOneToManyField, getPrimaryKey } from '@graphback/core';
 
 const PageRequestTypeName = 'PageRequest';
@@ -203,19 +203,23 @@ export const buildCreateMutationInputType = (modelType: GraphQLObjectType) => {
 export const buildSubscriptionFilterType = (modelType: GraphQLObjectType) => {
   const inputTypeName = getInputTypeName(modelType.name, GraphbackOperationType.SUBSCRIPTION_CREATE);
   const modelFields = Object.values(modelType.getFields());
-  const scalarFields = modelFields.filter((f: GraphQLField<any, any>) => isScalarType(getNamedType(f.type)));
+  const scalarFields = modelFields.filter((f: GraphQLField<any, any>) => {
+    const namedType = getNamedType(f.type);
+
+    return isScalarType(namedType) || isEnumType(namedType);
+  });
 
   return new GraphQLInputObjectType({
     name: inputTypeName,
     fields: () => scalarFields
       .map(({ name, type }: GraphQLField<any, any>) => {
-        const fieldType: GraphQLNamedType = getNamedType(type)
+        const fieldType: GraphQLNamedType = getNamedType(type);
 
         return {
           name,
           type: fieldType || type,
           description: undefined
-        }
+        };
       }).reduce((fieldObj: any, { name, type, description }: any) => {
         fieldObj[name] = { type, description }
 

--- a/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
+++ b/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
@@ -145,6 +145,11 @@ input CreateCommentInput {
   note_id: ID!
 }
 
+input CreateIssueInput {
+  id: ID
+  category: IssueCategory
+}
+
 input CreateNoteInput {
   id: ID
   title: String!
@@ -170,11 +175,53 @@ input IDInput {
   endsWith: ID
 }
 
+\\"\\"\\"
+Model added to test schema generation using enum. 
+See issue https://github.com/aerogear/graphback/issues/1299
+
+@model
+\\"\\"\\"
+type Issue {
+  id: ID!
+  category: IssueCategory
+}
+
+enum IssueCategory {
+  BUG
+  QUESTION
+  FEATURE_REQUEST
+}
+
+input IssueFilter {
+  id: IDInput
+  category: StringInput
+  and: [IssueFilter]
+  or: [IssueFilter]
+  not: IssueFilter
+}
+
+type IssueResultList {
+  items: [Issue]!
+  offset: Int
+  limit: Int
+  count: Int
+}
+
+input IssueSubscriptionFilter {
+  id: ID
+  category: IssueCategory
+}
+
 input MutateCommentInput {
   id: ID!
   title: String
   description: String
   note_id: ID
+}
+
+input MutateIssueInput {
+  id: ID!
+  category: IssueCategory
 }
 
 input MutateNoteInput {
@@ -200,6 +247,9 @@ type Mutation {
   createTest(input: CreateTestInput!): Test!
   updateTest(input: MutateTestInput!): Test!
   deleteTest(input: MutateTestInput!): Test!
+  createIssue(input: CreateIssueInput!): Issue!
+  updateIssue(input: MutateIssueInput!): Issue!
+  deleteIssue(input: MutateIssueInput!): Issue!
 }
 
 \\"\\"\\" @model \\"\\"\\"
@@ -256,6 +306,8 @@ type Query {
   findComments(filter: CommentFilter, page: PageRequest, orderBy: OrderByInput): CommentResultList!
   getTest(id: ID!): Test
   findTests(filter: TestFilter, page: PageRequest, orderBy: OrderByInput): TestResultList!
+  getIssue(id: ID!): Issue
+  findIssues(filter: IssueFilter, page: PageRequest, orderBy: OrderByInput): IssueResultList!
 }
 
 enum SortDirectionEnum {
@@ -286,6 +338,9 @@ type Subscription {
   newTest(filter: TestSubscriptionFilter): Test!
   updatedTest(filter: TestSubscriptionFilter): Test!
   deletedTest(filter: TestSubscriptionFilter): Test!
+  newIssue(filter: IssueSubscriptionFilter): Issue!
+  updatedIssue(filter: IssueSubscriptionFilter): Issue!
+  deletedIssue(filter: IssueSubscriptionFilter): Issue!
 }
 
 \\"\\"\\"@model\\"\\"\\"
@@ -358,6 +413,11 @@ input CreateCommentInput {
   note_id: ID!
 }
 
+input CreateIssueInput {
+  id: ID
+  category: IssueCategory
+}
+
 input CreateNoteInput {
   id: ID
   title: String!
@@ -383,11 +443,53 @@ input IDInput {
   endsWith: ID
 }
 
+\\"\\"\\"
+Model added to test schema generation using enum. 
+See issue https://github.com/aerogear/graphback/issues/1299
+
+@model
+\\"\\"\\"
+type Issue {
+  id: ID!
+  category: IssueCategory
+}
+
+enum IssueCategory {
+  BUG
+  QUESTION
+  FEATURE_REQUEST
+}
+
+input IssueFilter {
+  id: IDInput
+  category: StringInput
+  and: [IssueFilter]
+  or: [IssueFilter]
+  not: IssueFilter
+}
+
+type IssueResultList {
+  items: [Issue]!
+  offset: Int
+  limit: Int
+  count: Int
+}
+
+input IssueSubscriptionFilter {
+  id: ID
+  category: IssueCategory
+}
+
 input MutateCommentInput {
   id: ID!
   title: String
   description: String
   note_id: ID
+}
+
+input MutateIssueInput {
+  id: ID!
+  category: IssueCategory
 }
 
 input MutateNoteInput {
@@ -413,6 +515,9 @@ type Mutation {
   createTest(input: CreateTestInput!): Test!
   updateTest(input: MutateTestInput!): Test!
   deleteTest(input: MutateTestInput!): Test!
+  createIssue(input: CreateIssueInput!): Issue!
+  updateIssue(input: MutateIssueInput!): Issue!
+  deleteIssue(input: MutateIssueInput!): Issue!
 }
 
 \\"\\"\\" @model \\"\\"\\"
@@ -469,6 +574,8 @@ type Query {
   findComments(filter: CommentFilter, page: PageRequest, orderBy: OrderByInput): CommentResultList!
   getTest(id: ID!): Test
   findTests(filter: TestFilter, page: PageRequest, orderBy: OrderByInput): TestResultList!
+  getIssue(id: ID!): Issue
+  findIssues(filter: IssueFilter, page: PageRequest, orderBy: OrderByInput): IssueResultList!
 }
 
 enum SortDirectionEnum {
@@ -499,6 +606,9 @@ type Subscription {
   newTest(filter: TestSubscriptionFilter): Test!
   updatedTest(filter: TestSubscriptionFilter): Test!
   deletedTest(filter: TestSubscriptionFilter): Test!
+  newIssue(filter: IssueSubscriptionFilter): Issue!
+  updatedIssue(filter: IssueSubscriptionFilter): Issue!
+  deletedIssue(filter: IssueSubscriptionFilter): Issue!
 }
 
 \\"\\"\\"@model\\"\\"\\"
@@ -572,6 +682,11 @@ input CreateCommentInput {
   note_id: ID!
 }
 
+input CreateIssueInput {
+  id: ID
+  category: IssueCategory
+}
+
 input CreateNoteInput {
   id: ID
   title: String!
@@ -597,11 +712,53 @@ input IDInput {
   endsWith: ID
 }
 
+\\"\\"\\"
+Model added to test schema generation using enum. 
+See issue https://github.com/aerogear/graphback/issues/1299
+
+@model
+\\"\\"\\"
+type Issue {
+  id: ID!
+  category: IssueCategory
+}
+
+enum IssueCategory {
+  BUG
+  QUESTION
+  FEATURE_REQUEST
+}
+
+input IssueFilter {
+  id: IDInput
+  category: StringInput
+  and: [IssueFilter]
+  or: [IssueFilter]
+  not: IssueFilter
+}
+
+type IssueResultList {
+  items: [Issue]!
+  offset: Int
+  limit: Int
+  count: Int
+}
+
+input IssueSubscriptionFilter {
+  id: ID
+  category: IssueCategory
+}
+
 input MutateCommentInput {
   id: ID!
   title: String
   description: String
   note_id: ID
+}
+
+input MutateIssueInput {
+  id: ID!
+  category: IssueCategory
 }
 
 input MutateNoteInput {
@@ -627,6 +784,9 @@ type Mutation {
   createTest(input: CreateTestInput!): Test!
   updateTest(input: MutateTestInput!): Test!
   deleteTest(input: MutateTestInput!): Test!
+  createIssue(input: CreateIssueInput!): Issue!
+  updateIssue(input: MutateIssueInput!): Issue!
+  deleteIssue(input: MutateIssueInput!): Issue!
 }
 
 \\"\\"\\" @model \\"\\"\\"
@@ -683,6 +843,8 @@ type Query {
   findComments(filter: CommentFilter, page: PageRequest, orderBy: OrderByInput): CommentResultList!
   getTest(id: ID!): Test
   findTests(filter: TestFilter, page: PageRequest, orderBy: OrderByInput): TestResultList!
+  getIssue(id: ID!): Issue
+  findIssues(filter: IssueFilter, page: PageRequest, orderBy: OrderByInput): IssueResultList!
 }
 
 enum SortDirectionEnum {
@@ -713,6 +875,9 @@ type Subscription {
   newTest(filter: TestSubscriptionFilter): Test!
   updatedTest(filter: TestSubscriptionFilter): Test!
   deletedTest(filter: TestSubscriptionFilter): Test!
+  newIssue(filter: IssueSubscriptionFilter): Issue!
+  updatedIssue(filter: IssueSubscriptionFilter): Issue!
+  deletedIssue(filter: IssueSubscriptionFilter): Issue!
 }
 
 \\"\\"\\"@model\\"\\"\\"

--- a/packages/graphback-codegen-schema/tests/mock.graphql
+++ b/packages/graphback-codegen-schema/tests/mock.graphql
@@ -38,3 +38,20 @@ type Query {
 type Mutation {
   likeNote(id: ID!): Note!
 }
+
+"""
+Model added to test schema generation using enum. 
+See issue https://github.com/aerogear/graphback/issues/1299
+
+@model
+"""
+type  Issue {
+  id: ID!
+  category: IssueCategory
+}
+
+enum IssueCategory {
+ BUG
+ QUESTION
+ FEATURE_REQUEST
+}

--- a/packages/graphback-core/src/crud/mappingHelpers.ts
+++ b/packages/graphback-core/src/crud/mappingHelpers.ts
@@ -1,11 +1,11 @@
-import { GraphQLObjectType, GraphQLSchema, GraphQLField, GraphQLNamedType, getNamedType, isObjectType, getNullableType, GraphQLInputField, GraphQLInputFieldConfig, GraphQLScalarType, isScalarType, isNullableType, GraphQLNonNull, GraphQLInputType, isNonNullType } from 'graphql';
+import { GraphQLObjectType, GraphQLSchema, GraphQLField, GraphQLNamedType, getNamedType, isObjectType, getNullableType, GraphQLInputField, GraphQLInputFieldConfig, GraphQLScalarType, isScalarType, isNullableType, GraphQLNonNull, GraphQLInputType, isNonNullType, isEnumType } from 'graphql';
 import { parseMarker } from 'graphql-metadata';
 import * as pluralize from 'pluralize'
 import { getUserTypesFromSchema } from '@graphql-toolkit/common';
 import { parseRelationshipAnnotation, transformForeignKeyName, getPrimaryKey } from '..';
 import { GraphbackOperationType } from './GraphbackOperationType';
 
-//TODO is is esential to document this element
+//TODO it is esential to document this element
 
 /**
  * Graphback CRUD Mapping helpers
@@ -164,7 +164,7 @@ export function getInputFieldType(field: GraphQLField<any, any>): GraphQLInputTy
     fieldType = getNamedType(idField.type);
   }
 
-  if (isScalarType(fieldType)) {
+  if (isScalarType(fieldType) || isEnumType(fieldType)) {
     return isNonNullType(field.type) ? GraphQLNonNull(fieldType) : fieldType
   }
 


### PR DESCRIPTION
When a model contained an enum, an error `Error: ThunkComposer() returns empty value: undefined` was
thrown, which stopped the server from being started. Let's fix this by allowing enums to be
recognisable as filter input types.

Fixes #1299