### PR TITLE
docs(website): add database migrations documentation

### DIFF
--- a/docs/databases/migrations.md
+++ b/docs/databases/migrations.md
@@ -1,7 +1,0 @@
----
-id: graphql-migrations
-title: GraphQL Migrations
-sidebar_label: GraphQL Migrations
----
-
-## TODO

--- a/docs/graphql-migrations/api-reference.md
+++ b/docs/graphql-migrations/api-reference.md
@@ -1,0 +1,140 @@
+---
+id: api
+title: API Reference
+sidebar_label: API Reference
+---
+
+The `migrateDB` method takes the three arguments, listed below.
+- `config`: [Knex](https://knexjs.org/#Installation-client) database configuration options.
+- `schemaText`: GraphQL schema text.
+- `options`: 
+   - `dbSchemaName` (default: `'public'`): table schema: `<schemaName>.<tableName>`.
+  - `dbTablePrefix` (default: `''`): table name prefix: `<prefix><tableName>`.
+  - `dbColumnPrefix` (default: `''`): column name prefix: `<prefix><columnName>`.
+  - [`updateComments`](#table-and-column-comments) (default: `false`): by default, `migrateDB` will not create or update comments on table and columns.
+  - [`scalarMap`](#scalar-mapping) (default: `undefined`): Custom Scalar mapping
+  - `mapListToJson` (default: `true`): Map scalar/enum lists to json column type by default.
+  - [`plugins`](plugins.md) (default: `[]`): List of [graphql-migrations plugins](https://github.com/aerogear/graphback/blob/master/packages/graphql-migrations/src/plugin/MigratePlugin.ts) which describes queries that can be executed during migrations. 
+  - `debug` (default: `false`): displays debugging informations and SQL queries.
+  - `removeDirectivesFromSchema`: (default: `true`): Strips all directives from schema before processing.
+  - [`operationFilter`](./filter.md): Filter out database operations that we don't want, e.g. [prevent table deletion](https://github.com/aerogear/graphback/blob/master/packages/graphql-migrations/src/plugin/MigrateOperationFilter.ts).
+
+## Table and Column Comments
+
+When `updateComments` is set to `true` it will automatically create/update table and column comments. 
+Table / column comments are type or field description parsed from the model schema. 
+The parsing logic takes care of stripping off all annotations leaving only business related comments.    
+
+The below model:
+
+```graphql
+"""
+Note business model table comment.
+@model
+"""
+type Note {
+  id: ID!
+  """
+  Note title.
+  """
+  title: String!
+}
+```
+
+Execution with the `updateComments` options set to true, as shown below
+```ts
+....
+migrateDB(dbConfig, schemaText, {
+  updateComments: true
+}).then((ops) => {
+    console.log(ops);
+});
+...
+```
+
+Will create / update the `note` table comments as shown below: 
+
+```sql
+\d+
+                                       List of relations
+ Schema |    Name     |   Type   |   Owner    |    Size    |            Description             
+--------+-------------+----------+------------+------------+------------------------------------
+ public | note        | table    | postgresql | 8192 bytes | Note business model table comment.
+ public | note_id_seq | sequence | postgresql | 8192 bytes | 
+(2 rows)
+```
+
+```sql
+\d+ note
+                                                     Table "public.note"
+ Column |          Type          |                     Modifiers                     | Storage  | Stats target | Description 
+--------+------------------------+---------------------------------------------------+----------+--------------+-------------
+ title  | character varying(255) | not null                                          | extended |              | Note title.
+ id     | integer                | not null default nextval('note_id_seq'::regclass) | plain    |              | 
+Indexes:
+    "note_pkey" PRIMARY KEY, btree (id)
+```
+ 
+> NOTE: This options may not be supported by some database. 
+
+## Scalar Mapping
+
+This option is a function used to specify custom Scalar mapping.
+It takes three arguments `(field: GraphQLField, fieldType: GraphQLScalarType, dbAnnotation: any)`, depending on the field type you could return the `TableColumnTypeDescriptor`: 
+
+```ts
+interface TableColumnTypeDescriptor {
+  /**
+   * Knex column builder function name.
+   */
+  type: TableColumnType | string
+  /**
+   * Builder function arguments.
+   */
+  args: any[]
+}
+```
+
+For example, if you want a custom `CustomDate` scalar to be have a `date` type in the database:
+
+```ts
+import { migrateDB } from 'graphql-migrations';
+
+const schemaText = ```
+""" @model """
+type Note {
+  id: ID!
+  title: String!
+  createdAt: CustomDate
+}
+
+scalar CustomDate
+```;
+
+const dbConfig = {
+   // Knex.js db configuration
+};
+
+migrateDB(dbConfig, schemaText, {
+  scalarMap: (
+  field: GraphQLField<any, any>,
+  scalarType: GraphQLScalarType,
+  annotations: any,
+): TableColumnTypeDescriptor | null => {
+
+  // custom date converted to date type
+  if (scalarType.name === 'CustomDate') {
+    return {
+      type: 'date',
+      args: []
+    }
+  }
+
+  return undefined
+} 
+}).then((ops) => {
+    console.log(ops);
+});
+```
+
+A good example of this function is the [default scalar type to database column](https://github.com/aerogear/graphback/blob/master/packages/graphql-migrations/src/abstract/getColumnTypeFromScalar.ts#L18-L129) function, that Graphback uses to convert scalar types based on certain creteria.

--- a/docs/graphql-migrations/db-design.md
+++ b/docs/graphql-migrations/db-design.md
@@ -1,0 +1,464 @@
+---
+id: db-design
+title: Database Design
+sidebar_label: Database Design
+---
+
+GraphQL Migrations operates on business models defined in your schema: These are GraphQL types decorated with a [`@model`](../model/datamodel#model) annotation. 
+
+
+### Primary key
+
+Each type must have a primary key. You can specify one are one using the [`@id`](../model/annotations#id) annotation on a field.
+
+```graphql
+type Note {
+  """
+  custom primary key on a note
+  @id  
+  """
+  reference: String!
+  
+  title: String!
+}
+```
+
+Alternatively, you can use auto-incremented primary keys by having an `id` field which mus be of type `ID`.
+
+```graphql
+type Note {
+  id: ID!
+  title: String!
+}
+```
+
+### Nullability
+
+GraphQL Migrations packages automatically adds a `NOT NULL` constraint to all non null fields defined in the business model. 
+All primary keys are not nullable, irrespective of whether they are defined as non null or not. 
+
+```graphql
+type Note {
+  """
+  custom primary key on a note
+  @id  
+  """
+  reference: String!
+  
+  title: String!
+}
+```
+
+The above model definition will result in the following table being created: 
+```sql
+\d note
+              Table "public.note"
+  Column   |          Type          | Modifiers 
+-----------+------------------------+-----------
+ reference | character varying(255) | not null
+ title     | character varying(255) | not null
+Indexes:
+    "note_pkey" PRIMARY KEY, btree (reference)
+```
+
+### Foreign keys
+
+GraphQL Migrations will automatically create and index foreign keys once it sees relationships between business models.
+
+#### OneToOne
+
+```graphql
+"""
+@model
+"""
+type Profile {
+  id: ID!
+  """
+  @oneToOne
+  """
+  user: User!
+}
+
+"""
+@model
+"""
+type User {
+  id: ID!
+  name: String
+}
+```
+
+This creates a relationship via a `userId` column in the `profile` table. You can customize the key tracking the relationship with the `key` annotation:
+
+```graphql
+"""
+@model
+"""
+type Profile {
+  id: ID!
+  """
+  @oneToOne(key: 'user_id')
+  """
+  user: User!
+}
+
+"""
+@model
+"""
+type User {
+  id: ID!
+  name: String
+}
+```
+
+This maps `Profile.user` to `profile.user_id` in the database.
+
+#### OneToMany
+
+```graphql
+"""
+@model
+"""
+type Note {
+  id: ID!
+  title: String!
+  """
+  @oneToMany(field: 'note')
+  """
+  comments: [Comment]
+}
+```
+
+This specifies a relationship between `Note.comments` and `Comment.note` and maps to `comment.noteId` in the database. 
+
+With the `key` annotation you can customise the database column to map to.
+
+```graphql
+"""
+@model
+"""
+type Note {
+  id: ID!
+  title: String!
+  """
+  @oneToMany(field: 'note', key: 'note_id')
+  """
+  comments: [Comment]
+}
+```
+
+This maps to `comment.note_id` in the database.
+
+#### ManyToMany
+
+To create a many-to-many relationship, add a model for your join table and use two one-to-many relationship mappings to create the relationship.
+
+```graphql
+""" 
+@model 
+"""
+type Note {
+  id: ID!
+  title: String!
+  description: String
+  """
+  @oneToMany(field: 'note')
+  """
+  authors: [NoteAuthor]
+}
+
+"""
+@model
+"""
+type NoteAuthor {
+  id: ID!
+}
+
+"""
+@model
+"""
+type User {
+  id: ID!
+  name: String
+  """
+  @oneToMany(field: 'author')
+  """
+  notes: [NoteAuthor]
+}
+```
+
+Let's see all of these in an example code below ran agains the PostgreSQL database:
+
+```ts
+import { migrateDB } from 'graphql-migrations';
+
+const schemaText = ```
+""" @model """
+type Note {
+  id: ID!
+  title: String!
+  description: String
+  """
+  @oneToMany(field: 'note')
+  """
+  comments: [Comment]!
+}
+
+""" @model """
+type Comment {
+  """
+  @id
+  """
+  text: String
+  description: String
+}
+```;
+
+const dbConfig = {
+    client: process.env.DB_CLIENT,
+    connection: {
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      host: "localhost",
+      port: 5432
+    },
+    pool: { min: 5, max: 30 }
+};
+
+migrateDB(dbConfig, schemaText, {
+  // Additional options
+}).then((ops) => {
+    console.log(ops);
+});
+...
+```
+
+This is a classic business model containing two types: `Note` and `Comment`, having a `oneToMany` relationship between them.
+From the relationship definition we can deduce that a `Note` can have zero or many comments, inversely a `Comment` can be about
+one `Note`.
+
+Upon successfuly completion, the above migration will create the following layout in your database schema.
+
+```sql
+              List of relations
+ Schema |    Name     |   Type   |   Owner    
+--------+-------------+----------+------------
+ public | comment     | table    | postgresql
+ public | note        | table    | postgresql
+ public | note_id_seq | sequence | postgresql
+(3 rows)
+```
+
+We can see notice that we have the `note_id_seq` but not `comment_id_seq`, this is because we are using auto-incremented 
+primary key for the `Note` model and a custom primary key for the `Comment` model. We will see how these looks like in details 
+for each model below:
+
+```sql
+\d comment
+              Table "public.comment"
+   Column    |          Type          | Modifiers 
+-------------+------------------------+-----------
+ text        | character varying(255) | not null
+ description | character varying(255) | 
+ noteId      | integer                | 
+Indexes:
+    "comment_pkey" PRIMARY KEY, btree (text)
+Foreign-key constraints:
+    "comment_noteid_foreign" FOREIGN KEY ("noteId") REFERENCES note(id)
+```
+
+Table details for the `Comment` type shows that we have a `text` as the primary key and `noteId` as a foreign key on the `Note` type because of the relationship we defined. 
+
+Here is how the `Note` table looks like:
+
+```sql
+\d note
+                                   Table "public.note"
+   Column    |          Type          |                     Modifiers                     
+-------------+------------------------+---------------------------------------------------
+ title       | character varying(255) | not null
+ description | character varying(255) | 
+ id          | integer                | not null default nextval('note_id_seq'::regclass)
+Indexes:
+    "note_pkey" PRIMARY KEY, btree (id)
+Referenced by:
+    TABLE "comment" CONSTRAINT "comment_noteid_foreign" FOREIGN KEY ("noteId") REFERENCES note(id)
+```
+
+GraphQL Migrations created the auto-incremented primary key by inferring the usage of `id: ID!` field on the `Note` model.
+Additionally we can see that this primary key is referenced by the `comment` table because of the relationship.
+
+
+### Default field value
+
+You can specify a default value using the `@default` field annotation as shown below.
+
+```graphql
+type Note {
+  id: ID!
+  title: String!
+  """
+  Define a default value
+  @default(value: false)
+  """
+  complete: Boolean
+}
+```
+
+### Custom column type
+
+You can specify a custom type usig the `@db` field annotation as shown below:
+
+```graphql
+type Note {
+  id: ID!
+  """
+  Define a custom json type
+  @db(type: 'json')
+  """
+  comments: [Comment]
+}
+
+type Comment {
+  text: String
+  description: String
+}
+```
+
+### Column length
+
+By default string columns will be created as `varchar` with a column length of `255`. 
+This can be configured to any length using the `@db` field annnotation and the `length` argument:
+
+```graphql
+type Note {
+  id: ID!
+  """
+  Define custom column length
+  @db(length: 100)
+  """
+  title: String!
+}
+```
+
+### Ignore a field 
+
+Sometimes our business model can contain more fields and some of these fields may only be there for representation purposes.
+We can safely ignore generating columns for these fields using the `@db(skip: true)` annotation on the corresponding field. 
+
+```graphql
+type Note {
+  id: ID!
+  """
+  Define custom column length
+  @db(skip: true)
+  """
+  title: String!
+}
+```
+:::caution
+This annotation is not supported by Graphback CRUD.
+:::
+
+### Column name
+
+When working with database migration library it is possible to change individual database columns.
+
+```graphql
+type Note {
+  id: ID!
+  """
+  @db(name: 'note_title')
+  """
+  title: String!
+}
+```
+
+:::caution
+This annotation is not supported by Graphback CRUD.
+When using custom name in database we need to map it directly inside resolver or db layer.
+
+```ts
+      // In your data provider
+      data.title = data['note_title']
+      return data;
+    }
+```
+:::
+
+
+### Index
+
+The `@index` annotation can be used to create an index on a specific field. This annotation takes `name` as argument representing 
+the name of the created index. If the name argument is left out, GraphQL Migrations will create one for you using the `<tablename>_<columnName>_index` format.
+
+For example:
+
+```graphql
+"""
+@model
+"""
+type Comment {
+  id: ID!
+  """
+  @index(name: "title-index")
+  """
+  text: String!
+  """
+  @index
+  """
+  description: String
+}
+```
+
+The above model will result in the following indexes being created
+
+```sql
+\d comment
+                                   Table "public.comment"
+   Column    |          Type          |                       Modifiers                       
+-------------+------------------------+-------------------------------------------------------
+ text        | character varying(255) | not null
+ description | character varying(255) | 
+ id          | integer                | not null default nextval('comment_id_seq'::regclass)
+Indexes:
+    "comment_pkey" PRIMARY KEY, btree (id)
+    "comment_description_index" btree (description)
+    "title-index" btree (text)
+```
+
+
+### Unique
+
+The `@unique` annotation can be used to create an unique constraint on a specific field. GraphQL Migrations will create the constraint name
+using the `<tablename>_<columnName>_unique` format.
+
+For example:
+
+```graphql
+"""
+@model
+"""
+type Comment {
+  id: ID!
+  """
+  @unique
+  """
+  text: String
+}
+```
+
+The above model will result in the following constraint being created
+
+```sql
+\d comment
+                                   Table "public.comment"
+   Column    |          Type          |                       Modifiers                       
+-------------+------------------------+-------------------------------------------------------
+ text        | character varying(255) | 
+ id          | integer                | not null default nextval('comment_id_seq'::regclass)
+Indexes:
+    "comment_pkey" PRIMARY KEY, btree (id)
+    "comment_text_unique" UNIQUE CONSTRAINT, btree (text)
+```

--- a/docs/graphql-migrations/filter.md
+++ b/docs/graphql-migrations/filter.md
@@ -1,0 +1,7 @@
+---
+id: filter
+title: GraphQL Migrations Filters
+sidebar_label: Operation Filter
+---
+
+## TODO

--- a/docs/graphql-migrations/intro.md
+++ b/docs/graphql-migrations/intro.md
@@ -1,0 +1,92 @@
+---
+id: intro
+title: GraphQL Migrations
+sidebar_label: Introduction
+---
+
+Graphback uses [graphql-migrations](https://www.npmjs.com/package/graphql-migrations) to automatically create and update tables from a GraphQL schema.
+The library compares your database schema to your GraphQL schema and executes the required changes to keep the database structure synchronised with the GraphQL schema.
+
+## Compatibility
+
+- PostgreSQL (create and update database)
+- SQLite (create database only)
+
+## Installation
+
+You can install `graphql-migrations` on your existing project using the following commmands:
+
+With npm: 
+
+```shell
+npm i graphql-serve
+```
+
+or with yarn:
+
+```shell
+yarn add graphql-serve
+```
+
+## Usage
+
+GraphQL Migrations operates on business models defined in your schema: These are GraphQL types decorated with a [`@model`](../model/datamodel#model) annotation. 
+The package expose an API which you can programmatically set up in your source code and have it perform the migrations. 
+
+The package exposes a `migrateDB` method which creates and updates your tables and columns to match your GraphQL schema.
+All the database operations are wrapped in a single transaction, so your database will be fully rolled back to its initial state if an error occurs.
+The method takes three arguments as described in [migrations options](#options) section.
+
+```ts
+import { migrateDB } from 'graphql-migrations';
+
+const schemaText = ```
+"""
+@model
+"""
+type Note {
+  id: ID!
+  title: String!
+}
+```;
+
+const dbConfig = {
+  // Knex.js based configuration
+};
+
+migrateDB(dbConfig, schemaText, {
+  // Additional options
+}).then((ops) => {
+    console.log(ops);
+});
+...
+```
+
+Assuming the above code is ran against a PostgreSQL database, the following relations will be created:
+```sql
+\d
+              List of relations
+ Schema |    Name     |   Type   |   Owner    
+--------+-------------+----------+------------
+ public | note        | table    | postgresql
+ public | note_id_seq | sequence | postgresql
+```
+
+And the `note` table:
+
+```sql
+ \d note
+                                 Table "public.note"
+ Column |          Type          |                     Modifiers                     
+--------+------------------------+---------------------------------------------------
+ title  | character varying(255) | not null
+ id     | integer                | not null default nextval('note_id_seq'::regclass)
+Indexes:
+    "note_pkey" PRIMARY KEY, btree (id)
+```
+
+## Advanced usage
+
+For more advanced usage, visit the below pages:
+- [Database Design](db-design)
+- [API Reference](api)

--- a/docs/graphql-migrations/plugins.md
+++ b/docs/graphql-migrations/plugins.md
@@ -1,0 +1,7 @@
+---
+id: plugins
+title: GraphQL Migrations Plugins
+sidebar_label: Plugins
+---
+
+## TODO

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -18,8 +18,7 @@
     "Databases": [
       "databases/databases",
       "databases/postgres",
-      "databases/mongodb",
-      "databases/graphql-migrations"
+      "databases/mongodb"
     ],
     "Subscriptions": [
       "subscriptions/intro"
@@ -33,7 +32,9 @@
       "datasync/soft-delete"
     ],
     "GraphQL Migrations": [
-      "databases/graphql-migrations"
+      "graphql-migrations/intro",
+      "graphql-migrations/db-design",
+      "graphql-migrations/api"
     ],
     "GraphQL Serve": [
       "graphqlserve/graphqlserve"


### PR DESCRIPTION
TODO

- [x] Show an example generate table
- [x] Show an example of generated tables with advance options e.g database type, length, default value, foreign keys 
- [x] Indexing and unique columns 
- [x] Document various main options e.g ScalarMap