### PR TITLE
chore: replace sh with bash for syntax highlighting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ For CLI usage we recommend to use Node version manager - NVM.
 
 ## Building
 
-```sh
+```bash
 yarn install
 yarn build
 ```

--- a/docs/.old/db/datasources.md
+++ b/docs/.old/db/datasources.md
@@ -76,7 +76,7 @@ npm install @graphback/runtime-mongo
 
 You will also need to have a [MongoDB Node.js Driver](https://github.com/mongodb/node-mongodb-native) installed:
 
-```sh
+```bash
 npm install mongodb
 ```
 

--- a/docs/.old/intro/graphqlserve.md
+++ b/docs/.old/intro/graphqlserve.md
@@ -36,7 +36,7 @@ The `@model` annotation indicates that `Note` is a data model and Graphback will
 
 To start your server, run the following command from the same directory as `Note.graphql`:
 
-```sh
+```bash
 gqlserve serve .
 ```
 
@@ -44,19 +44,19 @@ This will start a GraphQL server on a random port using the data models we just 
 
 You can customise the directory of the data models:
 
-```sh
+```bash
 gqlserve serve ./path/to/models
 ```
 
 You can also specify where to load the data models from with a Glob pattern:
 
-```sh
+```bash
 gqlserve print-schema ./schema/**/*.graphql
 ```
 
 You can specify which port to start the server on:
 
-```sh
+```bash
 $ gqlserve serve ./path/to/models --port 8080
 
 Starting server...
@@ -70,7 +70,7 @@ Graphback receives your data models as an input and processes them to generate a
 
 GraphQL Serve allows you to print the resulting schema in your terminal with the `print-schema` subcommand:
 
-```sh
+```bash
 $ gqlserve print-schema ./path/to/models
 Generated schema:
 

--- a/docs/.old/intro/quickstart.md
+++ b/docs/.old/intro/quickstart.md
@@ -8,13 +8,13 @@ You can use the Graphback CLI to generate a new GraphQL project in minutes.
 
 Initializing with npx:
 
-```sh
+```bash
 npx graphback-cli init <project-name>
 ```
 
 Or by installing Graphback CLI globally:
 
-```sh
+```bash
 npm install -g graphback-cli
 graphback init <project-name>
 ```

--- a/docs/.old/releases.md
+++ b/docs/.old/releases.md
@@ -186,7 +186,7 @@ We have removed the `graphback openapi` CLI command, but you can still use [Open
 
 To use `graphql-serve` now you must use a model file:
 
-```sh
+```bash
 gqlserve serve ./path/to/models/*.graphql --port 8080
 ```
 

