### PR TITLE
fix(graphql-migrations): add column.drop as unsafe operations and filter it out

### DIFF
--- a/packages/graphql-migrations/src/plugin/MigrateOperationFilter.ts
+++ b/packages/graphql-migrations/src/plugin/MigrateOperationFilter.ts
@@ -1,4 +1,4 @@
-import { Operation } from '../diff/Operation';
+import { Operation, OperationType } from '../diff/Operation';
 
 
 /**
@@ -14,18 +14,9 @@ export interface MigrateOperationFilter {
  * Suppress table deletion and renaming for operations that are not going to cause
  * data loss when field was removed accidentially.
  */
+
+const UNSAFE_OPERATIONS: OperationType[] = ['table.drop', 'column.drop', 'table.rename', 'column.rename'];
+
 export const removeNonSafeOperationsFilter: MigrateOperationFilter = {
-
-  filter: (operations: Operation[]) => {
-    return operations.filter((op: Operation) => {
-      if (op.type === 'table.drop' ||
-                op.type === 'table.rename' ||
-                op.type === 'column.rename') {
-        return false;
-      }
-
-      return true;
-    })
-  }
+  filter: (operations: Operation[]) => operations.filter((op: Operation) => !UNSAFE_OPERATIONS.includes(op.type))
 };
-

--- a/packages/graphql-migrations/tests/removeNonSafeOperationsFilterTest.ts
+++ b/packages/graphql-migrations/tests/removeNonSafeOperationsFilterTest.ts
@@ -1,0 +1,23 @@
+import { Operation } from '../src/diff/Operation';
+import { removeNonSafeOperationsFilter } from '../src/plugin/MigrateOperationFilter';
+
+test('remove table, colum deletion and rename operations', () => {
+  const ops: Operation[] = [
+    { type: 'table.index.drop', priority: 0 },
+    { type: 'column.create', priority: 0 },
+    { type: 'column.drop', priority: 0 },
+    { type: 'table.rename', priority: 0 },
+    { type: 'table.create', priority: 0 },
+    { type: 'table.drop', priority: 0 },
+    { type: 'column.rename', priority: 0 }
+  ];
+
+  const expected = removeNonSafeOperationsFilter.filter(ops);
+
+  expect(expected).toEqual([
+    { type: 'table.index.drop', priority: 0 },
+    { type: 'column.create', priority: 0 },
+    { type: 'table.create', priority: 0 },
+  ])
+})
+


### PR DESCRIPTION

Fixes https://github.com/aerogear/graphback/issues/1673

Hoping to bring this in since the `removeNonSafeOperationsFilter` will be documented / advertised here https://github.com/aerogear/graphback/pull/1674