### PR TITLE
Add delta table

### DIFF
--- a/packages/graphback-datasync/src/conflict/index.ts
+++ b/packages/graphback-datasync/src/conflict/index.ts
@@ -1,0 +1,95 @@
+import { GraphbackContext, metadataMap, FieldTransform, NoDataError } from '@graphback/core';
+import { ConflictStateMap } from "../util";
+
+const {fieldNames} = metadataMap;
+/**
+ * API for conflict detection and resolution engine
+ */
+export interface ConflictEngine {
+  /**
+   * checkForConflicts
+   * @param serverState document in DB
+   * @param clientState document received from client
+   * @returns ConflictStateMap if there is a conflict, undefined if not
+   */
+  checkForConflicts(serverState: any, clientState: any): ConflictStateMap | undefined 
+
+  /**
+   * checkForConflicts
+   * @param conflict ConflictStateMap received from checkForConflicts
+   * @returns resolved document or undefined if conflict cannot be resolved
+   */
+  resolveConflicts?(conflict: ConflictStateMap): any
+
+  /**
+   * updateState
+   * @param document document to be updated
+   * @returns document with updated state
+   */
+  updateState(document: any): any
+}
+
+/**
+ * d
+ */
+export abstract class CustomConflictEngine implements ConflictEngine {
+  protected conflictFieldName: string = undefined;
+
+  public checkForConflicts(serverState: any, clientState: any): ConflictStateMap {
+    if (serverState[this.conflictFieldName] !== undefined && clientState[this.conflictFieldName].toString() !== serverState[fieldNames.updatedAt].toString()) {
+      return { serverState, clientState };
+    }
+
+    return undefined;
+  }
+
+  abstract updateState(document: any): any;
+  
+}
+
+/**
+ * TimestampConflictEngine
+ * Simple placeholder conflict engine that
+ * throws on conflict
+ */
+export class TimestampConflictEngine extends CustomConflictEngine {
+  protected conflictFieldName: string = fieldNames.updatedAt;
+
+  public updateState(_: any) {
+    return {};
+  }
+}
+
+/**
+ * For detecting conflicts using DeltaTable
+ */
+export class DeltaConflictEngine extends TimestampConflictEngine {
+  public checkForConflicts(serverDelta: any, clientSets: any): ConflictStateMap {
+    
+    if (super.checkForConflicts(serverDelta, clientSets) === undefined) {
+      return undefined;
+    }
+    
+    const ignoreFields = ["updatedAt", "id", "_id", "_deleted"]
+    const nonNullKeys = Object.keys(serverDelta).filter((key: string) => {
+
+      return (!ignoreFields.includes(key)) && serverDelta[key] !== undefined
+    })
+
+    const clientKeys = Object.keys(clientSets).filter((key: string) => {
+
+      return !ignoreFields.includes(key)
+    })
+
+    // If client is setting a field that has already changed
+    if (nonNullKeys.some((key: string) => {
+      return clientSets[key] !== undefined
+    }) || clientKeys.length === 0
+    ) {
+      // There is a conflict
+      return { serverState: serverDelta, clientState: clientSets };
+    }
+
+    return undefined;
+  }
+}

--- a/packages/graphback-datasync/src/index.ts
+++ b/packages/graphback-datasync/src/index.ts
@@ -1,6 +1,7 @@
 export * from './DataSyncPlugin'
 export * from './providers';
 export * from './services';
+export * from './conflict';
 export * from './util';
 
 //Required for plugins

