### PR TITLE
feat(schema): remove subscription filtering

### DIFF
--- a/packages/graphback-codegen-client/src/templates/gqlTemplates.ts
+++ b/packages/graphback-codegen-client/src/templates/gqlTemplates.ts
@@ -84,11 +84,10 @@ export const deleteMutation = (t: GraphQLObjectType) => {
 `
 }
 
-export const subscription = (t: GraphQLObjectType, fieldName: string, inputTypeField: string) => {
-
-  return `subscription ${fieldName}($filter: ${inputTypeField}) {
-  ${fieldName}(filter: $filter) {
-      ...${t.name}Fields
+export const subscription = (t: GraphQLObjectType, fieldName: string) => {
+  return `subscription ${fieldName} {
+  ${fieldName} {
+    ...${t.name}Fields
   }
 } `
 }
@@ -170,28 +169,25 @@ const createSubscriptions = (types: ModelDefinition[]) => {
 
     if (t.crudOptions.create && t.crudOptions.subCreate) {
       const operation = getSubscriptionName(name, GraphbackOperationType.CREATE);
-      const inputTypeField = getInputTypeName(t.graphqlType.name, GraphbackOperationType.SUBSCRIPTION_CREATE)
       subscriptions.push({
         name: operation,
-        implementation: subscription(t.graphqlType, operation, inputTypeField)
+        implementation: subscription(t.graphqlType, operation)
       })
     }
 
     if (t.crudOptions.update && t.crudOptions.subUpdate) {
       const operation = getSubscriptionName(name, GraphbackOperationType.UPDATE);
-      const inputTypeField = getInputTypeName(t.graphqlType.name, GraphbackOperationType.SUBSCRIPTION_UPDATE)
       subscriptions.push({
         name: operation,
-        implementation: subscription(t.graphqlType, operation, inputTypeField)
+        implementation: subscription(t.graphqlType, operation)
       })
     }
 
     if (t.crudOptions.delete && t.crudOptions.subDelete) {
       const operation = getSubscriptionName(name, GraphbackOperationType.DELETE);
-      const inputTypeField = getInputTypeName(t.graphqlType.name, GraphbackOperationType.SUBSCRIPTION_DELETE)
       subscriptions.push({
         name: operation,
-        implementation: subscription(t.graphqlType, operation, inputTypeField)
+        implementation: subscription(t.graphqlType, operation)
       })
     }
   })

--- a/packages/graphback-codegen-client/src/templates/tsTemplates.ts
+++ b/packages/graphback-codegen-client/src/templates/tsTemplates.ts
@@ -61,7 +61,7 @@ const deleteMutationTS = (t: GraphQLObjectType) => {
 
 const subscriptionTS = (t: GraphQLObjectType, subscriptionName: string, inputField: string) => {
   return `export const ${subscriptionName} = gql\`
-  ${subscription(t, subscriptionName, inputField)}
+  ${subscription(t, subscriptionName)}
 
   \$\{${t.name}Fragment}
 \`

--- a/packages/graphback-codegen-client/tests/__snapshots__/GraphQLClientCreatorTest.ts.snap
+++ b/packages/graphback-codegen-client/tests/__snapshots__/GraphQLClientCreatorTest.ts.snap
@@ -150,49 +150,49 @@ Object {
   ],
   "subscriptions": Array [
     Object {
-      "implementation": "subscription newNote($filter: NoteSubscriptionFilter) {
-  newNote(filter: $filter) {
-      ...NoteFields
+      "implementation": "subscription newNote {
+  newNote {
+    ...NoteFields
   }
 } ",
       "name": "newNote",
     },
     Object {
-      "implementation": "subscription updatedNote($filter: NoteSubscriptionFilter) {
-  updatedNote(filter: $filter) {
-      ...NoteFields
+      "implementation": "subscription updatedNote {
+  updatedNote {
+    ...NoteFields
   }
 } ",
       "name": "updatedNote",
     },
     Object {
-      "implementation": "subscription deletedNote($filter: NoteSubscriptionFilter) {
-  deletedNote(filter: $filter) {
-      ...NoteFields
+      "implementation": "subscription deletedNote {
+  deletedNote {
+    ...NoteFields
   }
 } ",
       "name": "deletedNote",
     },
     Object {
-      "implementation": "subscription newComment($filter: CommentSubscriptionFilter) {
-  newComment(filter: $filter) {
-      ...CommentFields
+      "implementation": "subscription newComment {
+  newComment {
+    ...CommentFields
   }
 } ",
       "name": "newComment",
     },
     Object {
-      "implementation": "subscription updatedComment($filter: CommentSubscriptionFilter) {
-  updatedComment(filter: $filter) {
-      ...CommentFields
+      "implementation": "subscription updatedComment {
+  updatedComment {
+    ...CommentFields
   }
 } ",
       "name": "updatedComment",
     },
     Object {
-      "implementation": "subscription deletedComment($filter: CommentSubscriptionFilter) {
-  deletedComment(filter: $filter) {
-      ...CommentFields
+      "implementation": "subscription deletedComment {
+  deletedComment {
+    ...CommentFields
   }
 } ",
       "name": "deletedComment",
@@ -418,9 +418,9 @@ export const CommentFragment = gql\`
   "subscriptions": Array [
     Object {
       "implementation": "export const newNote = gql\`
-  subscription newNote($filter: NoteSubscriptionFilter) {
-  newNote(filter: $filter) {
-      ...NoteFields
+  subscription newNote {
+  newNote {
+    ...NoteFields
   }
 } 
 
@@ -431,9 +431,9 @@ export const CommentFragment = gql\`
     },
     Object {
       "implementation": "export const updatedNote = gql\`
-  subscription updatedNote($filter: NoteSubscriptionFilter) {
-  updatedNote(filter: $filter) {
-      ...NoteFields
+  subscription updatedNote {
+  updatedNote {
+    ...NoteFields
   }
 } 
 
@@ -444,9 +444,9 @@ export const CommentFragment = gql\`
     },
     Object {
       "implementation": "export const deletedNote = gql\`
-  subscription deletedNote($filter: NoteSubscriptionFilter) {
-  deletedNote(filter: $filter) {
-      ...NoteFields
+  subscription deletedNote {
+  deletedNote {
+    ...NoteFields
   }
 } 
 
@@ -457,9 +457,9 @@ export const CommentFragment = gql\`
     },
     Object {
       "implementation": "export const newComment = gql\`
-  subscription newComment($filter: CommentSubscriptionFilter) {
-  newComment(filter: $filter) {
-      ...CommentFields
+  subscription newComment {
+  newComment {
+    ...CommentFields
   }
 } 
 
@@ -470,9 +470,9 @@ export const CommentFragment = gql\`
     },
     Object {
       "implementation": "export const updatedComment = gql\`
-  subscription updatedComment($filter: CommentSubscriptionFilter) {
-  updatedComment(filter: $filter) {
-      ...CommentFields
+  subscription updatedComment {
+  updatedComment {
+    ...CommentFields
   }
 } 
 
@@ -483,9 +483,9 @@ export const CommentFragment = gql\`
     },
     Object {
       "implementation": "export const deletedComment = gql\`
-  subscription deletedComment($filter: CommentSubscriptionFilter) {
-  deletedComment(filter: $filter) {
-      ...CommentFields
+  subscription deletedComment {
+  deletedComment {
+    ...CommentFields
   }
 } 
 

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -7,7 +7,7 @@ import { SchemaComposer, NamedTypeComposer } from 'graphql-compose';
 import { IResolvers, IFieldResolver } from '@graphql-tools/utils'
 import { parseMetadata } from "graphql-metadata";
 import { gqlSchemaFormatter, jsSchemaFormatter, tsSchemaFormatter } from './writer/schemaFormatters';
-import { buildFilterInputType, createModelListResultType, StringScalarInputType, BooleanScalarInputType, SortDirectionEnum, buildCreateMutationInputType, buildFindOneFieldMap, buildMutationInputType, OrderByInputType, buildSubscriptionFilterType, IDScalarInputType, PageRequest, createInputTypeForScalar, createVersionedFields, createVersionedInputFields, addCreateObjectInputType, addUpdateObjectInputType, JSONScalarInputType } from './definitions/schemaDefinitions';
+import { buildFilterInputType, createModelListResultType, StringScalarInputType, BooleanScalarInputType, SortDirectionEnum, buildCreateMutationInputType, buildFindOneFieldMap, buildMutationInputType, OrderByInputType, IDScalarInputType, PageRequest, createInputTypeForScalar, createVersionedFields, createVersionedInputFields, addCreateObjectInputType, addUpdateObjectInputType, JSONScalarInputType } from './definitions/schemaDefinitions';
 
 /**
  * Configuration for Schema generator CRUD plugin
@@ -155,52 +155,26 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const modelTC = schemaComposer.getOTC(name)
     const modelType = modelTC.getType()
 
-    buildSubscriptionFilterType(schemaComposer, modelType);
-
     const subscriptionFields = {}
     if (model.crudOptions.subCreate && model.crudOptions.create) {
       const operation = getSubscriptionName(name, GraphbackOperationType.CREATE)
 
-      const filterInputName = getInputTypeName(name, GraphbackOperationType.SUBSCRIPTION_CREATE)
-      const subCreateFilterInputType = schemaComposer.getITC(filterInputName).getType()
-
       subscriptionFields[operation] = {
-        type: GraphQLNonNull(modelType),
-        args: {
-          filter: {
-            type: subCreateFilterInputType,
-          },
-        }
+        type: GraphQLNonNull(modelType)
       };
     }
     if (model.crudOptions.subUpdate && model.crudOptions.update) {
       const operation = getSubscriptionName(name, GraphbackOperationType.UPDATE)
 
-      const filterInputName = getInputTypeName(name, GraphbackOperationType.SUBSCRIPTION_UPDATE)
-      const subUpdateFilterInputType = schemaComposer.getITC(filterInputName).getType()
-
       subscriptionFields[operation] = {
-        type: GraphQLNonNull(modelType),
-        args: {
-          filter: {
-            type: subUpdateFilterInputType,
-          },
-        }
+        type: GraphQLNonNull(modelType)
       };
     }
     if (model.crudOptions.subDelete && model.crudOptions.delete) {
       const operation = getSubscriptionName(name, GraphbackOperationType.DELETE)
 
-      const filterInputName = getInputTypeName(name, GraphbackOperationType.SUBSCRIPTION_DELETE)
-      const subDeleteFilterInputType = schemaComposer.getITC(filterInputName).getType()
-
       subscriptionFields[operation] = {
-        type: GraphQLNonNull(modelType),
-        args: {
-          filter: {
-            type: subDeleteFilterInputType,
-          },
-        }
+        type: GraphQLNonNull(modelType)
       };
     }
 

--- a/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
+++ b/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
@@ -224,36 +224,6 @@ export const buildCreateMutationInputType = (schemaComposer: SchemaComposer<any>
   schemaComposer.add(mutationInputType)
 }
 
-export const buildSubscriptionFilterType = (schemaComposer: SchemaComposer<any>, modelType: GraphQLObjectType) => {
-  const inputTypeName = getInputTypeName(modelType.name, GraphbackOperationType.SUBSCRIPTION_CREATE);
-  const modelFields = Object.values(modelType.getFields());
-  const scalarFields = modelFields.filter((f: GraphQLField<any, any>) => {
-    const namedType = getNamedType(f.type);
-
-    return isScalarType(namedType) || isEnumType(namedType);
-  });
-
-  const filterInputType = new GraphQLInputObjectType({
-    name: inputTypeName,
-    fields: () => scalarFields
-      .map(({ name, type }: GraphQLField<any, any>) => {
-        const fieldType: GraphQLNamedType = getNamedType(type);
-
-        return {
-          name,
-          type: fieldType || type,
-          description: undefined
-        };
-      }).reduce((fieldObj: any, { name, type, description }: any) => {
-        fieldObj[name] = { type, description }
-
-        return fieldObj;
-      }, {})
-  });
-
-  schemaComposer.add(filterInputType)
-}
-
 export const buildMutationInputType = (schemaComposer: SchemaComposer<any>, modelType: GraphQLObjectType) => {
   const operationType = GraphbackOperationType.UPDATE
   const inputTypeName = getInputTypeName(modelType.name, operationType);

--- a/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
+++ b/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
@@ -203,12 +203,6 @@ type CommentResultList {
   count: Int
 }
 
-input CommentSubscriptionFilter {
-  id: ID
-  title: String
-  description: String
-}
-
 input CreateCommentInput {
   id: ID
   title: String!
@@ -405,12 +399,6 @@ type NoteResultList {
   count: Int
 }
 
-input NoteSubscriptionFilter {
-  id: ID
-  title: String
-  description: String
-}
-
 input OrderByInput {
   field: String!
   order: SortDirectionEnum = ASC
@@ -450,15 +438,15 @@ input StringInput {
 }
 
 type Subscription {
-  newNote(filter: NoteSubscriptionFilter): Note!
-  updatedNote(filter: NoteSubscriptionFilter): Note!
-  deletedNote(filter: NoteSubscriptionFilter): Note!
-  newTest(filter: TestSubscriptionFilter): Test!
-  updatedTest(filter: TestSubscriptionFilter): Test!
-  deletedTest(filter: TestSubscriptionFilter): Test!
-  newComment(filter: CommentSubscriptionFilter): Comment!
-  updatedComment(filter: CommentSubscriptionFilter): Comment!
-  deletedComment(filter: CommentSubscriptionFilter): Comment!
+  newNote: Note!
+  updatedNote: Note!
+  deletedNote: Note!
+  newTest: Test!
+  updatedTest: Test!
+  deletedTest: Test!
+  newComment: Comment!
+  updatedComment: Comment!
+  deletedComment: Comment!
 }
 
 \\"\\"\\"@model\\"\\"\\"
@@ -480,11 +468,6 @@ type TestResultList {
   offset: Int
   limit: Int
   count: Int
-}
-
-input TestSubscriptionFilter {
-  id: ID
-  name: String
 }"
 `;
 
@@ -774,32 +757,15 @@ input CreateFixInput {
 }
 
 type Subscription {
-  newNote(filter: NoteSubscriptionFilter): Note!
-  updatedNote(filter: NoteSubscriptionFilter): Note!
-  deletedNote(filter: NoteSubscriptionFilter): Note!
-  newTest(filter: TestSubscriptionFilter): Test!
-  updatedTest(filter: TestSubscriptionFilter): Test!
-  deletedTest(filter: TestSubscriptionFilter): Test!
-  newComment(filter: CommentSubscriptionFilter): Comment!
-  updatedComment(filter: CommentSubscriptionFilter): Comment!
-  deletedComment(filter: CommentSubscriptionFilter): Comment!
-}
-
-input NoteSubscriptionFilter {
-  id: ID
-  title: String
-  description: String
-}
-
-input TestSubscriptionFilter {
-  id: ID
-  name: String
-}
-
-input CommentSubscriptionFilter {
-  id: ID
-  title: String
-  description: String
+  newNote: Note!
+  updatedNote: Note!
+  deletedNote: Note!
+  newTest: Test!
+  updatedTest: Test!
+  deletedTest: Test!
+  newComment: Comment!
+  updatedComment: Comment!
+  deletedComment: Comment!
 }
 "
 `;
@@ -1090,32 +1056,15 @@ input CreateFixInput {
 }
 
 type Subscription {
-  newNote(filter: NoteSubscriptionFilter): Note!
-  updatedNote(filter: NoteSubscriptionFilter): Note!
-  deletedNote(filter: NoteSubscriptionFilter): Note!
-  newTest(filter: TestSubscriptionFilter): Test!
-  updatedTest(filter: TestSubscriptionFilter): Test!
-  deletedTest(filter: TestSubscriptionFilter): Test!
-  newComment(filter: CommentSubscriptionFilter): Comment!
-  updatedComment(filter: CommentSubscriptionFilter): Comment!
-  deletedComment(filter: CommentSubscriptionFilter): Comment!
-}
-
-input NoteSubscriptionFilter {
-  id: ID
-  title: String
-  description: String
-}
-
-input TestSubscriptionFilter {
-  id: ID
-  name: String
-}
-
-input CommentSubscriptionFilter {
-  id: ID
-  title: String
-  description: String
+  newNote: Note!
+  updatedNote: Note!
+  deletedNote: Note!
+  newTest: Test!
+  updatedTest: Test!
+  deletedTest: Test!
+  newComment: Comment!
+  updatedComment: Comment!
+  deletedComment: Comment!
 }
 "
 `;

--- a/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
+++ b/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
@@ -69,12 +69,6 @@ type CommentResultList {
   count: Int
 }
 
-input CommentSubscriptionFilter {
-  id: ID
-  title: String
-  description: String
-}
-
 input CreateCommentInput {
   id: ID
   title: String!
@@ -190,12 +184,6 @@ type NoteResultList {
   count: Int
 }
 
-input NoteSubscriptionFilter {
-  id: ID
-  title: String
-  description: String
-}
-
 input OrderByInput {
   field: String!
   order: SortDirectionEnum = ASC
@@ -235,12 +223,12 @@ input StringInput {
 }
 
 type Subscription {
-  newNote(filter: NoteSubscriptionFilter): Note!
-  updatedNote(filter: NoteSubscriptionFilter): Note!
-  deletedNote(filter: NoteSubscriptionFilter): Note!
-  newComment(filter: CommentSubscriptionFilter): Comment!
-  updatedComment(filter: CommentSubscriptionFilter): Comment!
-  deletedComment(filter: CommentSubscriptionFilter): Comment!
+  newNote: Note!
+  updatedNote: Note!
+  deletedNote: Note!
+  newComment: Comment!
+  updatedComment: Comment!
+  deletedComment: Comment!
 }
 "
 `;

--- a/packages/graphql-serve/tests/__snapshots__/printSchema.test.ts.snap
+++ b/packages/graphql-serve/tests/__snapshots__/printSchema.test.ts.snap
@@ -91,9 +91,9 @@ input StringInput {
 }
 
 type Subscription {
-  newUser(filter: UserSubscriptionFilter): User!
-  updatedUser(filter: UserSubscriptionFilter): User!
-  deletedUser(filter: UserSubscriptionFilter): User!
+  newUser: User!
+  updatedUser: User!
+  deletedUser: User!
 }
 
 \\"\\"\\"@model\\"\\"\\"
@@ -115,10 +115,5 @@ type UserResultList {
   offset: Int
   limit: Int
   count: Int
-}
-
-input UserSubscriptionFilter {
-  id: ID
-  name: String
 }"
 `;

--- a/templates/ts-react-apollo-client/src/graphql/graphback.graphql
+++ b/templates/ts-react-apollo-client/src/graphql/graphback.graphql
@@ -41,6 +41,7 @@ query findNotes($filter: NoteFilter, $page: PageRequest, $orderBy: OrderByInput)
       }
       offset
       limit
+      count
     }
   }
 
@@ -57,6 +58,7 @@ query findComments($filter: CommentFilter, $page: PageRequest, $orderBy: OrderBy
       }
       offset
       limit
+      count
     }
   }
 
@@ -108,38 +110,38 @@ mutation deleteComment($input: MutateCommentInput!) {
 }
 
 
-subscription newNote($filter: NoteSubscriptionFilter) {
-  newNote(filter: $filter) {
-      ...NoteFields
+subscription newNote {
+  newNote {
+    ...NoteFields
   }
 } 
 
-subscription updatedNote($filter: NoteSubscriptionFilter) {
-  updatedNote(filter: $filter) {
-      ...NoteFields
+subscription updatedNote {
+  updatedNote {
+    ...NoteFields
   }
 } 
 
-subscription deletedNote($filter: NoteSubscriptionFilter) {
-  deletedNote(filter: $filter) {
-      ...NoteFields
+subscription deletedNote {
+  deletedNote {
+    ...NoteFields
   }
 } 
 
-subscription newComment($filter: CommentSubscriptionFilter) {
-  newComment(filter: $filter) {
-      ...CommentFields
+subscription newComment {
+  newComment {
+    ...CommentFields
   }
 } 
 
-subscription updatedComment($filter: CommentSubscriptionFilter) {
-  updatedComment(filter: $filter) {
-      ...CommentFields
+subscription updatedComment {
+  updatedComment {
+    ...CommentFields
   }
 } 
 
-subscription deletedComment($filter: CommentSubscriptionFilter) {
-  deletedComment(filter: $filter) {
-      ...CommentFields
+subscription deletedComment {
+  deletedComment {
+    ...CommentFields
   }
 } 


### PR DESCRIPTION
Subscription filtering is not implemented in Graphback.

This PR removes it from the schema. This commit can be reverted when https://github.com/aerogear/graphback/issues/1273 is in progress to restore filtering.

```diff
type Subscription {
+  newNote: Note!
-  newNote(filter: NoteSubscriptionFilter): Note!
+  updatedNote: Note!
-  updatedNote(filter: NoteSubscriptionFilter): Note!
+  deletedNote: Note!
-  deletedNote(filter: NoteSubscriptionFilter): Note!
}
```