### PR TITLE
feat: in memory subscription filtering

### DIFF
--- a/docs/crud/subscriptions.md
+++ b/docs/crud/subscriptions.md
@@ -49,7 +49,7 @@ subscription {
 }
 ```
 
-and with a filter:
+You can apply field-equality filters to the subscription:
 
 ```graphql
 subscription {
@@ -73,7 +73,7 @@ subscription {
 }
 ```
 
-and with a filter:
+You can apply field-equality filters to the subscription:
 
 ```graphql
 subscription {
@@ -97,7 +97,7 @@ subscription {
 }
 ```
 
-and with a filter:
+You can apply field-equality filters to the subscription:
 
 ```graphql
 subscription {

--- a/docs/crud/subscriptions.md
+++ b/docs/crud/subscriptions.md
@@ -35,10 +35,6 @@ type Subscription {
 // highlight-end
 ```
 
-:::caution
-Subscription filtering is not available yet and will be implemented in a future release.
-:::
-
 ### Examples
 
 Subscribing to a [`create`](./mutations#create) event on `Note`:
@@ -46,6 +42,18 @@ Subscribing to a [`create`](./mutations#create) event on `Note`:
 ```graphql
 subscription {
   newNote {
+    id
+    title
+    likes
+  }
+}
+```
+
+and with a filter:
+
+```graphql
+subscription {
+  newNote(filter: {likes: 100}) {
     id
     title
     likes
@@ -65,11 +73,35 @@ subscription {
 }
 ```
 
+and with a filter:
+
+```graphql
+subscription {
+  updatedNote(filter: {likes: 100}) {
+    id
+    title
+    likes
+  }
+}
+```
+
 Subscribing to a [`delete`](./mutations#delete) event on `Note`:
 
 ```graphql
 subscription {
   deletedNote {
+    id
+    title
+    likes
+  }
+}
+```
+
+and with a filter:
+
+```graphql
+subscription {
+  updatedNote(filter: {likes: 100}) {
     id
     title
     likes

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -596,12 +596,12 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const operation = getSubscriptionName(modelName, GraphbackOperationType.CREATE)
 
     subscriptionObj[operation] = {
-      subscribe: (_: any, __: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
+      subscribe: (_: any, args: any, context: GraphbackContext) => {
         if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
           throw new Error(`Missing service for ${modelName}`);
         }
 
-        return context.graphback.services[modelName].subscribeToCreate({}, context);
+        return context.graphback.services[modelName].subscribeToCreate(args.filter, context);
       }
     }
   }
@@ -617,12 +617,12 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const operation = getSubscriptionName(modelName, GraphbackOperationType.UPDATE)
 
     subscriptionObj[operation] = {
-      subscribe: (_: any, __: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
+      subscribe: (_: any, args: any, context: GraphbackContext) => {
         if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
           throw new Error(`Missing service for ${modelName}`);
         }
 
-        return context.graphback.services[modelName].subscribeToUpdate({}, context);
+        return context.graphback.services[modelName].subscribeToUpdate(args.filter, context);
       }
     }
   }
@@ -638,12 +638,12 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const operation = getSubscriptionName(modelName, GraphbackOperationType.DELETE)
 
     subscriptionObj[operation] = {
-      subscribe: (_: any, __: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
+      subscribe: (_: any, args: any, context: GraphbackContext) => {
         if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
           throw new Error(`Missing service for ${modelName}`);
         }
 
-        return context.graphback.services[modelName].subscribeToDelete({}, context);
+        return context.graphback.services[modelName].subscribeToDelete(args.filter, context);
       }
     }
   }

--- a/packages/graphback-core/src/runtime/CRUDService.ts
+++ b/packages/graphback-core/src/runtime/CRUDService.ts
@@ -1,6 +1,7 @@
 import * as DataLoader from "dataloader";
 import { PubSubEngine } from 'graphql-subscriptions';
-import { GraphbackCRUDGeneratorConfig, GraphbackOperationType, upperCaseFirstChar } from '..';
+import { GraphbackCRUDGeneratorConfig, GraphbackOperationType, upperCaseFirstChar, getSubscriptionName } from '..';
+import { withSubscriptionFilter } from './withSubscriptionFilter';
 import { GraphbackCRUDService, GraphbackDataProvider, GraphbackContext, GraphbackOrderBy, GraphbackPage, ResultList, QueryFilter } from '.';
 
 /**
@@ -104,31 +105,46 @@ export class CRUDService<Type = any> implements GraphbackCRUDService<Type>  {
     }
   }
 
-  public subscribeToCreate(filter: any, context: GraphbackContext): AsyncIterator<Type> | undefined {
+  public subscribeToCreate(filter: any, _context: GraphbackContext): AsyncIterator<Type> | undefined {
     if (!this.pubSub) {
       throw Error(`Missing PubSub implementation in CRUDService`);
     }
-    const createSubKey = this.subscriptionTopicMapping(GraphbackOperationType.CREATE, this.modelName);
 
-    return this.pubSub.asyncIterator(createSubKey)
+    const operationType = GraphbackOperationType.CREATE
+    const createSubKey = this.subscriptionTopicMapping(operationType, this.modelName);
+    const subscriptionName = getSubscriptionName(this.modelName, operationType)
+
+    const asyncIterator = this.pubSub.asyncIterator<Type>(createSubKey)
+
+    return withSubscriptionFilter(() => asyncIterator, filter, subscriptionName)()
   }
 
   public subscribeToUpdate(filter: any, context: GraphbackContext): AsyncIterator<Type> | undefined {
     if (!this.pubSub) {
       throw Error(`Missing PubSub implementation in CRUDService`);
     }
-    const updateSubKey = this.subscriptionTopicMapping(GraphbackOperationType.UPDATE, this.modelName);
 
-    return this.pubSub.asyncIterator(updateSubKey)
+    const operationType = GraphbackOperationType.UPDATE
+    const updateSubKey = this.subscriptionTopicMapping(operationType, this.modelName);
+    const subscriptionName = getSubscriptionName(this.modelName, operationType)
+
+    const asyncIterator = this.pubSub.asyncIterator<Type>(updateSubKey)
+
+    return withSubscriptionFilter(() => asyncIterator, filter, subscriptionName)()
   }
 
   public subscribeToDelete(filter: any, context: GraphbackContext): AsyncIterator<Type> | undefined {
     if (!this.pubSub) {
       throw Error(`Missing PubSub implementation in CRUDService`);
     }
-    const deleteSubKey = this.subscriptionTopicMapping(GraphbackOperationType.DELETE, this.modelName);
 
-    return this.pubSub.asyncIterator(deleteSubKey)
+    const operationType = GraphbackOperationType.UPDATE
+    const deleteSubKey = this.subscriptionTopicMapping(operationType, this.modelName);
+    const subscriptionName = getSubscriptionName(this.modelName, operationType)
+
+    const asyncIterator = this.pubSub.asyncIterator<Type>(deleteSubKey)
+
+    return withSubscriptionFilter(() => asyncIterator, filter, subscriptionName)()
   }
 
 

--- a/packages/graphback-core/src/runtime/CRUDService.ts
+++ b/packages/graphback-core/src/runtime/CRUDService.ts
@@ -39,6 +39,10 @@ export class CRUDService<Type = any> implements GraphbackCRUDService<Type>  {
   }
 
   public async create(data: Type, context: GraphbackContext): Promise<Type> {
+    if (this.crudOptions.subCreate) {
+      context.graphback.options.selectedFields = [];
+    }
+
     const result = await this.db.create(data, context);
 
     if (this.pubSub && this.crudOptions.subCreate) {
@@ -52,6 +56,9 @@ export class CRUDService<Type = any> implements GraphbackCRUDService<Type>  {
   }
 
   public async update(data: Type, context: GraphbackContext): Promise<Type> {
+    if (this.crudOptions.subUpdate) {
+      context.graphback.options.selectedFields = [];
+    }
 
     const result = await this.db.update(data, context);
 
@@ -67,6 +74,10 @@ export class CRUDService<Type = any> implements GraphbackCRUDService<Type>  {
 
   //tslint:disable-next-line: no-reserved-keywords
   public async delete(data: Type, context: GraphbackContext): Promise<Type> {
+    if (this.crudOptions.subDelete) {
+      context.graphback.options.selectedFields = [];
+    }
+
     const result = await this.db.delete(data, context);
 
     if (this.pubSub && this.crudOptions.subDelete) {

--- a/packages/graphback-core/src/runtime/CRUDService.ts
+++ b/packages/graphback-core/src/runtime/CRUDService.ts
@@ -138,7 +138,7 @@ export class CRUDService<Type = any> implements GraphbackCRUDService<Type>  {
       throw Error(`Missing PubSub implementation in CRUDService`);
     }
 
-    const operationType = GraphbackOperationType.UPDATE
+    const operationType = GraphbackOperationType.DELETE
     const deleteSubKey = this.subscriptionTopicMapping(operationType, this.modelName);
     const subscriptionName = getSubscriptionName(this.modelName, operationType)
 

--- a/packages/graphback-core/src/runtime/CRUDService.ts
+++ b/packages/graphback-core/src/runtime/CRUDService.ts
@@ -105,7 +105,7 @@ export class CRUDService<Type = any> implements GraphbackCRUDService<Type>  {
     }
   }
 
-  public subscribeToCreate(filter: any, _context: GraphbackContext): AsyncIterator<Type> | undefined {
+  public subscribeToCreate(filter: any, _context?: GraphbackContext): AsyncIterator<Type> | undefined {
     if (!this.pubSub) {
       throw Error(`Missing PubSub implementation in CRUDService`);
     }

--- a/packages/graphback-core/src/runtime/index.ts
+++ b/packages/graphback-core/src/runtime/index.ts
@@ -7,3 +7,4 @@ export * from "./createCRUDService"
 export * from "./NoDataError"
 export * from "./GraphbackProxyService"
 export * from "./QueryFilter"
+export * from './withSubscriptionFilter'

--- a/packages/graphback-core/src/runtime/withSubscriptionFilter.ts
+++ b/packages/graphback-core/src/runtime/withSubscriptionFilter.ts
@@ -9,7 +9,7 @@ export function withSubscriptionFilter(asyncIterator: ResolverFn, filter: any, s
     const subscriptionPayload = payload[subscriptionName]
 
     for (const key of Object.keys(filter)) {
-      if (!subscriptionPayload[key] || subscriptionPayload[key] !== filter[key]) {
+      if (!subscriptionPayload[key] || subscriptionPayload[key].toString() !== filter[key].toString()) {
         return false
       }
     }

--- a/packages/graphback-core/src/runtime/withSubscriptionFilter.ts
+++ b/packages/graphback-core/src/runtime/withSubscriptionFilter.ts
@@ -1,5 +1,11 @@
 import { withFilter, ResolverFn } from 'graphql-subscriptions'
 
+/**
+ *
+ * @param {ResolverFn} asyncIterator - PubSub asyncIterator
+ * @param {any} filter - Simple filter object to filter subscriptions
+ * @param {string} subscriptionName - The name of the subscription
+ */
 export function withSubscriptionFilter(asyncIterator: ResolverFn, filter: any, subscriptionName: string): ResolverFn {
   if (!filter) {
     return asyncIterator

--- a/packages/graphback-core/src/runtime/withSubscriptionFilter.ts
+++ b/packages/graphback-core/src/runtime/withSubscriptionFilter.ts
@@ -1,0 +1,19 @@
+import { withFilter, ResolverFn } from 'graphql-subscriptions'
+
+export function withSubscriptionFilter(asyncIterator: ResolverFn, filter: any, subscriptionName: string): ResolverFn {
+  if (!filter) {
+    return asyncIterator
+  }
+
+  return withFilter(asyncIterator, (payload: any) => {
+    const subscriptionPayload = payload[subscriptionName]
+
+    for (const key of Object.keys(filter)) {
+      if (!subscriptionPayload[key] || subscriptionPayload[key] !== filter[key]) {
+        return false
+      }
+    }
+
+    return true
+  })
+}

--- a/packages/graphback-runtime-knex/tests/service/DefaultCRUDServiceTest.ts
+++ b/packages/graphback-runtime-knex/tests/service/DefaultCRUDServiceTest.ts
@@ -118,15 +118,15 @@ test('delete Todo', async (done) => {
 
   const subId = await pubSub.subscribe("DELETE_TODO", ({ deletedTodo }) => {
     expect(deletedTodo).toEqual({
-      id: 2
+      id: 2,
+      text: "my second todo"
     });
     done();
     pubSub.unsubscribe(subId);
   });
 
   const data = await services.Todo.delete({
-    id: 2,
-    text: 'my second todo',
+    id: 2
   }, {
     graphback: {
       services: {},
@@ -274,25 +274,43 @@ test('find and count all users', async () => {
     }
   })
 
-  const resultWithCount = await services.User.findBy({ name: { startsWith: 'John' } }, {graphback: {services: {}, options: { selectedFields: ["id"], aggregations: {
-    count: true
-  }}}})
+  const resultWithCount = await services.User.findBy({ name: { startsWith: 'John' } }, {
+    graphback: {
+      services: {}, options: {
+        selectedFields: ["id"], aggregations: {
+          count: true
+        }
+      }
+    }
+  })
 
   expect(resultWithCount.count).toEqual(4);
   expect(resultWithCount.items).toHaveLength(4);
 
 
-  const resultWithoutCount = await services.User.findBy({ name: { startsWith: 'John' } }, {graphback: {services: {}, options: { selectedFields: ["id"], aggregations: {
-    count: false
-  }}}})
+  const resultWithoutCount = await services.User.findBy({ name: { startsWith: 'John' } }, {
+    graphback: {
+      services: {}, options: {
+        selectedFields: ["id"], aggregations: {
+          count: false
+        }
+      }
+    }
+  })
 
 
   expect(resultWithoutCount.count).toBeUndefined();
   expect(resultWithoutCount.items).toHaveLength(4);
 
-  const resultWithCountAndItems = await services.User.findBy({ name: { startsWith: 'John' } }, {graphback: {services: {}, options: { selectedFields: [], aggregations: {
-    count: true
-  }}}})
+  const resultWithCountAndItems = await services.User.findBy({ name: { startsWith: 'John' } }, {
+    graphback: {
+      services: {}, options: {
+        selectedFields: [], aggregations: {
+          count: true
+        }
+      }
+    }
+  })
 
 
   expect(resultWithCountAndItems.items.length).toEqual(4);
@@ -300,9 +318,15 @@ test('find and count all users', async () => {
 
   // count with limit and offset
 
-  let resultWithLimitAndOffset = await services.User.findBy({ name: { startsWith: 'John' } }, {graphback: {services: {}, options: { selectedFields: ["id"], aggregations: {
-    count: true
-  }}}}, {offset: 0, limit: 1})
+  let resultWithLimitAndOffset = await services.User.findBy({ name: { startsWith: 'John' } }, {
+    graphback: {
+      services: {}, options: {
+        selectedFields: ["id"], aggregations: {
+          count: true
+        }
+      }
+    }
+  }, { offset: 0, limit: 1 })
 
 
   expect(resultWithLimitAndOffset.items).toHaveLength(1);


### PR DESCRIPTION
This PR implements simplistic in-memory filtering of subscriptions using [withFilter](https://www.apollographql.com/docs/apollo-server/data/subscriptions/#subscription-filters) from graphql-subscriptions.

### Tasks

- [x] 72498d00b40b150566289200133f0c3aebfc3c78 return all fields from mutations as discussed in #1684
- [x] add ability to filter subscriptions on create, update, delete
- [ ] tests (struggled with how to add subscription filters in tests)
- [x] documentation

### Verification

Set up a subscription with a filter:

```gql
subscription {
  newNote(filter: {title:"note1", description:"note1hello"}) {
    id
    title
    description
    comments {
      id
    }
  }
}
```

Create a mutation matching the filter params. You should get a subscription even. Now try it with different filters.

```gql
mutation {
  createNote(input: {
    title: "note1",
    description:"note1hello"
  }) {
    id
  }
}
```

### Notes 

Opening this PR up for feedback now for a conversation on the general implementation. Tried adding quick tests to help with verify but they are non-trivial tricky so can revisit this.