### PR TITLE
feat: allow specifying of file name in outputPath option

### DIFF
--- a/docs/plugins/graphback-schema.md
+++ b/docs/plugins/graphback-schema.md
@@ -21,24 +21,14 @@ npm install @graphback/codegen-schema
 
 ### Configuration
 
-`SchemaCRUDPlugin` can be configured to write your generated schema to a file:
+By default `SchemaCRUDPlugin` will not generate any schema file, instead creating an in-memory schema. You might sometimes need the schema file for compatibility with other libraries or frameworks, so Graphback allows you to automate the persistence of the schema to a file in your project:
 
 
 ```ts
   /**
-   * Output format for schema
-   */
-  format: 'ts' | 'js' | 'graphql',
-
-  /**
    * RelativePath for the output files created by generator
    */
   outputPath: string
-
-  /**
-   * Name of the output file (by default `schema`)
-   */
-  outputFileName?: string
 ```
 
 
@@ -47,7 +37,7 @@ npm install @graphback/codegen-schema
 ```ts
   const schemaPlugin = new SchemaCRUDPlugin({
     format: 'graphql',
-    outputPath: './src/schema'
+    outputPath: './src/schema/schema.graphql'
   });
 
   const { schema } = buildGraphbackAPI(modelDefs, {
@@ -57,6 +47,12 @@ npm install @graphback/codegen-schema
     ]
   });
 ```
+
+You can also specify the directory of the schema:
+
+`outputPath: './path/to/schema'`
+
+Graphback will create a file called `schema.graphql` in `./path/to/schema/schema.graphql`.
 
 ## Extending schema using other plugins
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -148,6 +148,16 @@ To use `graphql-serve` now you must use a model file:
 gqls serve ./path/to/models/*.graphql --port 8080
 ```
 
+#### SchemaCRUDPlugin only has a single configuration option
+
+We have removed the `fileName` and `format` options from `SchemaCRUDPlugin`. These can be inferred from the `outputPath`:
+
+```ts
+const schemaPlugin = new SchemaCRUDPlugin({
+  outputPath: './path/to/my/schema.js'
+});
+```
+
 ### Deprecated
 
 - `PgKnexDBDataProvider` has been deprecated in favour of `KnexDBDataProvider`.
@@ -160,6 +170,7 @@ gqls serve ./path/to/models/*.graphql --port 8080
 - Added a new, simpler runtime API
 - GraphbackPluginEngine accepts now object instead of arguments.
 `new GraphbackPluginEngine({schema})`
+- Provide full path to schema in the `SchemaCRUDPlugin` config option `outputPath`
 
 # 0.13.0
 

--- a/integration/.graphqlrc.yml
+++ b/integration/.graphqlrc.yml
@@ -17,9 +17,6 @@ extensions:
       subDelete: true
     ## Codegen plugins
     plugins:
-        graphback-schema:
-          format: 'graphql'
-          outputPath: ./output/schema
         graphback-client:
           format: 'graphql'
           outputFile: './output/client/graphback.graphql'

--- a/integration/.vscode/launch.json
+++ b/integration/.vscode/launch.json
@@ -1,23 +1,26 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Jest All",
-            "program": "${workspaceFolder}/node_modules/.bin/jest",
-            "args": [
-                "--runInBand"
-            ],
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "disableOptimisticBPs": true,
-            "windows": {
-                "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-            }
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest All",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": [
+        "--runInBand"
+      ],
+      "env": {
+        "PORT": "55432"
+      },
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      }
+    }
+  ]
 }

--- a/packages/graphback-codegen-schema/tests/GraphQLSchemaCreatorTest.ts
+++ b/packages/graphback-codegen-schema/tests/GraphQLSchemaCreatorTest.ts
@@ -18,7 +18,7 @@ test('Test snapshot config gql', async () => {
   }
 
 
-  const schemaGenerator = new SchemaCRUDPlugin({ format: 'graphql', outputPath: './tmp' })
+  const schemaGenerator = new SchemaCRUDPlugin()
   const metadata = new GraphbackCoreMetadata({
     crudMethods: defautConfig
   }, buildSchema(schemaText))
@@ -40,7 +40,7 @@ test('Test snapshot config ts', async () => {
   }
 
 
-  const schemaGenerator = new SchemaCRUDPlugin({ format: 'ts', outputPath: './tmp' })
+  const schemaGenerator = new SchemaCRUDPlugin()
   const metadata = new GraphbackCoreMetadata({
     crudMethods: defautConfig
   }, buildSchema(schemaText))
@@ -62,7 +62,7 @@ test('Test snapshot config js', async () => {
   }
 
 
-  const schemaGenerator = new SchemaCRUDPlugin({ format: 'js', outputPath: './tmp' })
+  const schemaGenerator = new SchemaCRUDPlugin()
   const metadata = new GraphbackCoreMetadata({
     crudMethods: defautConfig
   }, buildSchema(schemaText))
@@ -103,7 +103,7 @@ test('Test one side relationship schema query type generation', async () => {
   `;
 
   const oneSidedSchema = buildSchema(schemaText);
-  const schemaGenerator = new SchemaCRUDPlugin({ format: 'graphql', outputPath: './tmp' })
+  const schemaGenerator = new SchemaCRUDPlugin()
   const metadata = new GraphbackCoreMetadata({
     crudMethods: defautConfig
   }, oneSidedSchema)

--- a/packages/graphback-datasync/tests/DataSyncMongoDBTests.ts
+++ b/packages/graphback-datasync/tests/DataSyncMongoDBTests.ts
@@ -33,7 +33,7 @@ export async function createTestingContext(schemaStr: string, config?: { seedDat
     "subDelete": true
   }
 
-  const schemaGenerator = new SchemaCRUDPlugin({ outputPath: './tmp', format: 'graphql' })
+  const schemaGenerator = new SchemaCRUDPlugin()
   const DataSyncGenerator = new DataSyncPlugin()
   const metadata = new GraphbackCoreMetadata({
     crudMethods: defautConfig
@@ -165,7 +165,7 @@ describe('Soft deletion test', () => {
     const updateTime = 1590679887032;
     advanceTo(startTime);
     const { id } = await Post.create({ text: 'TestPost' });
-    
+
     // Update document once
     advanceTo(updateTime);
     await Post.update({ id, text: 'updated post text', updatedAt: startTime });

--- a/packages/graphback-runtime-mongodb/tests/__util__.ts
+++ b/packages/graphback-runtime-mongodb/tests/__util__.ts
@@ -30,7 +30,7 @@ export async function createTestingContext(schemaStr: string, config?: { seedDat
     "subDelete": true
   }
 
-  const schemaGenerator = new SchemaCRUDPlugin({ outputPath: './tmp', format: 'graphql' })
+  const schemaGenerator = new SchemaCRUDPlugin()
   const metadata = new GraphbackCoreMetadata({
     crudMethods: defautConfig
   }, schema)


### PR DESCRIPTION
Fixes #1512 

## Description

This change allows the specifying of the schema in a single config option, `outputPath`:

```ts
const schemaPlugin = new SchemaCRUDPlugin({
  outputPath: './path/to/my/schema.js'
});
```

You can still let graphback create a default file type with:

```ts
const schemaPlugin = new SchemaCRUDPlugin({
  outputPath: './path/to/schema'
});
```

This creates `/path/to/schema/schema.graphql`

This is a breaking change because it removed the `format` and `outputFileName` options.