### PR TITLE
fix(cli): Cannot find module 'graphql'

### DIFF
--- a/packages/graphback-cli/src/config/graphbackExtension.ts
+++ b/packages/graphback-cli/src/config/graphbackExtension.ts
@@ -1,5 +1,5 @@
 import { CodeFileLoader } from '@graphql-toolkit/code-file-loader';
-import { GraphQLExtensionDeclaration, loadConfig } from 'graphql-config';
+import { GraphQLExtensionDeclaration } from 'graphql-config';
 
 
 export const graphbackExtension = 'graphback';

--- a/packages/graphback-cli/src/index.ts
+++ b/packages/graphback-cli/src/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import * as yargs from 'yargs';
-export * from './components'
 export * from './config/graphbackExtension'
 
 if (require.main === module) {

--- a/packages/graphback-cli/src/index.ts
+++ b/packages/graphback-cli/src/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import * as yargs from 'yargs';
-export * from './config/graphbackExtension'
 
 if (require.main === module) {
   // eslint-disable-next-line no-unused-expressions


### PR DESCRIPTION
Fixes #1530 

`graphback-cli` exported all code from the `generate` command, which requires `graphql`.

This meant that the CLI would not work from any directory which is required for `init`.

To verify, run this command from a folder outside of Graphback (eg: $HOME)

Run `node <path/to/graphback>/packages/graphback-cli/dist/index.js init test`

It should work.