### PR TITLE
fix(schema): make AND/OR fields non-nullable

### DIFF
--- a/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
+++ b/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
@@ -178,10 +178,10 @@ export const buildFilterInputType = (schemaComposer: SchemaComposer<any>, modelT
     fields: {
       ...scalarInputFields,
       and: {
-        type: `[${inputTypeName}]`
+        type: `[${inputTypeName}!]`
       },
       or: {
-        type: `[${inputTypeName}]`
+        type: `[${inputTypeName}!]`
       },
       not: {
         type: `${inputTypeName}`

--- a/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
+++ b/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
@@ -99,8 +99,8 @@ input TestFilter {
   id: IDInput
   name: StringInput
   test_id: IDInput
-  and: [TestFilter]
-  or: [TestFilter]
+  and: [TestFilter!]
+  or: [TestFilter!]
   not: TestFilter
 }
 
@@ -138,8 +138,8 @@ input NoteFilter {
   id: IDInput
   title: StringInput
   description: StringInput
-  and: [NoteFilter]
-  or: [NoteFilter]
+  and: [NoteFilter!]
+  or: [NoteFilter!]
   not: NoteFilter
 }
 
@@ -191,8 +191,8 @@ input CommentFilter {
   title: StringInput
   description: StringInput
   note_id: IDInput
-  and: [CommentFilter]
-  or: [CommentFilter]
+  and: [CommentFilter!]
+  or: [CommentFilter!]
   not: CommentFilter
 }
 
@@ -336,8 +336,8 @@ input IssueFilter {
   category: StringInput
   createdAt: DateTimeInput
   bugFixId: IDInput
-  and: [IssueFilter]
-  or: [IssueFilter]
+  and: [IssueFilter!]
+  or: [IssueFilter!]
   not: IssueFilter
 }
 
@@ -393,8 +393,8 @@ input NoteFilter {
   title: StringInput
   description: StringInput
   test_id: IDInput
-  and: [NoteFilter]
-  or: [NoteFilter]
+  and: [NoteFilter!]
+  or: [NoteFilter!]
   not: NoteFilter
 }
 
@@ -470,8 +470,8 @@ type Test {
 input TestFilter {
   id: IDInput
   name: StringInput
-  and: [TestFilter]
-  or: [TestFilter]
+  and: [TestFilter!]
+  or: [TestFilter!]
   not: TestFilter
 }
 
@@ -529,8 +529,8 @@ input CommentFilter {
   title: StringInput
   description: StringInput
   note_id: IDInput
-  and: [CommentFilter]
-  or: [CommentFilter]
+  and: [CommentFilter!]
+  or: [CommentFilter!]
   not: CommentFilter
 }
 
@@ -575,8 +575,8 @@ input NoteFilter {
   title: StringInput
   description: StringInput
   test_id: IDInput
-  and: [NoteFilter]
-  or: [NoteFilter]
+  and: [NoteFilter!]
+  or: [NoteFilter!]
   not: NoteFilter
 }
 
@@ -605,8 +605,8 @@ type TestResultList {
 input TestFilter {
   id: IDInput
   name: StringInput
-  and: [TestFilter]
-  or: [TestFilter]
+  and: [TestFilter!]
+  or: [TestFilter!]
   not: TestFilter
 }
 
@@ -741,8 +741,8 @@ input IssueFilter {
   category: StringInput
   createdAt: DateTimeInput
   bugFixId: IDInput
-  and: [IssueFilter]
-  or: [IssueFilter]
+  and: [IssueFilter!]
+  or: [IssueFilter!]
   not: IssueFilter
 }
 
@@ -845,8 +845,8 @@ input CommentFilter {
   title: StringInput
   description: StringInput
   note_id: IDInput
-  and: [CommentFilter]
-  or: [CommentFilter]
+  and: [CommentFilter!]
+  or: [CommentFilter!]
   not: CommentFilter
 }
 
@@ -891,8 +891,8 @@ input NoteFilter {
   title: StringInput
   description: StringInput
   test_id: IDInput
-  and: [NoteFilter]
-  or: [NoteFilter]
+  and: [NoteFilter!]
+  or: [NoteFilter!]
   not: NoteFilter
 }
 
@@ -921,8 +921,8 @@ type TestResultList {
 input TestFilter {
   id: IDInput
   name: StringInput
-  and: [TestFilter]
-  or: [TestFilter]
+  and: [TestFilter!]
+  or: [TestFilter!]
   not: TestFilter
 }
 
@@ -1057,8 +1057,8 @@ input IssueFilter {
   category: StringInput
   createdAt: DateTimeInput
   bugFixId: IDInput
-  and: [IssueFilter]
-  or: [IssueFilter]
+  and: [IssueFilter!]
+  or: [IssueFilter!]
   not: IssueFilter
 }
 

--- a/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
+++ b/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
@@ -55,8 +55,8 @@ input CommentFilter {
   title: StringInput
   description: StringInput
   noteId: IDInput
-  and: [CommentFilter]
-  or: [CommentFilter]
+  and: [CommentFilter!]
+  or: [CommentFilter!]
   not: CommentFilter
   createdAt: StringInput
   updatedAt: StringInput
@@ -176,8 +176,8 @@ input NoteFilter {
   id: IDInput
   title: StringInput
   description: StringInput
-  and: [NoteFilter]
-  or: [NoteFilter]
+  and: [NoteFilter!]
+  or: [NoteFilter!]
   not: NoteFilter
   createdAt: StringInput
   updatedAt: StringInput

--- a/packages/graphql-serve/tests/__snapshots__/printSchema.test.ts.snap
+++ b/packages/graphql-serve/tests/__snapshots__/printSchema.test.ts.snap
@@ -105,8 +105,8 @@ type User {
 input UserFilter {
   id: IDInput
   name: StringInput
-  and: [UserFilter]
-  or: [UserFilter]
+  and: [UserFilter!]
+  or: [UserFilter!]
   not: UserFilter
 }
 


### PR DESCRIPTION
This change makes filter field lists `and` and `or` non-nullable

```
and: [CommentFilter!]
or: [CommentFilter!]
```

Implements https://github.com/graphqlcrud/spec/pull/26