### PR TITLE
chore: make codegen-schema as prod deps in datasync plugin

### DIFF
--- a/packages/graphback-datasync/package.json
+++ b/packages/graphback-datasync/package.json
@@ -23,7 +23,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@graphback/codegen-schema": "0.14.0-alpha4",
     "@types/jest": "26.0.0",
     "@types/node": "12.12.47",
     "graphql": "15.1.0",
@@ -37,6 +36,7 @@
     "typescript": "3.9.5"
   },
   "dependencies": {
+    "@graphback/codegen-schema": "0.14.0-alpha4",
     "@graphback/core": "0.14.0-alpha4",
     "@graphback/runtime": "0.14.0-alpha4",
     "@graphback/runtime-knex": "0.14.0-alpha4",


### PR DESCRIPTION
required by https://github.com/aerogear/graphback/blob/f95b40e611c46b8e10b61f6ae771aa15833a0cce/packages/graphback-datasync/src/DataSyncPlugin.ts#L3