### PR TITLE
fix: start server if schema has no models

### DIFF
--- a/packages/graphback/tests/buildGraphbackAPITest.ts
+++ b/packages/graphback/tests/buildGraphbackAPITest.ts
@@ -180,5 +180,30 @@ describe('buildGraphbackAPI', () => {
 
     expect(schema.getType('NoteDeltaList')).toBeDefined()
   })
+
+  test('Works when there are no Graphback models', () => {
+
+    const model = `
+    type Note {
+      id: ID!
+      title: String!
+      description: String
+    }
+
+    type Query {
+      test: String
+    }
+    `
+
+    const { db } = setup()
+
+    const { schema, resolvers } = buildGraphbackAPI(model, {
+      dataProviderCreator: createKnexDbProvider(db)
+    })
+
+    expect(schema.getType('Note')).toBeDefined()
+    expect(resolvers).toBeUndefined()
+    expect(Object.keys(schema.getQueryType().getFields())).toEqual(['test'])
+  })
 })
 


### PR DESCRIPTION
Fixes #1427 

This allows the server to start if there are no types annotated by `@model`.

To verify, start a server with this model:

```
type User {
  name: String
}

type Query {
  hello: String
}
```