### PR TITLE
[WIP]Custom conflicts for DataSync

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -63,6 +63,29 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
+      "name": "Template app Datasync Mongo",
+      "type": "node",
+      "request": "launch",
+      "env": {
+        "DB_USER": "mongodb",
+        "DB_PASSWORD": "mongo",
+        "DB_HOST": "localhost",
+        "DB_PORT": "27017",
+        "DB_DATABASE": "users",
+        "DB_AUTHSOURCE": "admin"
+      },
+      "runtimeArgs": [
+        "-r",
+        "ts-node/register"
+      ],
+      "args": [
+        "${workspaceRoot}/templates/ts-apollo-mongodb-datasync-backend/src/index.ts"
+      ],
+      "cwd": "${workspaceRoot}/templates/ts-apollo-mongodb-datasync-backend",
+      "protocol": "inspector",
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "CLI config",

--- a/packages/graphback-datasync/src/DataSyncPlugin.ts
+++ b/packages/graphback-datasync/src/DataSyncPlugin.ts
@@ -18,7 +18,7 @@ export const DATASYNC_PLUGIN_NAME = "DataSyncPlugin";
 /**
  * DataSync plugin
  *
- * Plugin is enabled by """ @delta """ annotation
+ * Plugin is enabled by """ @datasync """ annotation
  * It will generate delta queries
  */
 export class DataSyncPlugin extends GraphbackPlugin {
@@ -32,7 +32,7 @@ export class DataSyncPlugin extends GraphbackPlugin {
 
       return schema;
     }
-
+    let dataSyncModelCount = 0;
     models.forEach((model: ModelDefinition) => {
 
       this.addDataSyncMetadataFields(schemaComposer, model);
@@ -60,6 +60,8 @@ export class DataSyncPlugin extends GraphbackPlugin {
       // Diff queries
       if (isDataSyncModel(model)) {
 
+        dataSyncModelCount+= 1;
+
         const deltaQuery = getDeltaQuery(model.graphqlType.name)
         schemaComposer.Query.addFields({
           [deltaQuery]: `${getDeltaListType(modelName)}!`
@@ -84,6 +86,10 @@ export class DataSyncPlugin extends GraphbackPlugin {
         }
       }
     })
+
+    if (dataSyncModelCount === 0) {
+      console.error("No DataSync Models detected, ensure that your models are properly annotated.")
+    }
 
     return buildSchema(schemaComposer.toSDL())
   }

--- a/packages/graphback-datasync/src/conflict/conflictEngine.ts
+++ b/packages/graphback-datasync/src/conflict/conflictEngine.ts
@@ -1,0 +1,48 @@
+import { GraphbackContext, metadataMap, FieldTransform } from '@graphback/core';
+import { ConflictStateMap } from "../util";
+
+const {fieldNames} = metadataMap;
+/**
+ * API for conflict detection and resolution engine
+ */
+export interface ConflictEngine {
+  /**
+   * checkForConflicts
+   * @param serverState document in DB
+   * @param clientState document received from client
+   * @returns ConflictStateMap if there is a conflict, undefined if not
+   */
+  checkForConflicts(serverState: any, clientState: any): ConflictStateMap | undefined 
+
+  /**
+   * checkForConflicts
+   * @param conflict ConflictStateMap received from checkForConflicts
+   * @returns resolved document or undefined if conflict cannot be resolved
+   */
+  resolveConflicts?(conflict: ConflictStateMap): any
+
+  /**
+   * updateState
+   * Supplies the updated At
+   * @param document document to be updated
+   * @returns document with updated state
+   */
+  updateState?(): FieldTransform[]
+}
+
+/**
+ * TimestampConflictEngine
+ * Simple placeholder conflict engine that
+ * throws on conflict
+ */
+export class TimestampConflictEngine implements ConflictEngine {
+  protected conflictFieldName: string = fieldNames.updatedAt;
+  
+  public checkForConflicts(serverState: any, clientState: any): ConflictStateMap {
+    if (serverState[this.conflictFieldName] !== undefined && clientState[this.conflictFieldName].toString() !== serverState[fieldNames.updatedAt].toString()) {
+      return { serverState, clientState };
+    }
+
+    return undefined;
+  }
+}

--- a/packages/graphback-datasync/src/util.ts
+++ b/packages/graphback-datasync/src/util.ts
@@ -25,7 +25,8 @@ export function isDataSyncService(service: GraphbackCRUDService): DataSyncCRUDSe
  */
 export interface ConflictStateMap {
   serverState: any,
-  clientState: any
+  clientState: any,
+  base?: any
 }
 
 /**


### PR DESCRIPTION
This is a very (**very**) rough implementation of custom conflicts in DataSync, need some serious feedback on this before we go ahead with this :smile:
### What is this?
This PR adds the ability for checking custom fields for conflicts and resolving conflicts as well. Similar to what's in Offix conflict-server.

### What's done?
A ConflictEngine interface which could be used to create custom Conflict Engines, not cleanly incorporated into the workflow yet, I am thinking of something like passing a custom conflict engine class to `createDataSyncMongoDbProvider` but I doubt it's optimal because I cannot see any way to extend this other than basic stuff like the engine used by default

### What's left?
- [ ] Finalize approach while optimising for extensiblity
- [ ] Writing tests
- [ ] Writing documentation