--- a/packages/graphback-datasync/src/providers/DeltaDbDataProvider.ts
+++ b/packages/graphback-datasync/src/providers/DeltaDbDataProvider.ts
@@ -1,0 +1,178 @@
+import { GraphQLObjectType } from 'graphql';
+import { getDatabaseArguments, metadataMap, GraphbackContext, NoDataError, TransformType, FieldTransform, GraphbackOrderBy, GraphbackPage } from '@graphback/core';
+import { ObjectId } from 'mongodb';
+import { MongoDBDataProvider, applyIndexes } from '@graphback/runtime-mongo';
+import { ConflictError, ConflictStateMap } from "../util";
+import { DataSyncProvider } from "./DataSyncProvider";
+import { DeltaProvider } from "./DeltaProvider";
+
+/**
+ * Mongo provider that attains data synchronization using soft deletes
+ */
+export class DeltaDBDataProvider<Type = any> extends MongoDBDataProvider<Type> implements DataSyncProvider {
+  protected deltaProvider: DeltaProvider;
+
+  public constructor(baseType: GraphQLObjectType, client: any) {
+    super(baseType, client);
+    applyIndexes([
+      {
+        key: {
+          _deleted: 1
+        }
+      }
+    ], this.db.collection(this.collectionName)).catch((e: any) => {
+      throw e;
+    });
+    this.deltaProvider = new DeltaProvider(baseType, client);
+  }
+
+  public async create(data: any, context: GraphbackContext): Promise<Type> {
+    data._deleted = false;
+
+    const res = await super.create(data, context);
+
+    this.deltaProvider.insertDiff(res).catch((e: any) => {
+      console.error(`Error: Couldn't insert into delta table: ${e}`);
+    })
+    
+    return this.mapFields(res);
+  }
+
+  public async update(data: any, context: GraphbackContext): Promise<Type> {
+    const conflict = await this.checkForConflicts(data, context);
+
+    if (conflict !== undefined) {
+      throw new ConflictError(conflict);
+    }
+
+    // TODO use findOneAndUpdate to check consistency afterwards
+    const { idField } = getDatabaseArguments(this.tableMap, data);
+
+    if (!idField.value) {
+      throw new NoDataError(`Cannot update ${this.collectionName} - missing ID field`)
+    }
+
+    this.fieldTransformMap[TransformType.UPDATE]
+      .forEach((f: FieldTransform) => {
+        data[f.fieldName] = f.transform(f.fieldName);
+      });
+
+    const objectId = new ObjectId(idField.value);
+    const result = await this.db.collection(this.collectionName).findOneAndUpdate({ _id: objectId }, { $set: data }, { returnOriginal: false });
+    if (result.ok) {
+      
+      this.deltaProvider.insertDiff(result.value).catch((e: any) => {
+        console.error(`Error: Couldn't insert into delta table: ${e}`);
+      })
+
+      return this.mapFields(result.value)
+      
+    }
+    throw new NoDataError(`Cannot update ${this.collectionName}`);
+
+
+  }
+
+  public async delete(data: any, context: GraphbackContext): Promise<Type> {
+    const conflict = await this.checkForConflicts(data, context);
+    if (conflict !== undefined) {
+      throw new ConflictError(conflict);
+    }
+
+    const { idField } = getDatabaseArguments(this.tableMap, data);
+    data = {};
+
+    this.fieldTransformMap[TransformType.UPDATE]
+      .forEach((f: FieldTransform) => {
+        data[f.fieldName] = f.transform();
+      });
+
+    data._deleted = true;
+    const objectId = new ObjectId(idField.value);
+    const projection = this.buildProjectionOption(context);
+    const result = await this.db.collection(this.collectionName).findOneAndUpdate({ _id: objectId }, { $set: data }, {/*projection,*/ returnOriginal: false });
+    if (result.ok) {
+      this.deltaProvider.insertDiff(result.value).catch((e: any) => {
+        console.error(`Error: Couldn't insert into delta table: ${e}`);
+      })
+
+      return this.mapFields(result.value);
+    }
+
+    throw new NoDataError(`Could not delete from ${this.collectionName}`);
+  }
+
+  public async findOne(filter: any, context: GraphbackContext): Promise<Type> {
+    if (filter.id) {
+      filter = { _id: new ObjectId(filter.id) }
+    }
+    const projection = this.buildProjectionOption(context);
+    const query = this.db.collection(this.collectionName).findOne({
+      ...filter,
+      _deleted: { $ne: true}
+    }, { projection });
+    const data = await query;
+
+    if (data) {
+      return this.mapFields(data);
+    }
+    throw new NoDataError(`Cannot find a result for ${this.collectionName} with filter: ${JSON.stringify(filter)}`);
+  }
+
+  public async findBy(filter: any, context: GraphbackContext, page?: GraphbackPage, orderBy?: GraphbackOrderBy): Promise<Type[]> {
+    if (filter === undefined) {
+      filter = {};
+    }
+
+    filter._deleted = { ne: true };
+
+    return super.findBy(filter, context, page, orderBy);
+  }
+
+  public async count(filter: any): Promise<number> {
+    if (filter === undefined) {
+      filter = {};
+    }
+
+    filter._deleted = { ne: true};
+
+    return super.count(filter);
+  }
+
+  public sync(lastSync: string, context: GraphbackContext, filter?: any): Promise<Type[]> {
+
+    return this.deltaProvider.sync(parseInt(lastSync, 10)).then((res: any[]) => {
+      return res.map((doc: any) => {
+        return this.mapFields(doc);
+      })
+    });
+  }
+
+  protected async checkForConflicts(clientData: any, context: GraphbackContext): Promise<ConflictStateMap> {
+    const { idField } = getDatabaseArguments(this.tableMap, clientData);
+    const { fieldNames } = metadataMap;
+
+    if (!idField.value) {
+      throw new NoDataError(`Couldn't get document from ${this.collectionName} - missing ID field`)
+    }
+    const projection = {
+      ...this.buildProjectionOption(context),
+      [fieldNames.updatedAt]: 1,
+      _deleted: 1
+    };
+    const queryResult = await this.db.collection(this.collectionName).findOne({ _id: new ObjectId(idField.value), _deleted: { $ne: true} }, {});
+    if (queryResult) {
+      queryResult[idField.name] = queryResult._id;
+      if (
+        queryResult[fieldNames.updatedAt] !== undefined &&
+        clientData[fieldNames.updatedAt].toString() !== queryResult[fieldNames.updatedAt].toString()
+      ) {
+        return { serverState: queryResult, clientState: clientData };
+      }
+
+      return undefined;
+    }
+
+    throw new NoDataError(`Could not find any such documents from ${this.collectionName}`);
+  }
+}

