### PR TITLE
fix(core): getPrimaryKey is undeterministic

### DIFF
--- a/packages/graphback-core/src/db/getPrimaryKey.ts
+++ b/packages/graphback-core/src/db/getPrimaryKey.ts
@@ -11,6 +11,7 @@ import { parseMetadata } from 'graphql-metadata';
 export function getPrimaryKey(graphqlType: GraphQLObjectType): GraphQLField<any, any> {
   const fields = Object.values(graphqlType.getFields());
 
+  let primaryKeyFromScalarID: GraphQLField<any, any>;
   let primaryKey: GraphQLField<any, any>;
   let primariesCount = 0;
   for (const field of fields) {
@@ -21,13 +22,15 @@ export function getPrimaryKey(graphqlType: GraphQLObjectType): GraphQLField<any,
       primaryKey = field;
       primariesCount += 1;
     } else if (field.name === 'id' && baseType.name === 'ID') {
-      primaryKey = field;
+      primaryKeyFromScalarID = field;
     }
   }
   
   if (primariesCount > 1) {
     throw new Error(`${graphqlType.name} type should not have multiple '@id' annotations.`)
   }
+
+  primaryKey = primaryKey || primaryKeyFromScalarID;
 
   if (!primaryKey) {
     throw new Error(`${graphqlType.name} type has no primary field.`)

--- a/packages/graphback-core/tests/getPrimaryKeyTest.ts
+++ b/packages/graphback-core/tests/getPrimaryKeyTest.ts
@@ -31,16 +31,25 @@ test('should get primary key from @id annotation', () => {
         """
         email: String!
         name: String
-    }`);
+    }
+    
+    """ @model """
+    type Note {
+        """
+        @id
+        """
+        reference: String!
+        id: ID!
+    }
+    `);
 
     const models = getUserTypesFromSchema(schema);
 
-    const userModel = models.find((graphqlType: GraphQLObjectType) => graphqlType.name === 'User');
+    const primaryKeys = models.map(userModel => getPrimaryKey(userModel).name);
 
-    const primaryKey = getPrimaryKey(userModel);
-
-    expect(primaryKey.name).toEqual('email');
+    expect(primaryKeys).toEqual(['email', 'reference']);
 });
+
 
 test('should throw an error if no primary key in model', () => {
     const schema = buildSchema(`


### PR DESCRIPTION
If the model contains a primary key field with `@db` annotation and an id scalar field, the computed
primary key will be different depending on the order of declaration. Fix the issue by making sure
that a primary key with `@db` is of high priority while defaulting to an id scalar field.

Fixes https://github.com/aerogear/graphback/issues/1401