### PR TITLE
chore: update docusaurus version to latest alpha release

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -10,7 +10,9 @@ module.exports = {
   organizationName: 'aerogear', // Usually your GitHub org/user name.
   projectName: 'graphback', // Usually your repo name.
   themeConfig: {
-    disableDarkMode: true,
+    colorMode: {
+      disableSwitch: true
+    },
     prism: {
       theme: require('prism-react-renderer/themes/dracula'),
       // darkTheme: require('prism-react-renderer/themes/dracula'),
@@ -22,7 +24,7 @@ module.exports = {
         alt: 'Graphback Logo',
         src: 'img/logo.png',
       },
-      links: [
+      items: [
         {
           to: 'docs/next/introduction',
           activeBasePath: 'docs',

--- a/website/package.json
+++ b/website/package.json
@@ -10,8 +10,8 @@
     "docs": "docusaurus docs:version"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-alpha.58",
-    "@docusaurus/preset-classic": "2.0.0-alpha.58",
+    "@docusaurus/core": "2.0.0-alpha.59",
+    "@docusaurus/preset-classic": "2.0.0-alpha.59",
     "classnames": "2.2.6",
     "react": "16.13.1",
     "react-dom": "16.13.1"


### PR DESCRIPTION
This fix an issue when launching `yarn start` or `yarn build` as the commands
errored with the following message below:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at validateString (internal/validators.js:120:11)
    at Object.resolve (path.js:980:7)
    at pluginContentBlog (/xxxx/graphback/website/node_modules/@docusaurus/plugin-content-blog/lib/index.js:28:40)
```