### PR TITLE
chore: disable automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "ora",
     "chalk"
   ],
-  "automerge": true,
+  "automerge": false,
   "major": {
     "automerge": false
   },


### PR DESCRIPTION
We want to avoid any code changes at this point including bumps.
Disabling this temporairly so we can lock dependencies and do proper line of testing