### PR TITLE
fix(schema): make return types nullable

### DIFF
--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -125,8 +125,6 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     writeFileSync(schemaPath, schemaString);
   }
 
-
-
   public getPluginName() {
     return SCHEMA_CRUD_PLUGIN_NAME;
   }
@@ -252,7 +250,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
 
       const operation = getFieldName(name, operationType)
       mutationFields[operation] = {
-        type: GraphQLNonNull(model.graphqlType),
+        type: modelType,
         args: {
           input: {
             type: GraphQLNonNull(createMutationInputType)
@@ -268,7 +266,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
       const updateMutationInputType = schemaComposer.getITC(inputTypeName).getType()
 
       mutationFields[operation] = {
-        type: GraphQLNonNull(modelType),
+        type: modelType,
         args: {
           input: {
             type: GraphQLNonNull(updateMutationInputType)
@@ -284,7 +282,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
       const deleteMutationInputType = schemaComposer.getITC(inputTypeName).getType()
 
       mutationFields[operation] = {
-        type: GraphQLNonNull(model.graphqlType),
+        type: modelType,
         args: {
           input: {
             type: GraphQLNonNull(deleteMutationInputType)
@@ -404,8 +402,6 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
    * @param {IFieldResolver} mutationObj - Mutation resolver object
    */
   protected addMutationResolvers(model: ModelDefinition, mutationObj: IFieldResolver<any, any>) {
-    const modelType = model.graphqlType;
-
     if (model.crudOptions.create) {
       this.addCreateMutationResolver(model, mutationObj)
     }

--- a/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
+++ b/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
@@ -30,8 +30,8 @@ export const createInputTypeForScalar = (scalarType: GraphQLScalarType) => {
       lt: { type: scalarType },
       ge: { type: scalarType },
       gt: { type: scalarType },
-      in: { type: GraphQLList(scalarType) },
-      between: { type: GraphQLList(scalarType) }
+      in: { type: GraphQLList(GraphQLNonNull(scalarType)) },
+      between: { type: GraphQLList(GraphQLNonNull(scalarType)) }
     }
   });
 
@@ -56,7 +56,7 @@ export const StringScalarInputType = new GraphQLInputObjectType({
     lt: { type: GraphQLString },
     ge: { type: GraphQLString },
     gt: { type: GraphQLString },
-    in: { type: GraphQLList(GraphQLString) },
+    in: { type: GraphQLList(GraphQLNonNull(GraphQLString)) },
     contains: { type: GraphQLString },
     startsWith: { type: GraphQLString },
     endsWith: { type: GraphQLString }
@@ -72,7 +72,7 @@ export const IDScalarInputType = new GraphQLInputObjectType({
     lt: { type: GraphQLID },
     ge: { type: GraphQLID },
     gt: { type: GraphQLID },
-    in: { type: GraphQLList(GraphQLID) },
+    in: { type: GraphQLList(GraphQLNonNull(GraphQLID)) },
   }
 })
 

--- a/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
+++ b/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
@@ -111,7 +111,7 @@ input IDInput {
   lt: ID
   ge: ID
   gt: ID
-  in: [ID]
+  in: [ID!]
 }
 
 input StringInput {
@@ -121,7 +121,7 @@ input StringInput {
   lt: String
   ge: String
   gt: String
-  in: [String]
+  in: [String!]
   contains: String
   startsWith: String
   endsWith: String
@@ -257,8 +257,8 @@ input DateTimeInput {
   lt: DateTime
   ge: DateTime
   gt: DateTime
-  in: [DateTime]
-  between: [DateTime]
+  in: [DateTime!]
+  between: [DateTime!]
 }
 
 \\"\\"\\"
@@ -292,7 +292,7 @@ input IDInput {
   lt: ID
   ge: ID
   gt: ID
-  in: [ID]
+  in: [ID!]
 }
 
 \\"\\"\\"
@@ -443,7 +443,7 @@ input StringInput {
   lt: String
   ge: String
   gt: String
-  in: [String]
+  in: [String!]
   contains: String
   startsWith: String
   endsWith: String
@@ -541,7 +541,7 @@ input IDInput {
   lt: ID
   ge: ID
   gt: ID
-  in: [ID]
+  in: [ID!]
 }
 
 input StringInput {
@@ -551,7 +551,7 @@ input StringInput {
   lt: String
   ge: String
   gt: String
-  in: [String]
+  in: [String!]
   contains: String
   startsWith: String
   endsWith: String
@@ -753,8 +753,8 @@ input DateTimeInput {
   lt: DateTime
   ge: DateTime
   gt: DateTime
-  in: [DateTime]
-  between: [DateTime]
+  in: [DateTime!]
+  between: [DateTime!]
 }
 
 input CreateIssueInput {
@@ -857,7 +857,7 @@ input IDInput {
   lt: ID
   ge: ID
   gt: ID
-  in: [ID]
+  in: [ID!]
 }
 
 input StringInput {
@@ -867,7 +867,7 @@ input StringInput {
   lt: String
   ge: String
   gt: String
-  in: [String]
+  in: [String!]
   contains: String
   startsWith: String
   endsWith: String
@@ -1069,8 +1069,8 @@ input DateTimeInput {
   lt: DateTime
   ge: DateTime
   gt: DateTime
-  in: [DateTime]
-  between: [DateTime]
+  in: [DateTime!]
+  between: [DateTime!]
 }
 
 input CreateIssueInput {

--- a/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
+++ b/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
@@ -362,17 +362,17 @@ input MutateTestInput {
 
 type Mutation {
   likeNote(id: ID!): Note!
-  createNote(input: CreateNoteInput!): Note!
-  updateNote(input: MutateNoteInput!): Note!
-  deleteNote(input: MutateNoteInput!): Note!
-  createTest(input: CreateTestInput!): Test!
-  updateTest(input: MutateTestInput!): Test!
-  deleteTest(input: MutateTestInput!): Test!
-  createComment(input: CreateCommentInput!): Comment!
-  updateComment(input: MutateCommentInput!): Comment!
-  deleteComment(input: MutateCommentInput!): Comment!
-  createIssue(input: CreateIssueInput!): Issue!
-  createFix(input: CreateFixInput!): Fix!
+  createNote(input: CreateNoteInput!): Note
+  updateNote(input: MutateNoteInput!): Note
+  deleteNote(input: MutateNoteInput!): Note
+  createTest(input: CreateTestInput!): Test
+  updateTest(input: MutateTestInput!): Test
+  deleteTest(input: MutateTestInput!): Test
+  createComment(input: CreateCommentInput!): Comment
+  updateComment(input: MutateCommentInput!): Comment
+  deleteComment(input: MutateCommentInput!): Comment
+  createIssue(input: CreateIssueInput!): Issue
+  createFix(input: CreateFixInput!): Fix
 }
 
 \\"\\"\\" @model \\"\\"\\"
@@ -619,17 +619,17 @@ type CommentResultList {
 
 type Mutation {
   likeNote(id: ID!): Note!
-  createNote(input: CreateNoteInput!): Note!
-  updateNote(input: MutateNoteInput!): Note!
-  deleteNote(input: MutateNoteInput!): Note!
-  createTest(input: CreateTestInput!): Test!
-  updateTest(input: MutateTestInput!): Test!
-  deleteTest(input: MutateTestInput!): Test!
-  createComment(input: CreateCommentInput!): Comment!
-  updateComment(input: MutateCommentInput!): Comment!
-  deleteComment(input: MutateCommentInput!): Comment!
-  createIssue(input: CreateIssueInput!): Issue!
-  createFix(input: CreateFixInput!): Fix!
+  createNote(input: CreateNoteInput!): Note
+  updateNote(input: MutateNoteInput!): Note
+  deleteNote(input: MutateNoteInput!): Note
+  createTest(input: CreateTestInput!): Test
+  updateTest(input: MutateTestInput!): Test
+  deleteTest(input: MutateTestInput!): Test
+  createComment(input: CreateCommentInput!): Comment
+  updateComment(input: MutateCommentInput!): Comment
+  deleteComment(input: MutateCommentInput!): Comment
+  createIssue(input: CreateIssueInput!): Issue
+  createFix(input: CreateFixInput!): Fix
 }
 
 input CreateNoteInput {
@@ -935,17 +935,17 @@ type CommentResultList {
 
 type Mutation {
   likeNote(id: ID!): Note!
-  createNote(input: CreateNoteInput!): Note!
-  updateNote(input: MutateNoteInput!): Note!
-  deleteNote(input: MutateNoteInput!): Note!
-  createTest(input: CreateTestInput!): Test!
-  updateTest(input: MutateTestInput!): Test!
-  deleteTest(input: MutateTestInput!): Test!
-  createComment(input: CreateCommentInput!): Comment!
-  updateComment(input: MutateCommentInput!): Comment!
-  deleteComment(input: MutateCommentInput!): Comment!
-  createIssue(input: CreateIssueInput!): Issue!
-  createFix(input: CreateFixInput!): Fix!
+  createNote(input: CreateNoteInput!): Note
+  updateNote(input: MutateNoteInput!): Note
+  deleteNote(input: MutateNoteInput!): Note
+  createTest(input: CreateTestInput!): Test
+  updateTest(input: MutateTestInput!): Test
+  deleteTest(input: MutateTestInput!): Test
+  createComment(input: CreateCommentInput!): Comment
+  updateComment(input: MutateCommentInput!): Comment
+  deleteComment(input: MutateCommentInput!): Comment
+  createIssue(input: CreateIssueInput!): Issue
+  createFix(input: CreateFixInput!): Fix
 }
 
 input CreateNoteInput {

--- a/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
+++ b/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
@@ -95,7 +95,7 @@ input IDInput {
   lt: ID
   ge: ID
   gt: ID
-  in: [ID]
+  in: [ID!]
 }
 
 input MutateCommentInput {
@@ -228,7 +228,7 @@ input StringInput {
   lt: String
   ge: String
   gt: String
-  in: [String]
+  in: [String!]
   contains: String
   startsWith: String
   endsWith: String

--- a/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
+++ b/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
@@ -115,12 +115,12 @@ input MutateNoteInput {
 
 type Mutation {
   likeNote(id: ID!): Note!
-  createNote(input: CreateNoteInput!): Note!
-  updateNote(input: MutateNoteInput!): Note!
-  deleteNote(input: MutateNoteInput!): Note!
-  createComment(input: CreateCommentInput!): Comment!
-  updateComment(input: MutateCommentInput!): Comment!
-  deleteComment(input: MutateCommentInput!): Comment!
+  createNote(input: CreateNoteInput!): Note
+  updateNote(input: MutateNoteInput!): Note
+  deleteNote(input: MutateNoteInput!): Note
+  createComment(input: CreateCommentInput!): Comment
+  updateComment(input: MutateCommentInput!): Comment
+  deleteComment(input: MutateCommentInput!): Comment
 }
 
 \\"\\"\\"

--- a/packages/graphql-serve/tests/__snapshots__/printSchema.test.ts.snap
+++ b/packages/graphql-serve/tests/__snapshots__/printSchema.test.ts.snap
@@ -52,9 +52,9 @@ input MutateUserInput {
 }
 
 type Mutation {
-  createUser(input: CreateUserInput!): User!
-  updateUser(input: MutateUserInput!): User!
-  deleteUser(input: MutateUserInput!): User!
+  createUser(input: CreateUserInput!): User
+  updateUser(input: MutateUserInput!): User
+  deleteUser(input: MutateUserInput!): User
 }
 
 input OrderByInput {

--- a/packages/graphql-serve/tests/__snapshots__/printSchema.test.ts.snap
+++ b/packages/graphql-serve/tests/__snapshots__/printSchema.test.ts.snap
@@ -43,7 +43,7 @@ input IDInput {
   lt: ID
   ge: ID
   gt: ID
-  in: [ID]
+  in: [ID!]
 }
 
 input MutateUserInput {
@@ -84,7 +84,7 @@ input StringInput {
   lt: String
   ge: String
   gt: String
-  in: [String]
+  in: [String!]
   contains: String
   startsWith: String
   endsWith: String


### PR DESCRIPTION
Closes #1592 

This PR makes return types for mutations nullable.

Implements change to GraphQLCRUD spec https://github.com/graphqlcrud/spec/pull/22