### PR TITLE
docs(website): add sqlite database documentation

### DIFF
--- a/docs/databases/mongodb.md
+++ b/docs/databases/mongodb.md
@@ -99,6 +99,6 @@ The highlighted code does the following:
  - Select the `users` database.
  - And finally, create a data provider creator by using the `createMongoDbProvider` API. 
   
-The rest of the code uses [buildGraphbackAPI](../api/build-graphback-api) to create Graphback CRUD API based on the defined `userModel` model.
+The rest of the code uses [`buildGraphbackAPI`](../api/build-graphback-api) to create Graphback CRUD API based on the defined `userModel` model.
 
 Visit [Data Models](../model/datamodel.md) to learn more about how to design your business models.

--- a/docs/databases/postgres.md
+++ b/docs/databases/postgres.md
@@ -35,7 +35,7 @@ If you do not have a running instance, you can use [Docker](https://www.docker.c
 :::
 
 ```ts
-import Knex from 'knex'
+import Knex from 'knex';
 
 const dbConfig = {
     client: "pg",
@@ -63,7 +63,7 @@ The provider exposes a [`createKnexDbProvider`](../api/create-knexdb-provider.md
 The code below shows how you can create such a data provider creator and how it can be passed to [`buildGraphbackAPI`](../api/build-graphback-api.md).
 
 ```ts
-import Knex from 'knex'
+import Knex from 'knex';
 import { migrateDB } from 'graphql-migrations';
 import { createKnexDbProvider } from '@graphback/runtime-knex';
 
@@ -116,6 +116,6 @@ The highlighted code does the following:
  - Perform the migrations using [GraphQL Migrations](../graphql-migrations/intro.md) to create the `user` table.
  - And finally, create a data provider creator by using the `createKnexDbProvider` API. 
   
-The rest of the code uses [buildGraphbackAPI](../api/build-graphback-api) to create Graphback CRUD API based on the defined `userModel` model.
+The rest of the code uses [`buildGraphbackAPI`](../api/build-graphback-api) to create Graphback CRUD API based on the defined `userModel` model.
 
 Visit [Data Models](../model/datamodel.md) pages to learn more about how to design your business models.

--- a/docs/databases/sqlite.md
+++ b/docs/databases/sqlite.md
@@ -4,4 +4,101 @@ title: Using SQLite with Graphback
 sidebar_label: SQLite
 ---
 
-## TODO
+[SQLite](https://www.sqlite.org/index.html) is an open-source, zero-configuration, self-contained, stand-alone, transaction relational database engine designed to be embedded into an application. [Graphback Knex Provider](https://www.npmjs.com/package/@graphback/runtime-knex) package provides instant integration to your SQLite database, giving you implementation of the [CRUD API](../crud/introduction.md). 
+
+:::caution
+ SQLite is a good choice for testing or development purposes. We do not recommend using it in production environment. For a production setup, you can use [PostgreSQL](postgres.md). 
+::::
+
+## Installation
+
+Install with npm:
+
+```bash
+npm install @graphback/runtime-knex knex
+```
+
+Install with yarn:
+
+```bash
+yarn add @graphback/runtime-knex knex
+```
+
+## Configuring the Database
+
+The following code shows how a SQLite database can be configured.
+
+```ts
+import Knex from 'knex';
+
+const dbConfig = {
+    client: "sqlite3",
+    connection: {
+      filename: "./users.sqlite"
+    }
+};
+
+const db = Knex(dbConfig);
+```
+
+Visit [Knex Connection Options](http://knexjs.org/#Installation-client) to learn more about the different connection options. 
+
+# Using Knex Provider
+
+The provider exposes a [`SQLiteKnexDBDataProvider`](https://github.com/aerogear/graphback/blob/master/packages/graphback-runtime-knex/src/SQLiteKnexDBDataProvider.ts) API, which can be used to create a SQLite data providers for each of your data models. 
+
+The code below shows how to create a data provider creator for a SQLite database and how to use it in [`buildGraphbackAPI`](../api/build-graphback-api.md).
+
+```ts
+import Knex from 'knex';
+import { migrateDB } from 'graphql-migrations';
+import { ModelDefinition } from '@graphback/core';
+import { SQLiteKnexDBDataProvider } from '@graphback/runtime-knex';
+
+// highlight-start
+// database configuration
+const dbConfig = {
+    client: "sqlite3",
+    connection: {
+      filename: "./users.sqlite"
+    }
+};
+
+// create the connection to the database
+const db = Knex(dbConfig);
+
+// the business model
+const userModel = `
+ """
+ @model
+ """
+ type User {
+     id: ID!
+     username: String!
+ }
+`;
+
+// create the user table in database 
+migrateDB(dbConfig, userModel, { }).then(() => {
+  console.log("Migrated database");
+});
+
+// create the SQLite data provider
+const dataProviderCreator = (model: ModelDefinition) => new SQLiteKnexDBDataProvider(model.graphqlType, db);
+
+// highlight-end
+
+// Use the dataProvider in buildGraphbackAPI
+const { resolvers, services, contextCreator } = buildGraphbackAPI(userModel, { dataProviderCreator });
+```
+
+The highlighted code does the following:
+ - Define connection configuration to the database.
+ - Create a connection to SQLite database using Knex.
+ - Define the user model.
+ - Perform the migrations using [GraphQL Migrations](../graphql-migrations/intro.md) to create the `user` table.
+ - And finally, create a data provider creator which will be applied to our model, using the [`SQLiteKnexDBDataProvider`](https://github.com/aerogear/graphback/blob/master/packages/graphback-runtime-knex/src/SQLiteKnexDBDataProvider.ts) API. 
+  
+The rest of the code uses [`buildGraphbackAPI`](../api/build-graphback-api) to create Graphback CRUD API based on the defined `userModel` model.
+
+Visit [Data Models](../model/datamodel.md) to learn more about how to design your business models.

--- a/packages/graphback-runtime-knex/src/index.ts
+++ b/packages/graphback-runtime-knex/src/index.ts
@@ -1,4 +1,6 @@
-export * from "./KnexDBDataProvider"
+export * from "./KnexDBDataProvider";
+
+export * from "./SQLiteKnexDBDataProvider";
 
 // Helpers
-export * from './createKnexDbProvider'
+export * from './createKnexDbProvider';


### PR DESCRIPTION
Also exposes `SQLiteKnexDBDataProvider` as public API as it can be used
for testing / development purposes.