### PR TITLE
feat: support create/update of embedded JSON objects

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -18,7 +18,7 @@ Graphback 0.14 contains a lot of breaking changes that will improve and simplify
 
 #### Changed annotation syntax
 
-All annotations now use a uniform syntax format: `@annotation(foo 'bar') that is similar to GraphQL Directives`
+All annotations now use a uniform syntax format: `@annotation(foo 'bar')` that is similar to GraphQL Directives
 
 Examples:
 

--- a/integration/mock.graphql
+++ b/integration/mock.graphql
@@ -7,6 +7,10 @@ type Note {
   @oneToMany(field: 'note')
   """
   comments: [Comment]!
+
+  """
+  @db(type:'json')
+  """
   tasks: [Task]!
 }
 

--- a/integration/mock.graphql
+++ b/integration/mock.graphql
@@ -7,6 +7,7 @@ type Note {
   @oneToMany(field: 'note')
   """
   comments: [Comment]!
+  tasks: [Task]!
 }
 
 """ @model """
@@ -26,6 +27,10 @@ type Comment {
 type CommentMetadata {
   id: ID!
   opened: Boolean
+}
+
+type Task {
+  title: String
 }
 
 type Query {

--- a/integration/tests/__snapshots__/runtime-workflow-postgres.ts.snap
+++ b/integration/tests/__snapshots__/runtime-workflow-postgres.ts.snap
@@ -46,6 +46,20 @@ Object {
           "nullable": true,
           "type": "string",
         },
+        "tasks" => Object {
+          "annotations": Object {
+            "type": "json",
+          },
+          "args": Array [],
+          "autoIncrementable": false,
+          "comment": undefined,
+          "defaultValue": undefined,
+          "foreign": undefined,
+          "isPrimaryKey": false,
+          "name": "tasks",
+          "nullable": false,
+          "type": "json",
+        },
       },
       "columns": Array [
         Object {
@@ -87,6 +101,20 @@ Object {
           "name": "description",
           "nullable": true,
           "type": "string",
+        },
+        Object {
+          "annotations": Object {
+            "type": "json",
+          },
+          "args": Array [],
+          "autoIncrementable": false,
+          "comment": undefined,
+          "defaultValue": undefined,
+          "foreign": undefined,
+          "isPrimaryKey": false,
+          "name": "tasks",
+          "nullable": false,
+          "type": "json",
         },
       ],
       "comment": undefined,
@@ -357,6 +385,20 @@ Object {
           "nullable": true,
           "type": "string",
         },
+        "tasks" => Object {
+          "annotations": Object {
+            "type": "json",
+          },
+          "args": Array [],
+          "autoIncrementable": false,
+          "comment": undefined,
+          "defaultValue": undefined,
+          "foreign": undefined,
+          "isPrimaryKey": false,
+          "name": "tasks",
+          "nullable": false,
+          "type": "json",
+        },
       },
       "columns": Array [
         Object {
@@ -398,6 +440,20 @@ Object {
           "name": "description",
           "nullable": true,
           "type": "string",
+        },
+        Object {
+          "annotations": Object {
+            "type": "json",
+          },
+          "args": Array [],
+          "autoIncrementable": false,
+          "comment": undefined,
+          "defaultValue": undefined,
+          "foreign": undefined,
+          "isPrimaryKey": false,
+          "name": "tasks",
+          "nullable": false,
+          "type": "json",
         },
       ],
       "comment": undefined,

--- a/integration/tests/runtime-workflow-mongo.ts
+++ b/integration/tests/runtime-workflow-mongo.ts
@@ -42,8 +42,8 @@ beforeAll(async () => {
     graphbackApi = buildGraphbackAPI(modelText, {
       dataProviderCreator: createMongoDbProvider(db),
       plugins: [
-        new SchemaCRUDPlugin({outputPath: "./output-mongo/schema/schema.graphql"}),
-        new ClientCRUDPlugin({format: 'graphql', outputFile: './output-mongo/client/graphback.graphql'})
+        new SchemaCRUDPlugin({ outputPath: "./output-mongo/schema/schema.graphql" }),
+        new ClientCRUDPlugin({ format: 'graphql', outputFile: './output-mongo/client/graphback.graphql' })
       ]
     });
 
@@ -89,7 +89,15 @@ async function seedDatabase(db: Db) {
     },
     {
       title: 'Note B',
-      description: 'Note B Description'
+      description: 'Note B Description',
+      tasks: [
+        {
+          title: 'Task 1'
+        },
+        {
+          title: 'Task 2'
+        }
+      ]
     }
   ]
 
@@ -108,7 +116,7 @@ async function seedDatabase(db: Db) {
   ]
 
   for (const metadata of commentMetadata) {
-    const {ops} = await db.collection('commentmetadata').insertOne(metadata);
+    const { ops } = await db.collection('commentmetadata').insertOne(metadata);
     metadataId.push(ops[0]._id.toString());
   }
 
@@ -127,24 +135,10 @@ async function seedDatabase(db: Db) {
     }
   ]
 
-  for (const comment of comments)  {
-    const {ops} = await db.collection('comment').insertOne(comment);
+  for (const comment of comments) {
+    const { ops } = await db.collection('comment').insertOne(comment);
     commentId.push(ops[0]._id.toString())
   }
-}
-
-const getConfig = async () => {
-  const config = await loadConfig({
-    rootDir: process.cwd(),
-    extensions: [
-      () => ({ name: 'graphback' })
-    ]
-  });
-
-  const projectConfig = config.getDefault();
-  const graphbackConfig = projectConfig.extension('graphback');
-
-  return { projectConfig, graphbackConfig };
 }
 
 test('Find all notes', async () => {
@@ -174,7 +168,15 @@ test('Find all notes', async () => {
         id: notesId[1],
         title: 'Note B',
         description: 'Note B Description',
-        comments: []
+        comments: [],
+        tasks: [
+          {
+            title: 'Task 1'
+          },
+          {
+            title: 'Task 2'
+          }
+        ]
       }
     ],
     limit: null,

--- a/integration/tests/runtime-workflow-postgres.ts
+++ b/integration/tests/runtime-workflow-postgres.ts
@@ -94,19 +94,20 @@ async function seedDatabase(db: Knex) {
   await db('note').insert([
     {
       title: 'Note A',
-      description: 'Note A Description'
+      description: 'Note A Description',
+      tasks: JSON.stringify([])
     },
     {
       title: 'Note B',
       description: 'Note B Description',
-      tasks: [
+      tasks: JSON.stringify([
         {
           title: 'Task 1'
         },
         {
           title: 'Task 2'
         }
-      ]
+      ])
     }
   ]);
 
@@ -194,7 +195,15 @@ test('Find all notes except the first', async () => {
         id: '2',
         title: 'Note B',
         description: 'Note B Description',
-        comments: []
+        comments: [],
+        tasks: [
+          {
+            title: 'Task 1'
+          },
+          {
+            title: 'Task 2'
+          }
+        ]
       }
     ],
     limit: null,
@@ -217,6 +226,7 @@ test('Find at most one note', async () => {
         id: '1',
         title: 'Note A',
         description: 'Note A Description',
+        tasks: [],
         comments: [
           {
             id: '1',
@@ -281,11 +291,12 @@ test('Find all comments', async () => {
 test('Note 1 should be defined', async () => {
   const response = await getNote('1', client);
   expect(response.data).toBeDefined();
-  const notes = response.data.getNote;
-  expect(notes).toEqual({
+  const note = response.data.getNote;
+  expect(note).toEqual({
     id: '1',
     title: 'Note A',
     description: 'Note A Description',
+    tasks: [],
     comments: [
       {
         id: '1',
@@ -369,9 +380,12 @@ test('Should update Note 1 title', async () => {
 });
 
 test('Should create a new Note', async () => {
-  const response = await createNote(client, { title: 'New note', description: 'New note description' });
+  const response = await createNote(client, { title: 'New note', description: 'New note description', tasks: [{ title: "new task title" }] });
   expect(response.data).toBeDefined();
   expect(response.data.createNote).toEqual({ id: '3', title: 'New note', description: 'New note description' });
+
+  const { data } = await getNote('3', client);
+  expect(data.getNote.tasks).toEqual([{ title: "new task title" }]);
 })
 
 test('Delete Note 1', async () => {
@@ -414,16 +428,6 @@ async function getNote(id: string | number, client: ApolloServerTestClient) {
     operationName: "getNote",
     query: documents,
     variables: { id }
-  });
-
-  return response;
-}
-
-async function findNoteComments(noteId: string, client: ApolloServerTestClient) {
-  const response = await client.query({
-    operationName: "findComments",
-    query: documents,
-    variables: { filter: { noteId } }
   });
 
   return response;

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -725,6 +725,8 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
       const namedType = tc.getType();
       if (isScalarType(namedType) && !isSpecifiedScalarType(namedType) && !isSpecifiedGraphbackScalarType(namedType)) {
         schemaComposer.add(createInputTypeForScalar(namedType));
+
+        return;
       }
 
       const isRootType = ['Query', 'Subscription', 'Mutation'].includes(namedType.name)

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -727,7 +727,8 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
         schemaComposer.add(createInputTypeForScalar(namedType));
       }
 
-      if (isObjectType(namedType) && !isModelType(namedType)) {
+      const isRootType = ['Query', 'Subscription', 'Mutation'].includes(namedType.name)
+      if (isObjectType(namedType) && !isModelType(namedType) && !isRootType) {
         addCreateObjectInputType(schemaComposer, namedType)
         addUpdateObjectInputType(schemaComposer, namedType)
       }

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -1,13 +1,13 @@
 /* eslint-disable max-lines */
-import { existsSync, mkdirSync, writeFileSync, fstat } from 'fs';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { resolve, dirname, join } from 'path';
-import { getFieldName, metadataMap, printSchemaWithDirectives, getSubscriptionName, GraphbackCoreMetadata, GraphbackOperationType, GraphbackPlugin, ModelDefinition, buildGeneratedRelationshipsFieldObject, buildModifiedRelationshipsFieldObject, buildRelationshipFilterFieldMap, getInputTypeName, FieldRelationshipMetadata, getPrimaryKey, GraphbackContext, getSelectedFieldsFromResolverInfo } from '@graphback/core'
-import { GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLInt, GraphQLFloat, isScalarType, isSpecifiedScalarType, GraphQLResolveInfo } from 'graphql';
+import { getFieldName, metadataMap, printSchemaWithDirectives, getSubscriptionName, GraphbackCoreMetadata, GraphbackOperationType, GraphbackPlugin, ModelDefinition, buildGeneratedRelationshipsFieldObject, buildModifiedRelationshipsFieldObject, buildRelationshipFilterFieldMap, getInputTypeName, FieldRelationshipMetadata, getPrimaryKey, GraphbackContext, getSelectedFieldsFromResolverInfo, isModelType, isSpecifiedGraphbackScalarType } from '@graphback/core'
+import { GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLInt, GraphQLFloat, isScalarType, isSpecifiedScalarType, GraphQLResolveInfo, isObjectType } from 'graphql';
 import { SchemaComposer, NamedTypeComposer } from 'graphql-compose';
 import { IResolvers, IFieldResolver } from '@graphql-tools/utils'
 import { parseMetadata } from "graphql-metadata";
 import { gqlSchemaFormatter, jsSchemaFormatter, tsSchemaFormatter } from './writer/schemaFormatters';
-import { buildFilterInputType, createModelListResultType, StringScalarInputType, BooleanScalarInputType, SortDirectionEnum, buildCreateMutationInputType, buildFindOneFieldMap, buildMutationInputType, OrderByInputType, buildSubscriptionFilterType, IDScalarInputType, PageRequest, createInputTypeForScalar, createVersionedFields,createVersionedInputFields } from './definitions/schemaDefinitions';
+import { buildFilterInputType, createModelListResultType, StringScalarInputType, BooleanScalarInputType, SortDirectionEnum, buildCreateMutationInputType, buildFindOneFieldMap, buildMutationInputType, OrderByInputType, buildSubscriptionFilterType, IDScalarInputType, PageRequest, createInputTypeForScalar, createVersionedFields,createVersionedInputFields, addCreateObjectInputType, addUpdateObjectInputType, JSONScalarInputType } from './definitions/schemaDefinitions';
 
 /**
  * Configuration for Schema generator CRUD plugin
@@ -153,38 +153,50 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const modelTC = schemaComposer.getOTC(name)
     const modelType = modelTC.getType()
 
-    const subFilterInputType = buildSubscriptionFilterType(modelType);
+    buildSubscriptionFilterType(schemaComposer, modelType);
 
     const subscriptionFields = {}
     if (model.crudOptions.subCreate && model.crudOptions.create) {
       const operation = getSubscriptionName(name, GraphbackOperationType.CREATE)
+
+      const filterInputName = getInputTypeName(name, GraphbackOperationType.SUBSCRIPTION_CREATE)
+      const subCreateFilterInputType = schemaComposer.getITC(filterInputName).getType()
+
       subscriptionFields[operation] = {
         type: GraphQLNonNull(modelType),
         args: {
           filter: {
-            type: subFilterInputType,
+            type: subCreateFilterInputType,
           },
         }
       };
     }
     if (model.crudOptions.subUpdate && model.crudOptions.update) {
       const operation = getSubscriptionName(name, GraphbackOperationType.UPDATE)
+
+      const filterInputName = getInputTypeName(name, GraphbackOperationType.SUBSCRIPTION_UPDATE)
+      const subUpdateFilterInputType = schemaComposer.getITC(filterInputName).getType()
+
       subscriptionFields[operation] = {
         type: GraphQLNonNull(modelType),
         args: {
           filter: {
-            type: subFilterInputType,
+            type: subUpdateFilterInputType,
           },
         }
       };
     }
     if (model.crudOptions.subDelete && model.crudOptions.delete) {
       const operation = getSubscriptionName(name, GraphbackOperationType.DELETE)
+
+      const filterInputName = getInputTypeName(name, GraphbackOperationType.SUBSCRIPTION_DELETE)
+      const subDeleteFilterInputType = schemaComposer.getITC(filterInputName).getType()
+
       subscriptionFields[operation] = {
         type: GraphQLNonNull(modelType),
         args: {
           filter: {
-            type: subFilterInputType,
+            type: subDeleteFilterInputType,
           },
         }
       };
@@ -227,38 +239,55 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const modelTC = schemaComposer.getOTC(name)
     const modelType = modelTC.getType()
 
-    const mutationInput = buildMutationInputType(modelType)
+    buildMutationInputType(schemaComposer, modelType)
 
     const mutationFields = {}
     if (model.crudOptions.create) {
-      const operation = getFieldName(name, GraphbackOperationType.CREATE)
+      const operationType = GraphbackOperationType.CREATE
+
+      buildCreateMutationInputType(schemaComposer, modelType)
+
+      const inputTypeName = getInputTypeName(name, operationType)
+      const createMutationInputType = schemaComposer.getITC(inputTypeName).getType()
+
+      const operation = getFieldName(name, operationType)
       mutationFields[operation] = {
         type: GraphQLNonNull(model.graphqlType),
         args: {
           input: {
-            type: GraphQLNonNull(buildCreateMutationInputType(modelType))
+            type: GraphQLNonNull(createMutationInputType)
           },
         }
       };
     }
     if (model.crudOptions.update) {
-      const operation = getFieldName(name, GraphbackOperationType.UPDATE)
+      const operationType = GraphbackOperationType.UPDATE
+      const operation = getFieldName(name, operationType)
+
+      const inputTypeName = getInputTypeName(name, operationType)
+      const updateMutationInputType = schemaComposer.getITC(inputTypeName).getType()
+
       mutationFields[operation] = {
         type: GraphQLNonNull(modelType),
         args: {
           input: {
-            type: GraphQLNonNull(mutationInput)
+            type: GraphQLNonNull(updateMutationInputType)
           },
         }
       };
     }
     if (model.crudOptions.delete) {
-      const operation = getFieldName(name, GraphbackOperationType.DELETE)
+      const operationType = GraphbackOperationType.DELETE
+      const operation = getFieldName(name, operationType)
+
+      const inputTypeName = getInputTypeName(name, operationType)
+      const deleteMutationInputType = schemaComposer.getITC(inputTypeName).getType()
+
       mutationFields[operation] = {
         type: GraphQLNonNull(model.graphqlType),
         args: {
           input: {
-            type: GraphQLNonNull(mutationInput)
+            type: GraphQLNonNull(deleteMutationInputType)
           }
         }
       };
@@ -271,8 +300,9 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const name = model.graphqlType.name;
     const modelTC = schemaComposer.getOTC(name)
     const modelType = modelTC.getType()
-    const filterInputType = buildFilterInputType(modelType);
-    schemaComposer.add(filterInputType);
+
+    buildFilterInputType(schemaComposer, modelType);
+
     const queryFields = {}
     if (model.crudOptions.findOne) {
       const operation = getFieldName(name, GraphbackOperationType.FIND_ONE)
@@ -282,8 +312,13 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
       };
     }
     if (model.crudOptions.find) {
-      const operation = getFieldName(name, GraphbackOperationType.FIND)
+      const operationType = GraphbackOperationType.FIND
+      const operation = getFieldName(name, operationType)
+
+      const inputTypeName = getInputTypeName(name, operationType)
+      const filterInputType = schemaComposer.getITC(inputTypeName).getType()
       const resultListType = createModelListResultType(modelType)
+
       queryFields[operation] = {
         type: GraphQLNonNull(resultListType),
         args: {
@@ -315,7 +350,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
 
         modelTC.addFields(metadataFields);
 
-        const inputType = schemaComposer.getITC(getInputTypeName(model.graphqlType.name, GraphbackOperationType.FIND))
+        const inputType = schemaComposer.getITC(getInputTypeName(name, GraphbackOperationType.FIND))
         if (inputType) {
           const metadataInputFields = createVersionedInputFields();
           inputType.addFields(metadataInputFields);
@@ -682,13 +717,19 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     schemaComposer.add(SortDirectionEnum);
     schemaComposer.add(StringScalarInputType);
     schemaComposer.add(BooleanScalarInputType);
+    schemaComposer.add(JSONScalarInputType);
     schemaComposer.add(createInputTypeForScalar(GraphQLInt));
     schemaComposer.add(createInputTypeForScalar(GraphQLFloat));
 
     schemaComposer.forEach((tc: NamedTypeComposer<any>) => {
       const namedType = tc.getType();
-      if (isScalarType(namedType) && !isSpecifiedScalarType(namedType)) {
+      if (isScalarType(namedType) && !isSpecifiedScalarType(namedType) && !isSpecifiedGraphbackScalarType(namedType)) {
         schemaComposer.add(createInputTypeForScalar(namedType));
+      }
+
+      if (isObjectType(namedType) && !isModelType(namedType)) {
+        addCreateObjectInputType(schemaComposer, namedType)
+        addUpdateObjectInputType(schemaComposer, namedType)
       }
     });
   }

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { resolve, dirname, join } from 'path';
-import { getFieldName, metadataMap, printSchemaWithDirectives, getSubscriptionName, GraphbackCoreMetadata, GraphbackOperationType, GraphbackPlugin, ModelDefinition, buildGeneratedRelationshipsFieldObject, buildModifiedRelationshipsFieldObject, buildRelationshipFilterFieldMap, getInputTypeName, FieldRelationshipMetadata, getPrimaryKey, GraphbackContext, getSelectedFieldsFromResolverInfo, isModelType, isSpecifiedGraphbackScalarType } from '@graphback/core'
+import { getFieldName, metadataMap, printSchemaWithDirectives, getSubscriptionName, GraphbackCoreMetadata, GraphbackOperationType, GraphbackPlugin, ModelDefinition, buildGeneratedRelationshipsFieldObject, buildModifiedRelationshipsFieldObject, buildRelationshipFilterFieldMap, getInputTypeName, FieldRelationshipMetadata, GraphbackContext, getSelectedFieldsFromResolverInfo, isModelType, isSpecifiedGraphbackScalarType, getPrimaryKey } from '@graphback/core'
 import { GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLInt, GraphQLFloat, isScalarType, isSpecifiedScalarType, GraphQLResolveInfo, isObjectType } from 'graphql';
 import { SchemaComposer, NamedTypeComposer } from 'graphql-compose';
 import { IResolvers, IFieldResolver } from '@graphql-tools/utils'
@@ -568,8 +568,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const modelType = model.graphqlType
     const modelName = modelType.name;
     const findOneField = getFieldName(modelName, GraphbackOperationType.FIND_ONE);
-
-    const primaryKeyLabel = getPrimaryKey(modelType).name;
+    const primaryKeyLabel = model.primaryKey;
 
     queryObj[findOneField] = (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo ) => {
       if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
@@ -658,7 +657,6 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
    */
   protected addOneToManyResolver(relationship: FieldRelationshipMetadata, resolverObj: IResolvers, modelNameToModelDefinition: any) {
     const modelName = relationship.relationType.name;
-    const relationIdField = getPrimaryKey(relationship.relationType);
     const relationOwner = relationship.ownerField.name;
     const model = modelNameToModelDefinition[modelName];
 
@@ -676,7 +674,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
 
       return context.graphback.services[modelName].batchLoadData(
         relationship.relationForeignKey,
-        parent[relationIdField.name],
+        parent[model.primaryKey],
         args.filter,
         {...context, graphback}
       );

--- a/packages/graphback-codegen-schema/src/definitions/copyWrappingType.ts
+++ b/packages/graphback-codegen-schema/src/definitions/copyWrappingType.ts
@@ -1,0 +1,35 @@
+import { isWrappingType, GraphQLNonNull, isListType, GraphQLList, GraphQLType, getNamedType } from 'graphql';
+
+type WrappingType = 'GraphQLList' | 'GraphQLNonNull'
+
+/**
+ * Copies the wrapping type(s) from one GraphQLType to another
+ *
+ * @param {GraphQLType} copyFromType - Get the wrapping types from this type
+ * @param {GraphQLType} copyToType - Add the wrapping types to this type
+ */
+export function copyWrappingType(copyFromType: GraphQLType, copyToType: GraphQLType): GraphQLType {
+  const wrappers: WrappingType[] = []
+
+  let oldTypeCopy = copyFromType
+  while (isWrappingType(oldTypeCopy)) {
+    if (isListType(oldTypeCopy)) {
+      wrappers.push('GraphQLList')
+    } else {
+      wrappers.push('GraphQLNonNull')
+    }
+    oldTypeCopy = oldTypeCopy.ofType
+  }
+
+  let namedNewType: GraphQLType = getNamedType(copyToType)
+  while (wrappers.length > 0) {
+    const wrappingType = wrappers.pop()
+    if (wrappingType === 'GraphQLList') {
+      namedNewType = GraphQLList(namedNewType)
+    } else {
+      namedNewType = GraphQLNonNull(namedNewType)
+    }
+  }
+
+  return namedNewType
+}

--- a/packages/graphback-codegen-schema/src/definitions/copyWrappingType.ts
+++ b/packages/graphback-codegen-schema/src/definitions/copyWrappingType.ts
@@ -1,4 +1,4 @@
-import { isWrappingType, GraphQLNonNull, isListType, GraphQLList, GraphQLType, getNamedType, GraphQLInputType, GraphQLOutputType, GraphQLObjectType } from 'graphql';
+import { isWrappingType, GraphQLNonNull, isListType, GraphQLList, GraphQLType, getNamedType, GraphQLInputType, GraphQLOutputType } from 'graphql';
 
 type WrappingTypeName = 'GraphQLList' | 'GraphQLNonNull'
 type InputOrOutTypeType = GraphQLInputType | GraphQLOutputType

--- a/packages/graphback-codegen-schema/src/definitions/copyWrappingType.ts
+++ b/packages/graphback-codegen-schema/src/definitions/copyWrappingType.ts
@@ -1,6 +1,7 @@
-import { isWrappingType, GraphQLNonNull, isListType, GraphQLList, GraphQLType, getNamedType } from 'graphql';
+import { isWrappingType, GraphQLNonNull, isListType, GraphQLList, GraphQLType, getNamedType, GraphQLInputType, GraphQLOutputType, GraphQLObjectType } from 'graphql';
 
-type WrappingType = 'GraphQLList' | 'GraphQLNonNull'
+type WrappingTypeName = 'GraphQLList' | 'GraphQLNonNull'
+type InputOrOutTypeType = GraphQLInputType | GraphQLOutputType
 
 /**
  * Copies the wrapping type(s) from one GraphQLType to another
@@ -8,8 +9,8 @@ type WrappingType = 'GraphQLList' | 'GraphQLNonNull'
  * @param {GraphQLType} copyFromType - Get the wrapping types from this type
  * @param {GraphQLType} copyToType - Add the wrapping types to this type
  */
-export function copyWrappingType(copyFromType: GraphQLType, copyToType: GraphQLType): GraphQLType {
-  const wrappers: WrappingType[] = []
+export function copyWrappingType(copyFromType: InputOrOutTypeType, copyToType: InputOrOutTypeType): InputOrOutTypeType {
+  const wrappers: WrappingTypeName[] = []
 
   let oldTypeCopy = copyFromType
   while (isWrappingType(oldTypeCopy)) {

--- a/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
+++ b/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
@@ -216,6 +216,10 @@ input CreateCommentInput {
   note_id: ID!
 }
 
+input CreateCustomTypeInput {
+  issue1432: String
+}
+
 input CreateFixInput {
   id: ID
 }
@@ -224,6 +228,7 @@ input CreateIssueInput {
   id: ID
   category: IssueCategory
   createdAt: DateTime
+  custom: CreateCustomTypeInput
   bugFixId: ID
 }
 
@@ -756,7 +761,12 @@ input CreateIssueInput {
   id: ID
   category: IssueCategory
   createdAt: DateTime
+  custom: CreateCustomTypeInput
   bugFixId: ID
+}
+
+input CreateCustomTypeInput {
+  issue1432: String
 }
 
 input CreateFixInput {
@@ -1067,7 +1077,12 @@ input CreateIssueInput {
   id: ID
   category: IssueCategory
   createdAt: DateTime
+  custom: CreateCustomTypeInput
   bugFixId: ID
+}
+
+input CreateCustomTypeInput {
+  issue1432: String
 }
 
 input CreateFixInput {

--- a/packages/graphback-codegen-schema/tests/copyWrappingTypeTest.ts
+++ b/packages/graphback-codegen-schema/tests/copyWrappingTypeTest.ts
@@ -1,0 +1,51 @@
+import { GraphQLNonNull, GraphQLString, GraphQLBoolean, GraphQLList, GraphQLFloat, GraphQLInt, GraphQLObjectType } from 'graphql'
+import { copyWrappingType } from '../src/definitions/copyWrappingType'
+
+describe('copyWrappingType', () => {
+  test('Boolean should become Boolean!', () => {
+    const oldType = GraphQLNonNull(GraphQLString)
+    const newType = GraphQLBoolean
+
+    const copiedType = copyWrappingType(oldType, newType)
+    expect(copiedType.toString()).toEqual('Boolean!')
+  })
+
+  test('Float should become [Float]', () => {
+    const oldType = GraphQLList(GraphQLString)
+    const newType = GraphQLFloat
+
+    const copiedType = copyWrappingType(oldType, newType)
+    expect(copiedType.toString()).toEqual('[Float]')
+  })
+
+  test('Int should become [Int]!', () => {
+    const oldType = GraphQLNonNull(GraphQLList(GraphQLString))
+    const newType = GraphQLInt
+
+    const copiedType = copyWrappingType(oldType, newType)
+    expect(copiedType.toString()).toEqual('[Int]!')
+  })
+
+  test('String should become [String!]!', () => {
+    const oldType = GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLInt)))
+    const newType = GraphQLString
+
+    const copiedType = copyWrappingType(oldType, newType)
+    expect(copiedType.toString()).toEqual('[String!]!')
+  })
+
+  test('User should become User!', () => {
+    const oldType = GraphQLNonNull(GraphQLString)
+    const newType = new GraphQLObjectType({
+      name: 'User',
+      fields: {
+        test: {
+          type: GraphQLString
+        }
+      }
+    })
+
+    const copiedType = copyWrappingType(oldType, newType)
+    expect(copiedType.toString()).toEqual('User!')
+  })
+})

--- a/packages/graphback-core/package.json
+++ b/packages/graphback-core/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@graphql-tools/utils": "6.0.10",
     "@graphql-toolkit/common": "0.10.7",
+    "graphql-type-json": "0.3.2",
     "glob": "7.1.6",
     "graphql-compose": "7.18.1",
     "graphql-fields-list": "2.1.3",

--- a/packages/graphback-core/src/crud/mappingHelpers.ts
+++ b/packages/graphback-core/src/crud/mappingHelpers.ts
@@ -172,8 +172,10 @@ export function getInputFieldNamedType(schemaComposer: SchemaComposer<any>, fiel
   }
 
   if (isObjectType(fieldType) && !isModelType(fieldType)) {
+    // TODO: Filtering on JSON fields
     if (operation === GraphbackOperationType.FIND) {
-      return GraphQLJSON
+      return undefined
+      // return GraphQLJSON
     }
 
     const typeName = getInputTypeName(fieldType.name, operation)

--- a/packages/graphback-core/src/db/dataMapper.ts
+++ b/packages/graphback-core/src/db/dataMapper.ts
@@ -1,5 +1,4 @@
 import { ModelTableMap } from './buildModelTableMap';
-import { type } from 'os';
 
 export interface TableDataMap {
   idField?: TableID

--- a/packages/graphback-core/src/db/dataMapper.ts
+++ b/packages/graphback-core/src/db/dataMapper.ts
@@ -26,22 +26,21 @@ function getTableId(idField: string, data: any): TableID {
   }
 }
 
-export const getDatabaseArguments = (modelMap: ModelTableMap, data?: any, fieldMap?: any): TableDataMap => {
+export const getDatabaseArguments = (modelMap: ModelTableMap, data?: any): TableDataMap => {
   const idField = modelMap.idField;
+  // Transform data if it defined
+  let transFormedData: any;
+  if (data) {
+    const keys = Object.keys(data);
+    transFormedData = {};
+    for (const key of keys) {
+      const value: any = data[key];
+      transFormedData[key] = typeof value === 'object'? JSON.stringify(value) : value;
+    }
+  };
 
   return {
     idField: getTableId(idField, data),
-    // eslint-disable-next-line @typescript-eslint/tslint/config
-    data: Object.keys(data).reduce((dataObj, key) => {
-      const value = data[key]
-
-      if (typeof value === 'object') {
-        dataObj[key] = JSON.stringify(value)
-      } else {
-        dataObj[key] = value
-      }
-      
-      return dataObj
-    }, {})
+    data: transFormedData
   }
 }

--- a/packages/graphback-core/src/db/dataMapper.ts
+++ b/packages/graphback-core/src/db/dataMapper.ts
@@ -1,4 +1,5 @@
 import { ModelTableMap } from './buildModelTableMap';
+import { type } from 'os';
 
 export interface TableDataMap {
   idField?: TableID
@@ -29,10 +30,19 @@ function getTableId(idField: string, data: any): TableID {
 export const getDatabaseArguments = (modelMap: ModelTableMap, data?: any, fieldMap?: any): TableDataMap => {
   const idField = modelMap.idField;
 
-  //TODO: Map fields to custom db names
-
   return {
     idField: getTableId(idField, data),
-    data
+    // eslint-disable-next-line @typescript-eslint/tslint/config
+    data: Object.keys(data).reduce((dataObj, key) => {
+      const value = data[key]
+
+      if (typeof value === 'object') {
+        dataObj[key] = JSON.stringify(value)
+      } else {
+        dataObj[key] = value
+      }
+      
+      return dataObj
+    }, {})
   }
 }

--- a/packages/graphback-core/src/index.ts
+++ b/packages/graphback-core/src/index.ts
@@ -20,3 +20,5 @@ export * from './utils/fieldTransformHelpers';
 
 export * from './runtime';
 export * from './db';
+
+export * from './scalars'

--- a/packages/graphback-core/src/plugin/GraphbackCoreMetadata.ts
+++ b/packages/graphback-core/src/plugin/GraphbackCoreMetadata.ts
@@ -4,6 +4,7 @@ import { getUserTypesFromSchema } from '@graphql-toolkit/common'
 import { IResolvers } from '@graphql-tools/utils'
 import { mergeResolvers } from '@graphql-tools/merge';
 import { RelationshipMetadataBuilder, FieldRelationshipMetadata } from '../relationships/RelationshipMetadataBuilder'
+import { getPrimaryKey } from '../db';
 import { GraphbackCRUDGeneratorConfig } from './GraphbackCRUDGeneratorConfig'
 import { GraphbackGlobalConfig } from './GraphbackGlobalConfig'
 import { ModelDefinition } from './ModelDefinition';
@@ -97,9 +98,11 @@ export class GraphbackCoreMetadata {
     const deltaSync = parseMetadata('delta', modelType);
 
     return {
-      graphqlType: modelType, relationships, crudOptions, config: {
-        deltaSync
-      }
+      relationships,
+      crudOptions,
+      graphqlType: modelType,
+      config: { deltaSync },
+      primaryKey: getPrimaryKey(modelType).name
     };
   }
 }

--- a/packages/graphback-core/src/plugin/ModelDefinition.ts
+++ b/packages/graphback-core/src/plugin/ModelDefinition.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType } from "graphql";
+import { GraphQLObjectType, GraphQLField } from "graphql";
 import { FieldRelationshipMetadata } from '../relationships/RelationshipMetadataBuilder';
 import { GraphbackCRUDGeneratorConfig } from "./GraphbackCRUDGeneratorConfig"
 
@@ -6,6 +6,7 @@ import { GraphbackCRUDGeneratorConfig } from "./GraphbackCRUDGeneratorConfig"
  * Used to encapsulate configuration for the type
  */
 export type ModelDefinition = {
+  primaryKey: string
   graphqlType: GraphQLObjectType,
   relationships: FieldRelationshipMetadata[]
   crudOptions: GraphbackCRUDGeneratorConfig,

--- a/packages/graphback-core/src/plugin/getSelectedFieldsFromResolverInfo.ts
+++ b/packages/graphback-core/src/plugin/getSelectedFieldsFromResolverInfo.ts
@@ -21,6 +21,8 @@ export const getSelectedFieldsFromResolverInfo = (info: GraphQLResolveInfo, mode
 
         if (foundRelationship) {
           acc.push(foundRelationship.relationForeignKey)
+        } else {
+          acc.push(entry[0])
         }
       } else {
         acc.push(entry[0]);

--- a/packages/graphback-core/src/plugin/getSelectedFieldsFromResolverInfo.ts
+++ b/packages/graphback-core/src/plugin/getSelectedFieldsFromResolverInfo.ts
@@ -13,23 +13,28 @@ export const getSelectedFieldsFromResolverInfo = (info: GraphQLResolveInfo, mode
   const resolverFields = fieldsMap(info, { path });
   const selectedFields = Object.entries(resolverFields)
     .reduce((
-      acc: string[],
+      acc: Set<string>,
       entry: [string, unknown]
     ) => {
-      if (typeof entry[1] === "object") { // it is a nested object, check if it is a relationship to add the appropriate foreign key field
-        const foundRelationship = model.relationships.find((relationship: FieldRelationshipMetadata) => relationship.ownerField.name === entry[0] && relationship.kind !== "oneToMany");
 
-        if (foundRelationship) {
-          acc.push(foundRelationship.relationForeignKey)
-        } else {
-          acc.push(entry[0])
-        }
+      if (typeof entry[1] !== 'object') {
+        acc.add(entry[0]);
       } else {
-        acc.push(entry[0]);
+        // it is a nested object, check if it is a relationship to add the appropriate foreign key field
+        const foundRelationship = model.relationships.find((relationship: FieldRelationshipMetadata) => relationship.ownerField.name === entry[0]);
+        if (foundRelationship) {
+          if (foundRelationship.kind !== "oneToMany") {
+            acc.add(foundRelationship.relationForeignKey);
+          } else {
+            acc.add(model.primaryKey);
+          }
+        } else {
+          acc.add(entry[0])
+        }
       }
 
       return acc;
-    } , []);
+    } , new Set<string>());
 
-  return selectedFields;
+  return [...selectedFields];
 }

--- a/packages/graphback-core/src/scalars/index.ts
+++ b/packages/graphback-core/src/scalars/index.ts
@@ -1,0 +1,2 @@
+export * from 'graphql-type-json';
+export * from './scalars'

--- a/packages/graphback-core/src/scalars/scalars.ts
+++ b/packages/graphback-core/src/scalars/scalars.ts
@@ -1,0 +1,13 @@
+import { GraphQLNamedType, GraphQLScalarType } from 'graphql';
+import { GraphQLJSON, GraphQLJSONObject } from 'graphql-compose';
+
+const graphbackScalarTypes: GraphQLScalarType[] = [GraphQLJSON, GraphQLJSONObject]
+
+/**
+ * Checks if the type is on the the default Graphback supported scalars
+ *
+ * @param type - GraphQL type
+ */
+export function isSpecifiedGraphbackScalarType(type: GraphQLNamedType): boolean {
+  return graphbackScalarTypes.some(({ name }: GraphQLScalarType) => type.name === name);
+}

--- a/packages/graphback-runtime-knex/src/knexQueryMapper.ts
+++ b/packages/graphback-runtime-knex/src/knexQueryMapper.ts
@@ -130,8 +130,6 @@ function where(builder: Knex.QueryBuilder, filter: any, or: boolean = false, not
     builder = where(builder, orFilter, true, not)
   }
 
-  console.log(builder.toQuery())
-
   return builder
 }
 

--- a/packages/graphback-runtime-knex/src/knexQueryMapper.ts
+++ b/packages/graphback-runtime-knex/src/knexQueryMapper.ts
@@ -101,7 +101,7 @@ function where(builder: Knex.QueryBuilder, filter: any, or: boolean = false, not
 
     // eslint-disable-next-line no-null/no-null
     if (exprEntry[1] === null) {
-      builder = builder[builderMethod('whereNull', or, not)](col)
+      builder = builder[builderMethod('whereNull', or, exprEntry[0] === 'ne')](col)
     } else if (Object.keys(methodMapping).includes(exprEntry[0])) {
       builder = builder[builderMethod(exprEntry[0], or, not)](col, exprEntry[1])
     } else if (exprEntry[0] === 'contains') {
@@ -129,6 +129,8 @@ function where(builder: Knex.QueryBuilder, filter: any, or: boolean = false, not
   for (const orFilter of orQueries) {
     builder = where(builder, orFilter, true, not)
   }
+
+  console.log(builder.toQuery())
 
   return builder
 }

--- a/packages/graphql-migrations/src/abstract/generateAbstractDatabase.ts
+++ b/packages/graphql-migrations/src/abstract/generateAbstractDatabase.ts
@@ -426,9 +426,9 @@ class AbstractDatabaseBuilder {
             type: indexType,
             columns: [],
           } : {
-              name: indexName,
-              columns: [],
-            }
+            name: indexName,
+            columns: [],
+          }
           list.push(index)
         }
         index.columns.push(columnName)

--- a/packages/graphql-migrations/src/abstract/generateAbstractDatabase.ts
+++ b/packages/graphql-migrations/src/abstract/generateAbstractDatabase.ts
@@ -426,9 +426,9 @@ class AbstractDatabaseBuilder {
             type: indexType,
             columns: [],
           } : {
-            name: indexName,
-            columns: [],
-          }
+              name: indexName,
+              columns: [],
+            }
           list.push(index)
         }
         index.columns.push(columnName)
@@ -489,6 +489,13 @@ class AbstractDatabaseBuilder {
 
   private isOneToMany(type: GraphQLObjectType, field: GraphQLField<any, any>) {
     const relationType = getObjectTypeFromList(field);
+    const dbAnnotations = parseMetadata('db', field.description)
+    const isJsonColumn = dbAnnotations?.type === 'json'
+
+    if (isJsonColumn) {
+      return false
+    }
+
     if ((relationType && relationType.name !== type.name) && !parseMetadata('manyToMany', field)) {
       return true;
     }

--- a/templates/ts-apollo-postgres-backend/model/datamodel.graphql
+++ b/templates/ts-apollo-postgres-backend/model/datamodel.graphql
@@ -4,19 +4,14 @@ type Note {
   title: String!
   description: String
   """
-  @db(type: 'json')
+  @oneToMany(field: 'note')
   """
-  comment: Comment
+  comments: [Comment]!
 }
 
+""" @model """
 type Comment {
   id: ID!
-  text: String!
-  description: String!
-  test: Test!
-  test2: [Test!]!
-}
-
-type Test {
-  hello: String
+  text: String
+  description: String
 }

--- a/templates/ts-apollo-postgres-backend/model/datamodel.graphql
+++ b/templates/ts-apollo-postgres-backend/model/datamodel.graphql
@@ -4,14 +4,19 @@ type Note {
   title: String!
   description: String
   """
-  @oneToMany(field: 'note')
+  @db(type: 'json')
   """
-  comments: [Comment]!
+  comment: Comment
 }
 
-""" @model """
 type Comment {
   id: ID!
-  text: String
-  description: String
+  text: String!
+  description: String!
+  test: Test!
+  test2: [Test!]!
+}
+
+type Test {
+  hello: String
 }


### PR DESCRIPTION
This adds support for create/update of embedded relationship documents in both PostgreSQL and MongoDB.

Before this change, it was not possible to CREATE/UPDATE/FIND fields which are GraphQL types which are not models because:

a) There were no input fields added for these types to the CRUD input types
b) `getSelectedFieldsFromResolverInfo` did not include GraphQL type fields in the selectable fields, so `.select(x)` would never return this data from the database.

TL;DR we added support for non-model type fields in out models in https://github.com/aerogear/graphback/issues/1432 but this data could not be inserted/updated/retrieved from the database.

```graphql
"""
@model
"""
type Note {
  id: ID!
  title: String
  """
  this annotation is only needed for Postgres
  @db(type: 'json') 
  """
  comments: [Comment]
}

type Comment {
  owner: String
  comment: String
}
```

You can perform a mutation like so:

```gql
mutation {
  createNote(input: {
    title:"my new note",
    comments: [
      {
        comment:"Awesome!",
        owner:"Enda"
      }
    ]
  }) {
    id
    title
    comments {
      owner
      comment
    }
  }
}
```

### Tasks

- [x] Create input types for non-model fields
- [x] Allow CREATE/UPDATE/FIND on non-model fields (Mongo/Postgres)
- [x] Integration tests 