### PR TITLE
fix(codegen-schema): can't add field with custom type to model type

### DIFF
--- a/docs/intro/datamodel.md
+++ b/docs/intro/datamodel.md
@@ -51,6 +51,34 @@ type Note {
 }
 ```
 
+Your data models can also contain custom types that are not Graphback models as shown below. 
+However, it is expected that you provide the custom resolvers for your custom type as Graphback will not generate one for you.
+```graphql
+"""
+@model
+"""
+type Note {
+  id: ID!
+  """
+  @id
+  """
+  email: String
+
+  """
+  Field from a custom type that is not a Graphback model
+  """
+  comments: [Comment]
+}
+
+"""
+A custom type
+"""
+type Comment {
+  id: ID!
+  text: String
+}
+```
+
 ## Relationships
 
 Graphback provides support for one-to-many and one-to-one relationships.

--- a/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
+++ b/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
@@ -97,16 +97,33 @@ export const OrderByInputType = new GraphQLInputObjectType({
 })
 
 function getModelInputFields(modelType: GraphQLObjectType): GraphQLInputField[] {
-  return Object.values(modelType.getFields())
-    .filter((f: GraphQLField<any, any>) => !isOneToManyField(f))
-    .map((f: GraphQLField<any, any>) => {
-      return {
-        name: getInputFieldName(f),
-        type: getInputFieldType(f),
-        description: undefined,
-        extensions: []
-      }
-    })
+  const inputFields: GraphQLInputField[] = [];
+  const fields: GraphQLField<any, any>[] = Object.values(modelType.getFields());
+
+  for (const field of fields) {
+    if (isOneToManyField(field)) {
+        continue;
+    }
+
+    const type = getInputFieldType(field);
+
+    if (!type) {
+      continue;
+    }
+
+    const name = getInputFieldName(field);
+
+    const inputField: GraphQLInputField = {
+      name,
+      type,
+      description: undefined,
+      extensions: []
+    }
+
+    inputFields.push(inputField);
+  }
+
+  return inputFields;
 }
 
 export function buildFindOneFieldMap(modelType: GraphQLObjectType): GraphQLInputFieldMap {

--- a/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
+++ b/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
@@ -160,6 +160,10 @@ input CreateTestInput {
   name: String
 }
 
+type CustomType {
+  issue1432: String
+}
+
 scalar DateTime
 
 input DateTimeInput {
@@ -193,6 +197,12 @@ type Issue {
   id: ID!
   category: IssueCategory
   createdAt: DateTime
+
+  \\"\\"\\"
+  Field with custom type added as a fix for https://github.com/aerogear/graphback/issues/1432
+  This shows that a custom type can be added without breaking Graphback schema generation
+  \\"\\"\\"
+  custom: CustomType
 }
 
 enum IssueCategory {
@@ -443,6 +453,10 @@ input CreateTestInput {
   name: String
 }
 
+type CustomType {
+  issue1432: String
+}
+
 scalar DateTime
 
 input DateTimeInput {
@@ -476,6 +490,12 @@ type Issue {
   id: ID!
   category: IssueCategory
   createdAt: DateTime
+
+  \\"\\"\\"
+  Field with custom type added as a fix for https://github.com/aerogear/graphback/issues/1432
+  This shows that a custom type can be added without breaking Graphback schema generation
+  \\"\\"\\"
+  custom: CustomType
 }
 
 enum IssueCategory {
@@ -727,6 +747,10 @@ input CreateTestInput {
   name: String
 }
 
+type CustomType {
+  issue1432: String
+}
+
 scalar DateTime
 
 input DateTimeInput {
@@ -760,6 +784,12 @@ type Issue {
   id: ID!
   category: IssueCategory
   createdAt: DateTime
+
+  \\"\\"\\"
+  Field with custom type added as a fix for https://github.com/aerogear/graphback/issues/1432
+  This shows that a custom type can be added without breaking Graphback schema generation
+  \\"\\"\\"
+  custom: CustomType
 }
 
 enum IssueCategory {

--- a/packages/graphback-codegen-schema/tests/mock.graphql
+++ b/packages/graphback-codegen-schema/tests/mock.graphql
@@ -48,13 +48,22 @@ See issue https://github.com/aerogear/graphback/issues/1299
 type  Issue {
   id: ID!
   category: IssueCategory
-  createdAt: DateTime
+  createdAt: DateTime,
+  """
+  Field with custom type added as a fix for https://github.com/aerogear/graphback/issues/1432
+  This shows that a custom type can be added without breaking Graphback schema generation
+  """
+  custom: CustomType
 }
 
 enum IssueCategory {
  BUG
  QUESTION
  FEATURE_REQUEST
+}
+
+type CustomType {
+  issue1432: String
 }
 
 scalar DateTime


### PR DESCRIPTION
Adding a field with custom type was breaking since the custom type is neither a scalar , enum or a
model type so we cannot really generate the necessary crud bits for it. Let's ignore the field with
undefined type as it is breaking the CRUD bits generation part. `undefined` is returned by this
method
https://github.com/aerogear/graphback/blob/ae5c6d5148877fb7ce6fa622036dcd31ad6b9946/packages/graphback-core/src/crud/mappingHelpers.ts#L159-L173

Fixes https://github.com/aerogear/graphback/issues/1432