### PR TITLE
fix(schema): allow model field on non-model types

### DIFF
--- a/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
+++ b/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
@@ -292,10 +292,6 @@ function mapObjectInputFields(schemaComposer: SchemaComposer<any>, fields: Graph
 
     let inputType
     if (isObjectType(namedType)) {
-      // if (isModelType(namedType)) {
-      //   throw new Error(`Non-model ${objectName}.${field.name} maps to Graphback model (${namedType.name}) which is not allowed.`)
-      // }
-
       typeName = getInputTypeName(typeName, GraphbackOperationType.CREATE)
       namedType = schemaComposer.getOrCreateITC(typeName).getType()
 

--- a/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
+++ b/packages/graphback-codegen-schema/src/definitions/schemaDefinitions.ts
@@ -292,9 +292,9 @@ function mapObjectInputFields(schemaComposer: SchemaComposer<any>, fields: Graph
 
     let inputType
     if (isObjectType(namedType)) {
-      if (isModelType(namedType)) {
-        throw new Error(`Non-model ${objectName}.${field.name} maps to Graphback model (${namedType.name}) which is not allowed.`)
-      }
+      // if (isModelType(namedType)) {
+      //   throw new Error(`Non-model ${objectName}.${field.name} maps to Graphback model (${namedType.name}) which is not allowed.`)
+      // }
 
       typeName = getInputTypeName(typeName, GraphbackOperationType.CREATE)
       namedType = schemaComposer.getOrCreateITC(typeName).getType()

--- a/packages/graphback-codegen-schema/tests/GraphQLSchemaCreatorTest.ts
+++ b/packages/graphback-codegen-schema/tests/GraphQLSchemaCreatorTest.ts
@@ -82,7 +82,7 @@ test('Test one side relationship schema query type generation', async () => {
     "subDelete": false
   }
 
-  const schemaText = `""" @model """
+  const modelText = `""" @model """
   type Note {
     id: ID!
     title: String!
@@ -102,7 +102,7 @@ test('Test one side relationship schema query type generation', async () => {
   }
   `;
 
-  const oneSidedSchema = buildSchema(schemaText);
+  const oneSidedSchema = buildSchema(modelText);
   const schemaGenerator = new SchemaCRUDPlugin()
   const metadata = new GraphbackCoreMetadata({
     crudMethods: defautConfig
@@ -111,6 +111,43 @@ test('Test one side relationship schema query type generation', async () => {
   const transformedSchema = schemaGenerator.transformSchema(metadata)
   expect(printSchema(transformedSchema)).toMatchSnapshot()
 });
+
+test('Non-model type has model-type field', () => {
+  const defautConfig = {
+    "create": true,
+    "update": true,
+    "findOne": true,
+    "find": true,
+    "delete": true,
+    "subCreate": true,
+    "subUpdate": true,
+    "subDelete": true
+  }
+
+  const modelText = `
+type JWTAuthResult {
+  user: User!
+  csrfToken: String!
+  authJWT: String!
+}
+
+"""@model"""
+type User {
+  id: ID!
+  name: String
+}
+
+type Query {
+  jwt: JWTAuthResult
+}`
+
+  const schemaGenerator = new SchemaCRUDPlugin()
+  const metadata = new GraphbackCoreMetadata({
+    crudMethods: defautConfig
+  }, buildSchema(modelText))
+  const schema = schemaGenerator.transformSchema(metadata)
+  expect(schema.getType('JWTAuthResult')).toBeDefined()
+})
 
 
 test('Creates CRUD resolvers for models', async () => {


### PR DESCRIPTION
Fixes #1751 

The original reason we disabled model fields on non-model types was because of circular generation causing a Maximum call stack size exceeded error, in scenarios where a Model referenced a non-model which referenced the model again.

Obviously we made this too restrictive and prevented other common use cases.

### Verification

Start your Graphback server with the following model:

```gql
type AnonymousJWTAuthResult {
    user: User!
    csrfToken: String!
    authJWT: String!
}

"""@model"""
type User {
  id: ID!
  name: String
}

type Query {
  test: AnonymousJWTAuthResult
}
```