### PR TITLE
enable datasync for graphql-serve

### DIFF
--- a/packages/graphql-serve/package.json
+++ b/packages/graphql-serve/package.json
@@ -42,6 +42,7 @@
     "@graphback/core": "0.14.0-alpha4",
     "@graphback/runtime-knex": "0.14.0-alpha4",
     "@graphback/runtime-mongo": "0.14.0-alpha4",
+    "@graphback/datasync": "0.14.0-alpha4",
     "@graphql-tools/load": "6.0.10",
     "@graphql-tools/graphql-file-loader": "6.0.10",
     "apollo-server-express": "2.15.0",

--- a/packages/graphql-serve/src/GraphbackServer.ts
+++ b/packages/graphql-serve/src/GraphbackServer.ts
@@ -100,7 +100,7 @@ export class GraphbackServer {
   }
 }
 
-export async function buildGraphbackServer(modelDir: string): Promise<GraphbackServer> {
+export async function buildGraphbackServer(modelDir: string, enableDataSync: boolean): Promise<GraphbackServer> {
   const app = express();
 
   app.use(cors());
@@ -108,7 +108,7 @@ export async function buildGraphbackServer(modelDir: string): Promise<GraphbackS
   const dbClient = await createMongoDBClient();
   const db = dbClient.db('test')
 
-  const { typeDefs, resolvers, contextCreator } = await createRuntime(modelDir, db);
+  const { typeDefs, resolvers, contextCreator } = await createRuntime(modelDir, db, enableDataSync);
 
   const apolloConfig = {
     typeDefs,

--- a/packages/graphql-serve/src/commands/serve.ts
+++ b/packages/graphql-serve/src/commands/serve.ts
@@ -1,14 +1,14 @@
 import yargs from 'yargs';
 import { serveHandler } from '../components/serveHandler';
 
-type Params = { model?: string, port?: number };
+type Params = { model?: string, port?: number, datasync: boolean };
 
 export const command = 'serve [modelDir] [options]';
 
 export const desc = 'Generate and start GraphQL server from data model files';
 
 // tslint:disable-next-line: typedef
-export const builder = (args: yargs.Argv):void => {
+export const builder = (args: yargs.Argv): void => {
   args.positional('modelDir', {
     describe: 'Directory to search for data models',
     type: 'string',
@@ -18,6 +18,12 @@ export const builder = (args: yargs.Argv):void => {
     describe: 'Specify the port on which to listen on',
     type: 'number',
     alias: 'p'
+  })
+
+  args.option('datasync', {
+    describe: 'Enable datasynchronization features',
+    type: 'boolean',
+    alias: 'ds'
   })
   args.example('$0 serve . -p 8080', 'generate schema from data model files in current directory and start GraphQL server on port 8080')
 }

--- a/packages/graphql-serve/src/components/serveHandler.ts
+++ b/packages/graphql-serve/src/components/serveHandler.ts
@@ -1,7 +1,7 @@
 import { buildGraphbackServer, GraphbackServer } from "../GraphbackServer";
 
-export const serveHandler = async (argv: { model?: string, port?: number }): Promise<GraphbackServer> => {
-  const server = await buildGraphbackServer(argv.model);
+export const serveHandler = async (argv: { model?: string, port?: number, datasync }): Promise<GraphbackServer> => {
+  const server = await buildGraphbackServer(argv.model, !!argv.datasync);
 
   if ('port' in argv) {
     const portNumber = argv.port;

--- a/packages/graphql-serve/src/runtime.ts
+++ b/packages/graphql-serve/src/runtime.ts
@@ -35,16 +35,16 @@ export const createRuntime = async (modelDir: string, db: Db, datasync: boolean)
   let graphbackAPI;
   if (datasync) {
     graphbackAPI = buildGraphbackAPI(model, {
-      dataProviderCreator: createMongoDbProvider(db)
-    })
-  } else {
-    graphbackAPI = buildGraphbackAPI(model, {
       serviceCreator: createDataSyncCRUDService({ pubSub: new PubSub() }),
       dataProviderCreator: createDataSyncMongoDbProvider(db),
       plugins: [new DataSyncPlugin()]
     })
-  }
 
+  } else {
+    graphbackAPI = buildGraphbackAPI(model, {
+      dataProviderCreator: createMongoDbProvider(db)
+    })
+  }
 
   return graphbackAPI;
 }

--- a/packages/graphql-serve/src/runtime.ts
+++ b/packages/graphql-serve/src/runtime.ts
@@ -5,6 +5,8 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import { MongoClient, Db } from 'mongodb';
 import { loadModel } from './loadModel';
 import { GraphQLSchema } from 'graphql';
+import { DataSyncPlugin, createDataSyncMongoDbProvider, createDataSyncCRUDService } from "@graphback/datasync"
+import { PubSub } from 'graphql-subscriptions';
 
 export interface Runtime {
   schema: GraphQLSchema;
@@ -27,12 +29,22 @@ export const createMongoDBClient = async (): Promise<MongoClient> => {
  * Method used to create runtime schema
  * It will be part of the integration tests
  */
-export const createRuntime = async (modelDir: string, db: Db): Promise<GraphbackAPI> => {
+export const createRuntime = async (modelDir: string, db: Db, datasync: boolean): Promise<GraphbackAPI> => {
   const model = await loadModel(modelDir);
 
-  const graphbackAPI = buildGraphbackAPI(model, {
-    dataProviderCreator: createMongoDbProvider(db)
-  })
+  let graphbackAPI;
+  if (datasync) {
+    graphbackAPI = buildGraphbackAPI(model, {
+      dataProviderCreator: createMongoDbProvider(db)
+    })
+  } else {
+    graphbackAPI = buildGraphbackAPI(model, {
+      serviceCreator: createDataSyncCRUDService({ pubSub: new PubSub() }),
+      dataProviderCreator: createDataSyncMongoDbProvider(db),
+      plugins: [new DataSyncPlugin()]
+    })
+  }
+
 
   return graphbackAPI;
 }


### PR DESCRIPTION
Motivation here is to enable datasync in graphql serve.
We need that to have headless backend for offix that works with conflicts etc. 
This will be only for example purposes but it will be really powerful for the demos.


## Verification

1. Link cli
2. Run graphql-serve serve task.graphql -p 8080 --datasync