### PR TITLE
chore: update graphql version to v15.3.0

### DIFF
--- a/templates/ts-apollo-mongodb-datasync-backend/package.json
+++ b/templates/ts-apollo-mongodb-datasync-backend/package.json
@@ -20,7 +20,7 @@
     "dotenv": "8.2.0",
     "express": "4.17.1",
     "graphback": "0.14.1",
-    "graphql": "14.7.0",
+    "graphql": "15.3.0",
     "graphql-config": "3.0.3",
     "graphql-subscriptions": "1.1.0",
     "graphql-tag": "2.10.4",


### PR DESCRIPTION
This updates the version of graphql in the datasync template to use v15.x.

Was there a reason this template still used v14.x?

Since this is a different major version to the one used in Graphback devDependencies, I was unable to start the datasync template when using the one directly in the repo.

However this is not an issue in production, it is more of a developer experience issue.