--- a/docs/databases/mongodb.md
+++ b/docs/databases/mongodb.md
@@ -13,13 +13,13 @@ The package is built on top of the official [MongoDB Node.js Driver](https://mon
 
 Install with npm:
 
-```shell
+```bash
 npm install @graphback/runtime-mongo mongodb
 ```
 
 Install with yarn:
 
-```shell
+```bash
 yarn add @graphback/runtime-mongo mongodb
 ```
 

--- a/docs/getting-started/adding-graphback-to-your-project.md
+++ b/docs/getting-started/adding-graphback-to-your-project.md
@@ -55,7 +55,7 @@ For this example we are going to assume that the project uses a PostgreSQL datab
 
 To use PostgreSQL with Graphback install [Knex.js](https://knexjs.org/) with the Graphback PostgreSQL library:
 
-```sh
+```bash
 npm install knex @graphback/runtime-knex
 ```
 
@@ -103,7 +103,7 @@ For more advanced usage on how to configure your data models, see our [Model](..
 
 Let's install Graphback and use it in the project.
 
-```sh
+```bash
 npm install graphback
 ```
 

--- a/docs/getting-started/creating-a-new-application.md
+++ b/docs/getting-started/creating-a-new-application.md
@@ -18,7 +18,7 @@ Before you start, check to make sure you have the following installed:
 
 Create a Graphback application with npx:
 
-```sh
+```bash
 npx create-graphql my-awesome-project
 ```
 
@@ -26,13 +26,13 @@ The CLI will ask you to pick from one of a number of templates. Once chosen, the
 
 Change into your project folder:
 
-```sh
+```bash
 cd my-awesome-project
 ```
 
 Install dependencies with yarn (or npm):
 
-```sh
+```bash
 yarn install
 ```
 

--- a/docs/graphql-migrations/intro.md
+++ b/docs/graphql-migrations/intro.md
@@ -18,13 +18,13 @@ You can install `graphql-migrations` on your existing project using the followin
 
 With npm: 
 
-```shell
+```bash
 npm i graphql-serve
 ```
 
 or with yarn:
 
-```shell
+```bash
 yarn add graphql-serve
 ```
 

--- a/docs/graphqlserve/graphqlserve.md
+++ b/docs/graphqlserve/graphqlserve.md
@@ -12,19 +12,19 @@ GraphQL Serve is a CLI tool that leverages the power of Graphback to generate a 
 
 You can install `graphql-serve` globally with npm:
 
-```shell
+```bash
 npm i -g graphql-serve
 ```
 
 or with yarn:
 
-```shell
+```bash
 yarn global add graphql-serve
 ```
 
 or run it with [npx](https://www.npmjs.com/package/npx): 
 
-```shell
+```bash
 npx graphql-serve
 ```
 
@@ -48,7 +48,7 @@ The `@model` annotation indicates that `Note` is a data model and Graphback will
 
 To start your server, run the following command from the same directory as `Note.graphql`:
 
-```shell
+```bash
 gqlserve serve Note.graphql
 ```
 
@@ -56,19 +56,19 @@ This will start a GraphQL server on a random port using the `Note.graphql` data 
 
 You can customise the directory of the data models:
 
-```shell
+```bash
 gqlserve serve ./path/to/models
 ```
 
 You can also specify where to load the data models from with a Glob pattern:
 
-```shell
+```bash
 gqlserve serve ./schema/**/*.graphql
 ```
 
 You can specify which port to start the server on:
 
-```shell
+```bash
 $ gqlserve serve ./path/to/models --port 8080
 
 Starting server...
@@ -104,7 +104,7 @@ type Note {
 
 Once we have a model with datasync capabilities, we can run our GraphQL server by enabling data synchronization as shown below:
 
-```shell
+```bash
 gqlserve serve Note.graphql --datasync
 ```
  
@@ -114,7 +114,7 @@ Graphback receives your data models as an input and processes them to generate a
 
 GraphQL Serve allows you to print the resulting schema in your terminal with the `print-schema` subcommand:
 
-```shell
+```bash
 $ gqlserve print-schema ./path/to/models
 Generated schema:
 
@@ -125,7 +125,7 @@ Generated schema:
 
 This information is also provided with the command itself:
 
-```shell
+```bash
 $ gqlserve -h
 gqlserve <command>
 
@@ -142,7 +142,7 @@ Options:
 
 For the `serve` command:
 
-```shell
+```bash
 $ gqlserve serve -h
 gqlserve serve [modelDir] [options]
 
@@ -164,7 +164,7 @@ Examples:
 
 Also for `print-schema` command:
 
-```shell
+```bash
 $ gqlserve print-schema -h
 gqlserve print-schema [modelDir]
 

--- a/packages/graphql-serve/README.md
+++ b/packages/graphql-serve/README.md
@@ -30,13 +30,13 @@ database.
 
 Using npm:
 
-```shell
+```bash
 npm install -g graphql-serve
 ```
 
 or yarn:
 
-```shell
+```bash
 yarn global add graphql-serve
 ```
 
@@ -60,20 +60,20 @@ type Note {
 
 Assuming you have created your various `*.graphql` data model files in the `models` directory, to automatically generate resolvers and start a GraphQL server listening on port 8080 do the following:
 
-```shell
+```bash
 $ gqlserve serve models --port=8080
 ```
 
 
 If you only need to see the generated GraphQL Schema, use the `print-schema` command:
 
-```shell
+```bash
 $ gqlserve print-schema .
 ```
 The above command prints schema generated from data model files in the current directory.
 
 This information is also provided with the command itself:
-```shell
+```bash
 $ gqlserve -h
 gqlserve <command>
 
@@ -88,7 +88,7 @@ Options:
   -v, --version  Show version number                                   [boolean]
 ```
 For the `serve` command:
-```shell
+```bash
 $ gqlserve serve -h
 gqlserve serve [modelDir] [options]
 
@@ -109,7 +109,7 @@ Examples:
 ```
 
 Also for `print-schema` command:
-```shell
+```bash
 $ gqlserve print-schema -h
 gqlserve print-schema [modelDir]
 

--- a/templates/ts-apollo-postgres-backend/.graphqlrc.yaml
+++ b/templates/ts-apollo-postgres-backend/.graphqlrc.yaml
@@ -1,0 +1,9 @@
+schema: './src/schema.graphql'
+documents: ./client/src/graphql/**/*.graphql
+extensions:
+  graphback:
+    model: ./model/datamodel.graphql
+    plugins:
+      graphback-client:
+        format: 'ts'
+        outputFile: ./client/src/graphql/graphback.ts

--- a/templates/ts-apollo-postgres-backend/.graphqlrc.yaml
+++ b/templates/ts-apollo-postgres-backend/.graphqlrc.yaml
@@ -1,9 +1,0 @@
-schema: './src/schema.graphql'
-documents: ./client/src/graphql/**/*.graphql
-extensions:
-  graphback:
-    model: ./model/datamodel.graphql
-    plugins:
-      graphback-client:
-        format: 'ts'
-        outputFile: ./client/src/graphql/graphback.ts

--- a/templates/ts-react-apollo-client/README.md
+++ b/templates/ts-react-apollo-client/README.md
@@ -9,7 +9,7 @@ Run the project using the following steps:
 
 - Install
 
-```sh
+```bash
 yarn install
 ```
 
@@ -20,6 +20,6 @@ yarn codegen:client
 
 - Start React App
 
-```sh
+```bash
 yarn start:client
 ```

--- a/website/README.md
+++ b/website/README.md
@@ -12,13 +12,13 @@ This website was created with [Docusaurus](https://docusaurus.io/).
 
 1. Make sure all the dependencies for the website are installed:
 
-```sh
+```bash
 # Install dependencies
 $ yarn
 ```
 2. Run your dev server:
 
-```sh
+```bash
 # Start the site
 $ yarn start
 ```

--- a/website/versioned_docs/version-0.10.x/database-schema-migrations.md
+++ b/website/versioned_docs/version-0.10.x/database-schema-migrations.md
@@ -11,7 +11,7 @@ Graphback uses [graphql-migrations](../packages/graphql-migrations) to automatic
 
 To create or update your database from the CLI, run:
 
-```sh
+```bash
 graphback db
 ```
 

--- a/website/versioned_docs/version-0.11.x/db/datasources.md
+++ b/website/versioned_docs/version-0.11.x/db/datasources.md
@@ -77,7 +77,7 @@ npm install @graphback/runtime-mongo
 
 You will also need to have a [MongoDB Node.js Driver](https://github.com/mongodb/node-mongodb-native) installed:
 
-```sh
+```bash
 npm install mongodb
 ```
 

--- a/website/versioned_docs/version-0.11.x/db/migrations.md
+++ b/website/versioned_docs/version-0.11.x/db/migrations.md
@@ -18,7 +18,7 @@ Graphback uses [graphql-migrations](https://www.npmjs.com/package/graphql-migrat
 
 To create or update your database from the CLI, run:
 
-```sh
+```bash
 graphback db
 ```
 

--- a/website/versioned_docs/version-0.11.x/intro/graphqlserve.md
+++ b/website/versioned_docs/version-0.11.x/intro/graphqlserve.md
@@ -37,7 +37,7 @@ The `@model` annotation indicates that `Note` is a data model and Graphback will
 
 To start your server, run the following command from the same directory as `Note.graphql`:
 
-```sh
+```bash
 gqls serve .
 ```
 
@@ -45,13 +45,13 @@ This will start a GraphQL server on a random port using the data models we just 
 
 You can customise the directory of the data models:
 
-```sh
+```bash
 gqls serve ./path/to/models
 ```
 
 You can specify which port to start the server on:
 
-```sh
+```bash
 $ gqls serve ./path/to/models --port 8080
 
 Starting server...
@@ -109,7 +109,7 @@ Graphback enabled applications use [GraphQL Config](https://graphql-config.com) 
 
 GraphQL Serve is fully compatible with GraphQL Config. Running `gqlserve [subcommand]` in the same directory as your `.graphqlrc` file will use the Graphback configuration section to find your model directory, configure global CRUD methods and execute the plugin sequence.
 
-```sh
+```bash
 $ gqls serve                    
 
 No port number specified.

--- a/website/versioned_docs/version-0.11.x/intro/quickstart.md
+++ b/website/versioned_docs/version-0.11.x/intro/quickstart.md
@@ -9,13 +9,13 @@ You can use the Graphback CLI to generate a new GraphQL project in minutes.
 
 Initializing with npx:
 
-```sh
+```bash
 npx graphback-cli init <project-name>
 ```
 
 Or by installing Graphback CLI globally:
 
-```sh
+```bash
 npm install -g graphback-cli
 graphback init <project-name>
 ```

--- a/website/versioned_docs/version-0.12.x/db/datasources.md
+++ b/website/versioned_docs/version-0.12.x/db/datasources.md
@@ -76,7 +76,7 @@ npm install @graphback/runtime-mongo
 
 You will also need to have a [MongoDB Node.js Driver](https://github.com/mongodb/node-mongodb-native) installed:
 
-```sh
+```bash
 npm install mongodb
 ```
 

--- a/website/versioned_docs/version-0.12.x/db/migrations.md
+++ b/website/versioned_docs/version-0.12.x/db/migrations.md
@@ -17,7 +17,7 @@ Graphback uses [graphql-migrations](https://www.npmjs.com/package/graphql-migrat
 
 To create or update your database from the CLI, run:
 
-```sh
+```bash
 graphback db
 ```
 

--- a/website/versioned_docs/version-0.12.x/intro/graphqlserve.md
+++ b/website/versioned_docs/version-0.12.x/intro/graphqlserve.md
@@ -36,7 +36,7 @@ The `@model` annotation indicates that `Note` is a data model and Graphback will
 
 To start your server, run the following command from the same directory as `Note.graphql`:
 
-```sh
+```bash
 gqls serve .
 ```
 
@@ -44,13 +44,13 @@ This will start a GraphQL server on a random port using the data models we just 
 
 You can customise the directory of the data models:
 
-```sh
+```bash
 gqls serve ./path/to/models
 ```
 
 You can specify which port to start the server on:
 
-```sh
+```bash
 $ gqls serve ./path/to/models --port 8080
 
 Starting server...
@@ -108,7 +108,7 @@ Graphback enabled applications use [GraphQL Config](https://graphql-config.com) 
 
 GraphQL Serve is fully compatible with GraphQL Config. Running `gqlserve [subcommand]` in the same directory as your `.graphqlrc` file will use the Graphback configuration section to find your model directory, configure global CRUD methods and execute the plugin sequence.
 
-```sh
+```bash
 $ gqls serve                    
 
 No port number specified.

--- a/website/versioned_docs/version-0.12.x/intro/quickstart.md
+++ b/website/versioned_docs/version-0.12.x/intro/quickstart.md
@@ -8,13 +8,13 @@ You can use the Graphback CLI to generate a new GraphQL project in minutes.
 
 Initializing with npx:
 
-```sh
+```bash
 npx graphback-cli init <project-name>
 ```
 
 Or by installing Graphback CLI globally:
 
-```sh
+```bash
 npm install -g graphback-cli
 graphback init <project-name>
 ```

--- a/website/versioned_docs/version-0.9.x/commands.md
+++ b/website/versioned_docs/version-0.9.x/commands.md
@@ -36,7 +36,7 @@ Execute `graphback` in your shell for more information
 
 ## Update Database
 
-```sh
+```bash
 graphback update-db
 ```
 

--- a/website/versioned_docs/version-0.9.x/database-schema-migrations.md
+++ b/website/versioned_docs/version-0.9.x/database-schema-migrations.md
@@ -11,7 +11,7 @@ Graphback uses [graphql-migrations](../packages/graphql-migrations) to automatic
 
 To create or update your database from the CLI, run:
 
-```sh
+```bash
 graphback db
 ```
 


### PR DESCRIPTION
Replace `sh` with `bash` everywhere for better syntax highlighting in Docusaurus.