### PR TITLE
Revert "chore: use locally installed lerna instead of a global one"

### DIFF
--- a/scripts/validateRelease.sh
+++ b/scripts/validateRelease.sh
@@ -3,11 +3,12 @@
 # explicit declaration that this script needs a $TAG variable passed in e.g TAG=1.2.3 ./script.sh
 TAG=$TAG
 TAG_SYNTAX='^[0-9]+\.[0-9]+\.[0-9]+(-.+)*$'
+
 # get version found in lerna.json. This is the source of truth
 PACKAGE_VERSION=$(cat lerna.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')
 
 # get names of packages being managed by lerna
-PACKAGES=$(yarn lerna --loglevel=silent ls | awk -F ' ' '{print $1}')
+PACKAGES=$(lerna --loglevel=silent ls | awk -F ' ' '{print $1}')
 
 # validate tag has format x.y.z
 if [[ "$(echo $TAG | grep -E $TAG_SYNTAX)" == "" ]]; then
@@ -23,7 +24,7 @@ fi
 
 # validate that all packages have the same version found in lerna.json
 for package in $PACKAGES; do
-  version=$(yarn lerna --loglevel=silent ls -l | grep $package | awk -F ' ' '{print $2}' | cut -c2-)
+  version=$(lerna --loglevel=silent ls -l | grep $package | awk -F ' ' '{print $2}' | cut -c2-)
   if [[ $version =~ $PACKAGE_VERSION ]]; then
     echo "package $package has version $version"
   else


### PR DESCRIPTION
Reverts aerogear/graphback#1308

This actually caused issue when releasing https://github.com/aerogear/graphback/releases/tag/0.14.0-alpha1 
as the output contained more than the packages under lerna. 

When releasing CI failed with 
```
#!/bin/bash -eo pipefail
TAG=$CIRCLE_TAG npm run release:validate

> graphback-monorepository@1.0.0 release:validate /home/circleci/aerogear/graphback
> ./scripts/validateRelease.sh

package yarn has version un but expected 0.14.0-alpha1
```

More logs here https://circleci.com/gh/aerogear/graphback/4421?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link


The failure was due to the command `yarn lerna --loglevel=silent ls | awk -F ' ' ' ' '{print $1}` outputting 
something like 
```
yarn $ graphback-cli @graphback/codegen-client @graphback/codegen-offix @graphback/codegen-resolvers @graphback/codegen-schema @graphback/core @graphback/keycloak-authz @graphback/runtime-knex @graphback/runtime-mongo @graphback/runtime graphback graphql-migrations graphql-serve Done
```

Notice the `yarn $` at the beginning and `Done` at the end of the output. These inputs messed up the validation phase as `yarn`, `$` and `Done` were treated as packages under lerna. 

My bad for the initial PR. 