### PR TITLE
fix(core): return resolvers as object

### DIFF
--- a/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
+++ b/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { GraphQLInputObjectType, GraphQLList, GraphQLBoolean, GraphQLInt, GraphQLString, GraphQLID, GraphQLEnumType, GraphQLObjectType, GraphQLNonNull, GraphQLField, getNamedType, isScalarType, GraphQLInputFieldMap, GraphQLScalarType, GraphQLNamedType, GraphQLInputField, isSpecifiedScalarType, isEnumType } from "graphql";
+import { GraphQLInputObjectType, GraphQLList, GraphQLBoolean, GraphQLInt, GraphQLString, GraphQLID, GraphQLEnumType, GraphQLObjectType, GraphQLNonNull, GraphQLField, getNamedType, isScalarType, GraphQLInputFieldMap, GraphQLScalarType, GraphQLNamedType, GraphQLInputField, isEnumType } from "graphql";
 import { GraphbackOperationType, getInputTypeName, getInputFieldName, getInputFieldType, isOneToManyField, getPrimaryKey, metadataMap } from '@graphback/core';
 
 const PageRequestTypeName = 'PageRequest';

--- a/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
+++ b/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
@@ -1,73 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Creates CRUD resolvers for models 1`] = `
-Array [
-  Object {
-    "Comment": Object {
-      "noteComment": [Function],
+Object {
+  "Comment": Object {
+    "noteComment": [Function],
+  },
+  "Fix": Object {
+    "issues": [Function],
+  },
+  "Issue": Object {
+    "bugFix": [Function],
+  },
+  "Mutation": Object {
+    "createComment": [Function],
+    "createFix": [Function],
+    "createIssue": [Function],
+    "createNote": [Function],
+    "createTest": [Function],
+    "deleteComment": [Function],
+    "deleteNote": [Function],
+    "deleteTest": [Function],
+    "updateComment": [Function],
+    "updateNote": [Function],
+    "updateTest": [Function],
+  },
+  "Note": Object {
+    "comments": [Function],
+    "test": [Function],
+  },
+  "Query": Object {
+    "findComments": [Function],
+    "findNotes": [Function],
+    "findTests": [Function],
+    "getComment": [Function],
+    "getNote": [Function],
+    "getTest": [Function],
+  },
+  "Subscription": Object {
+    "deletedComment": Object {
+      "subscribe": [Function],
     },
-    "Fix": Object {
-      "issues": [Function],
+    "deletedNote": Object {
+      "subscribe": [Function],
     },
-    "Issue": Object {
-      "bugFix": [Function],
+    "deletedTest": Object {
+      "subscribe": [Function],
     },
-    "Mutation": Object {
-      "createComment": [Function],
-      "createFix": [Function],
-      "createIssue": [Function],
-      "createNote": [Function],
-      "createTest": [Function],
-      "deleteComment": [Function],
-      "deleteNote": [Function],
-      "deleteTest": [Function],
-      "updateComment": [Function],
-      "updateNote": [Function],
-      "updateTest": [Function],
+    "newComment": Object {
+      "subscribe": [Function],
     },
-    "Note": Object {
-      "comments": [Function],
-      "test": [Function],
+    "newNote": Object {
+      "subscribe": [Function],
     },
-    "Query": Object {
-      "findComments": [Function],
-      "findNotes": [Function],
-      "findTests": [Function],
-      "getComment": [Function],
-      "getNote": [Function],
-      "getTest": [Function],
+    "newTest": Object {
+      "subscribe": [Function],
     },
-    "Subscription": Object {
-      "deletedComment": Object {
-        "subscribe": [Function],
-      },
-      "deletedNote": Object {
-        "subscribe": [Function],
-      },
-      "deletedTest": Object {
-        "subscribe": [Function],
-      },
-      "newComment": Object {
-        "subscribe": [Function],
-      },
-      "newNote": Object {
-        "subscribe": [Function],
-      },
-      "newTest": Object {
-        "subscribe": [Function],
-      },
-      "updatedComment": Object {
-        "subscribe": [Function],
-      },
-      "updatedNote": Object {
-        "subscribe": [Function],
-      },
-      "updatedTest": Object {
-        "subscribe": [Function],
-      },
+    "updatedComment": Object {
+      "subscribe": [Function],
+    },
+    "updatedNote": Object {
+      "subscribe": [Function],
+    },
+    "updatedTest": Object {
+      "subscribe": [Function],
     },
   },
-]
+}
 `;
 
 exports[`Test one side relationship schema query type generation 1`] = `

--- a/packages/graphback-core/package.json
+++ b/packages/graphback-core/package.json
@@ -42,6 +42,7 @@
     "graphql-compose": "7.18.1",
     "graphql-fields-list": "2.1.3",
     "graphql-metadata": "0.7.0",
+    "@graphql-tools/merge": "6.0.10",
     "pino": "6.3.2",
     "pluralize": "8.0.0",
     "dataloader": "2.0.0",

--- a/packages/graphback/tests/buildGraphbackAPITest.ts
+++ b/packages/graphback/tests/buildGraphbackAPITest.ts
@@ -1,7 +1,8 @@
-/* eslint-disable import/no-extraneous-dependencies */
-import { createKnexDbProvider } from '@graphback/runtime-knex'
+// eslint-disable-next-line import/no-extraneous-dependencies
 import * as Knex from 'knex'
-import { buildGraphbackAPI, CRUDService } from '../src'
+import { createKnexDbProvider } from '../../graphback-runtime-knex/src'
+import { buildGraphbackAPI } from '../src'
+import { CRUDService } from '../../graphback-core/src'
 import { DataSyncPlugin } from '../../graphback-datasync/src/DataSyncPlugin'
 
 describe('buildGraphbackAPI', () => {
@@ -35,7 +36,7 @@ describe('buildGraphbackAPI', () => {
       dataProviderCreator: createKnexDbProvider(db)
     })
 
-    const { Query, Subscription, Mutation } = resolvers[0]
+    const { Query, Subscription, Mutation } = resolvers
     expect(Object.keys(Query)).toEqual(['getNote', 'findNotes'])
     expect(Object.keys(Subscription)).toEqual(['newNote', 'updatedNote', 'deletedNote'])
     expect(Object.keys(Mutation)).toEqual(['createNote', 'updateNote', 'deleteNote'])
@@ -74,7 +75,7 @@ describe('buildGraphbackAPI', () => {
       }
     })
 
-    const { Query, Mutation } = resolvers[0]
+    const { Query, Mutation } = resolvers
     expect(Object.keys(Query)).toEqual(['findNotes', 'getComment'])
     expect(Object.keys(Mutation)).toEqual(['createNote', 'createComment', 'deleteComment'])
   })
@@ -100,7 +101,7 @@ describe('buildGraphbackAPI', () => {
       }
     })
 
-    const { Subscription } = resolvers[0]
+    const { Subscription } = resolvers
     expect(Object.keys(Subscription)).toEqual(['newNote', 'updatedNote'])
   })
 
@@ -125,7 +126,7 @@ describe('buildGraphbackAPI', () => {
       }
     })
 
-    const { Subscription } = resolvers[0]
+    const { Subscription } = resolvers
     expect(Object.keys(Subscription)).toEqual(['updatedNote', 'deletedNote'])
   })
 
@@ -150,7 +151,7 @@ describe('buildGraphbackAPI', () => {
       }
     })
 
-    const { Subscription } = resolvers[0]
+    const { Subscription } = resolvers
     expect(Object.keys(Subscription)).toEqual(['newNote', 'deletedNote'])
   })
 


### PR DESCRIPTION
Fixes #1546 #1556 

Returns resolvers as an object instead of an array.