### PR TITLE
Fix query builder not using 'in' operator

### DIFF
--- a/packages/graphback-runtime-mongodb/src/queryBuilder.ts
+++ b/packages/graphback-runtime-mongodb/src/queryBuilder.ts
@@ -15,6 +15,7 @@ const operatorMap = {
     lt: '$lt',
     ge: '$gte',
     gt: '$gt',
+    in: '$in',
 }
 
 type OperatorTransform = [string, any][];


### PR DESCRIPTION
The mongodb query builder was not using the 'in' operator, this PR fixes that