### PR TITLE
fix: postgres 12 issue when running migrations multiple times

### DIFF
--- a/packages/graphql-migrations/src/util/getCheckConstraints.ts
+++ b/packages/graphql-migrations/src/util/getCheckConstraints.ts
@@ -5,7 +5,7 @@ const queries: any = {
     sql: `select
     c.conname as "indexName",
     array_to_string(array_agg(a.attname), ',') as "columnNames",
-    c.consrc as "expression"
+    pg_get_constraintdef(c.oid) as "expression"
   from
     pg_class t,
     pg_constraint c,
@@ -22,7 +22,7 @@ const queries: any = {
   group by
     t.relname,
     c.conname,
-    c.consrc;`,
+    pg_get_constraintdef(c.oid);`,
     bindings: [tableName, schemaName],
     output: (resp: any) => resp.rows.map((row: any) => {
       let values: any;


### PR DESCRIPTION
When checking constraints in postgres 12, the sql query belowed failed
with `column c.consrc does not exist`

```
select
    c.conname as "indexName",
    array_to_string(array_agg(a.attname), ',') as "columnNames",
    c.consrc as "expression"
  from
    pg_class t,
    pg_constraint c,
    pg_namespace n,
    pg_attribute a
  where
    c.conrelid = t.oid
    and n.oid = c.connamespace
    and a.attrelid = t.oid
    and a.attnum = ANY(c.conkey)
    and c.contype = 'c'
    and t.relname = ?
    and n.nspname = ?
  group by
    t.relname,
    c.conname,
    c.consrc;
```

This was because the `consrc` column was removed from the `pg_constraint` table starting from pg 12.

Starting the version 11, https://www.postgresql.org/docs/11/catalog-pg-constraint.html, it is recommended to use pg_get_constraintdef()
to extract the definition of a check constraint.

Fixes https://github.com/aerogear/graphback/issues/1076