--- a/packages/graphback-datasync/src/providers/DeltaProvider.ts
+++ b/packages/graphback-datasync/src/providers/DeltaProvider.ts
@@ -1,6 +1,6 @@
 import { applyIndexes } from "@graphback/runtime-mongo";
 import { GraphQLObjectType } from 'graphql';
-import { Db } from "mongodb"
+import { Db, ObjectId, FilterQuery } from "mongodb"
 import { getTableName, GraphbackOperationType } from '@graphback/core';
 
 function getDeltaTableName(baseType: GraphQLObjectType) {
@@ -36,7 +36,7 @@ export class DeltaProvider implements DeltaDB {
     applyIndexes([
       {
         key: {
-          "doc._id": 1,
+          "docId": 1,
           "doc.updatedAt": 1
         }
       },
@@ -49,30 +49,116 @@ export class DeltaProvider implements DeltaDB {
   }
 
 
-  public async insertDiff(data: any) {
-    delete data.id;
+  public async insertDiff(data: any, op: DeltaOps) {
+    const diff = getDiffEntry(data);
 
     const res = await this.db.collection(this.collectionName).insertOne({
-      doc: data
+      op: op.toString(),
+      ...diff
     })
 
     return res.insertedId;
   }
 
-  public async sync(lastSync: number) {
-    return this.db.collection(this.collectionName).aggregate([
+  public async sync(lastSync: number, filter?: FilterQuery<any>) {
+    const syncPipeline = [
       {
         $match: {
-          "doc.updatedAt": {
-            $gte: lastSync
+          timestamp: {
+            $gte: new Date(lastSync)
           }
-        }
+
+        },
       },
       {
-        $replaceRoot: {
-          newRoot: '$doc'
+        $group: {
+          _id: "$docId",
+          sets: {
+            $mergeObjects: "$sets"
+          },
+          lastOp: {
+            $last: "$op"
+          },
+          lastUpdated: {
+            $last: "$timestamp"
+          }
         }
-      }
-    ]).toArray()
+      }, {
+        $replaceRoot: {
+          newRoot: {
+            $mergeObjects: [
+              {
+                _id: "$_id",
+                _deleted: { $eq: ["$lastOp", "delete"] },
+                updatedAt: {
+                  $toLong: "$lastUpdated"
+                }
+              },
+              "$sets"
+            ]
+          }
+        }
+      }, {
+        $match: filter
+      }];
+
+    return this.db.collection(this.collectionName).aggregate(syncPipeline).toArray()
+  }
+
+  public async checkForConflicts(updateData: any): Promise<boolean> {
+    if (updateData === {} || updateData === undefined) {
+      return false
+    }
+
+    const fieldChecks = getFieldChecks(updateData);
+
+    const filter: FilterQuery<any> = {
+      docId: (updateData.id instanceof ObjectId ? updateData.id : new ObjectId(updateData.id)),
+      timestamp: {
+        $gt: new Date(parseInt(updateData.updatedAt, 10))
+      },
+      ...fieldChecks
+    };
+
+    const count = await this.db.collection(this.collectionName).countDocuments(filter)
+    
+    return count > 0
+  }
+}
+
+export function getFieldChecks(updateData: any) {
+  const deltaMap = Object.assign({}, updateData);
+  delete deltaMap.id;
+  delete deltaMap.updatedAt;
+
+  return Object.keys(deltaMap).reduce((fieldChecks: any, fieldName: string) => {
+    fieldChecks[`sets.${fieldName}`] = {
+      $exists: true
+    }
+
+    return fieldChecks
+  }, {})
+}
+
+export interface DiffEntry {
+  docId: ObjectId,
+  sets: { [fieldName: string]: any },
+  timestamp: Date
+}
+
+export function getDiffEntry(data: any): DiffEntry {
+  const sets = Object.assign({}, data);
+  const objectId = sets.id instanceof ObjectId ? sets.id : new ObjectId(sets.id);
+  delete sets.id;
+  delete sets._id;
+  delete sets._deleted
+  const timestamp = new Date(sets.updatedAt);
+  delete sets.updatedAt;
+  delete sets.createdAt;
+  
+  return {
+    docId: objectId,
+    sets,
+    timestamp
   }
 }

--- a/packages/graphback-datasync/src/providers/DeltaProvider.ts
+++ b/packages/graphback-datasync/src/providers/DeltaProvider.ts
@@ -1,0 +1,78 @@
+import { applyIndexes } from "@graphback/runtime-mongo";
+import { GraphQLObjectType } from 'graphql';
+import { Db } from "mongodb"
+import { getTableName, GraphbackOperationType } from '@graphback/core';
+
+function getDeltaTableName(baseType: GraphQLObjectType) {
+  return `_${getTableName(baseType)}_delta`
+}
+
+type DeltaOps = GraphbackOperationType.CREATE | GraphbackOperationType.UPDATE | GraphbackOperationType.DELETE;
+
+interface DeltaDB {
+  insertDiff(data: any, op: DeltaOps): Promise<any>
+}
+
+type Hook = (doc: any) => any;
+
+interface HookMap {
+  [GraphbackOperationType.CREATE]: Hook[]
+  [GraphbackOperationType.UPDATE]: Hook[]
+}
+
+/**
+ * Provides an interface for interacting with deltas and stuff
+ */
+export class DeltaProvider implements DeltaDB {
+  protected collectionName: string;
+  protected db: Db;
+  protected hooks:HookMap;
+
+  public constructor(baseType: GraphQLObjectType, db: Db) {
+    this.db = db;
+
+    this.collectionName = getDeltaTableName(baseType);
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    applyIndexes([
+      {
+        key: {
+          "doc._id": 1,
+          "doc.updatedAt": 1
+        }
+      },
+      {
+        key: {
+          "doc.updatedAt": 1
+        }
+      }
+    ], this.db.collection(this.collectionName));
+  }
+
+
+  public async insertDiff(data: any) {
+    delete data.id;
+
+    const res = await this.db.collection(this.collectionName).insertOne({
+      doc: data
+    })
+
+    return res.insertedId;
+  }
+
+  public async sync(lastSync: number) {
+    return this.db.collection(this.collectionName).aggregate([
+      {
+        $match: {
+          "doc.updatedAt": {
+            $gte: lastSync
+          }
+        }
+      },
+      {
+        $replaceRoot: {
+          newRoot: '$doc'
+        }
+      }
+    ]).toArray()
+  }
+}

--- a/packages/graphback-datasync/src/providers/createDataSyncMongoDbProvider.ts
+++ b/packages/graphback-datasync/src/providers/createDataSyncMongoDbProvider.ts
@@ -3,6 +3,7 @@ import { ModelDefinition, GraphbackDataProvider } from '@graphback/core';
 import { MongoDBDataProvider } from "@graphback/runtime-mongo"
 import { isDataSyncModel } from '../util';
 import { DataSyncMongoDBDataProvider } from './DatasyncMongoDBDataProvider';
+import { DeltaDBDataProvider } from './DeltaDbDataProvider';
 
 /**
  * Creates a new Data synchronisation data provider for MongoDb
@@ -11,7 +12,12 @@ import { DataSyncMongoDBDataProvider } from './DatasyncMongoDBDataProvider';
  */
 export function createDataSyncMongoDbProvider(db: Db): (...args: any[]) => GraphbackDataProvider {
   return (model: ModelDefinition): GraphbackDataProvider => {
-    if (isDataSyncModel(model)) {
+    const annotationData = isDataSyncModel(model);
+    if (annotationData) {
+      if (annotationData.deltaTable === true) {
+        return new DeltaDBDataProvider(model.graphqlType, db);
+      }
+      
       return new DataSyncMongoDBDataProvider(model.graphqlType, db)
     } else {
       return new MongoDBDataProvider(model.graphqlType, db)

--- a/packages/graphback-datasync/src/providers/createDataSyncMongoDbProvider.ts
+++ b/packages/graphback-datasync/src/providers/createDataSyncMongoDbProvider.ts
@@ -2,23 +2,32 @@ import { Db } from 'mongodb';
 import { ModelDefinition, GraphbackDataProvider } from '@graphback/core';
 import { MongoDBDataProvider } from "@graphback/runtime-mongo"
 import { isDataSyncModel } from '../util';
+import { ConflictEngine, TimestampConflictEngine } from "../conflict";
 import { DataSyncMongoDBDataProvider } from './DatasyncMongoDBDataProvider';
 import { DeltaDBDataProvider } from './DeltaDbDataProvider';
+
+export interface ConflictStrategyMap {
+  [modelName: string]: new() => ConflictEngine
+}
 
 /**
  * Creates a new Data synchronisation data provider for MongoDb
  *
  * @param {Db} db - MongoDb connection
  */
-export function createDataSyncMongoDbProvider(db: Db): (...args: any[]) => GraphbackDataProvider {
+export function createDataSyncMongoDbProvider(db: Db, conflictStrategyMap?: ConflictStrategyMap): (...args: any[]) => GraphbackDataProvider {
   return (model: ModelDefinition): GraphbackDataProvider => {
     const annotationData = isDataSyncModel(model);
     if (annotationData) {
+      let conflictStrategy: new() => ConflictEngine;
+      if (conflictStrategyMap !== undefined) {
+        conflictStrategy = conflictStrategyMap[model.graphqlType.name];
+      }
       if (annotationData.deltaTable === true) {
-        return new DeltaDBDataProvider(model.graphqlType, db);
+        return new DeltaDBDataProvider(model.graphqlType, db, conflictStrategy);
       }
       
-      return new DataSyncMongoDBDataProvider(model.graphqlType, db)
+      return new DataSyncMongoDBDataProvider(model.graphqlType, db, conflictStrategy);
     } else {
       return new MongoDBDataProvider(model.graphqlType, db)
     }

--- a/packages/graphback-datasync/src/providers/index.ts
+++ b/packages/graphback-datasync/src/providers/index.ts
@@ -1,3 +1,5 @@
 export * from "./DataSyncProvider";
 export * from './DatasyncMongoDBDataProvider';
 export * from './createDataSyncMongoDbProvider';
+export * from './DeltaDbDataProvider';
+export * from './DeltaProvider';

--- a/packages/graphback-datasync/src/util.ts
+++ b/packages/graphback-datasync/src/util.ts
@@ -2,10 +2,10 @@ import { ModelDefinition, GraphbackCRUDService } from '@graphback/core';
 import { parseMetadata } from 'graphql-metadata';
 import { DataSyncCRUDService } from "./services";
 
-export function isDataSyncModel(model: ModelDefinition): boolean {
+export function isDataSyncModel(model: ModelDefinition): any {
   // (Both delta and versioned) or (just datasync)
   return (
-    (parseMetadata("delta", model.graphqlType) && parseMetadata("versioned", model.graphqlType))
+    (parseMetadata("versioned", model.graphqlType) && parseMetadata("delta", model.graphqlType))
     ||
     (parseMetadata('datasync', model.graphqlType))
   )

--- a/packages/graphback-datasync/tests/DataSyncMongoDBTests.ts
+++ b/packages/graphback-datasync/tests/DataSyncMongoDBTests.ts
@@ -4,7 +4,7 @@ import { buildSchema } from 'graphql';
 import { filterModelTypes, GraphbackCoreMetadata, metadataMap, NoDataError, defaultTableNameTransform } from '@graphback/core';
 import { advanceTo } from "jest-date-mock";
 import { SchemaCRUDPlugin } from "@graphback/codegen-schema";
-import { DataSyncMongoDBDataProvider, DataSyncPlugin, ConflictError } from '../src';
+import { DataSyncMongoDBDataProvider, DataSyncPlugin, ConflictError, TimestampConflictEngine } from '../src';
 
 const {fieldNames} = metadataMap;
 export interface Context {
@@ -45,7 +45,7 @@ export async function createTestingContext(schemaStr: string, config?: { seedDat
   const providers: { [name: string]: DataSyncMongoDBDataProvider } = {}
   const models = filterModelTypes(schema)
   for (const modelType of models) {
-    providers[modelType.name] = new DataSyncMongoDBDataProvider(modelType, db);
+    providers[modelType.name] = new DataSyncMongoDBDataProvider(modelType, db, TimestampConflictEngine);
   }
 
   // if seed data is supplied, insert it into collections

--- a/packages/graphback-runtime-mongodb/src/index.ts
+++ b/packages/graphback-runtime-mongodb/src/index.ts
@@ -1,4 +1,5 @@
 
 export * from "./MongoDBDataProvider";
 export * from './createMongoDbProvider';
+export * from './queryBuilder';
 export * from './utils/createIndexes';

--- a/packages/graphback-runtime-mongodb/tests/MongoDataProviderTest.ts
+++ b/packages/graphback-runtime-mongodb/tests/MongoDataProviderTest.ts
@@ -272,7 +272,7 @@ describe('MongoDBDataProvider Basic CRUD', () => {
     expect(updatedTodo.description).toBeUndefined();
     expect(updatedTodo.text).toEqual("updated todo");
 
-    const deletedTodo = await context.providers.Todos.update({id: createdTodo.id}, {graphback: {services: {}, options: { selectedFields: ["id", "text", "description"]}}});
+    const deletedTodo = await context.providers.Todos.delete({id: createdTodo.id}, {graphback: {services: {}, options: { selectedFields: ["id", "text", "description"]}}});
     expect(deletedTodo.id).toEqual(createdTodo.id);
     expect(deletedTodo.text).toEqual("updated todo");
     expect(deletedTodo.description).toEqual("todo add description");

--- a/templates/ts-apollo-mongodb-datasync-backend/src/index.ts
+++ b/templates/ts-apollo-mongodb-datasync-backend/src/index.ts
@@ -6,7 +6,7 @@ import { ApolloServer } from "apollo-server-express"
 import { buildGraphbackAPI } from 'graphback'
 import { loadSchemaSync } from '@graphql-tools/load'
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader'
-import { createDataSyncMongoDbProvider, createDataSyncCRUDService, DataSyncPlugin } from '@graphback/datasync'
+import { createDataSyncCRUDService, DataSyncPlugin } from '@graphback/datasync'
 // eslint-disable-next-line @typescript-eslint/tslint/config
 import cors from "cors"
 // eslint-disable-next-line @typescript-eslint/tslint/config


### PR DESCRIPTION
This is a spike towards investigating Delta Tables for datasync, can be tested out as follows:

- for delta Table

This is enabled in schema
Use the following schema with datasync template

```graphql
""" 
@model
@datasync(deltaTable: true)
"""
type Comment {
  id: ID!
  text: String
  description: String
}
```
It should create a comment_delta collection in the database

- conflict

Conflicts are enabled in code
Import TimestampConflictEngine from datasync package:
```typescript
import { TimestampConflictEngine } from '@graphback/datasync'
```

Provide a map of model name to conflict strategy(pardon the horrendous inconsistency in the names, I would love some feedback about what to call them) in createDataSyncMongoDbProvider as follows:
```typescript
createDataSyncMongoDbProvider(db, { Comment: TimestampConflictEngine })
```
This tells it to use Timestamp based conflicts for the Comment model, there is also another strategy intended for use with delta tables called DeltaConflictEngine, it checks if the fields to be updated have changed since the client passed `updatedAt` timestamp, and raises a conflict if they have, I would love some feedback about this as well.

Note, if using delta table, sync query only returns fields that have changed, not sure this is optimal so feedback needed