### PR TITLE
docs: generate api reference docs using typedoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ integration/test.sqlite
 integration/output/
 integration/output-postgres/
 integration/output-mongo/
+
+# Generated docs
+docs/api/

--- a/docs/api/build-graphback-api.md
+++ b/docs/api/build-graphback-api.md
@@ -1,7 +1,0 @@
----
-id: build-graphback-api
-title: buildGraphbackAPI
-sidebar_label: buildGraphbackAPI
----
-
-## TODO

--- a/docs/api/create-crud-service.md
+++ b/docs/api/create-crud-service.md
@@ -1,7 +1,0 @@
----
-id: create-crud-service
-title: createCRUDService
-sidebar_label: createCRUDService
----
-
-## TODO

--- a/docs/api/create-knexdb-provider.md
+++ b/docs/api/create-knexdb-provider.md
@@ -1,7 +1,0 @@
----
-id: create-knexdb-provider
-title: createKnexDbProvider
-sidebar_label: createKnexDbProvider
----
-
-## TODO

--- a/docs/api/create-mongodb-provider.md
+++ b/docs/api/create-mongodb-provider.md
@@ -1,7 +1,0 @@
----
-id: create-mongodb-provider
-title: createMongoDbProvider
-sidebar_label: createMongoDbProvider
----
-
-## TODO

--- a/docs/api/graphback-crud-service.md
+++ b/docs/api/graphback-crud-service.md
@@ -1,7 +1,0 @@
----
-id: graphback-crud-service
-title: GraphbackCRUDService
-sidebar_label: GraphbackCRUDService
----
-
-## TODO

--- a/docs/api/graphback-data-provider.md
+++ b/docs/api/graphback-data-provider.md
@@ -1,7 +1,0 @@
----
-id: graphback-data-provider
-title: GraphbackDataProvider
-sidebar_label: GraphbackDataProvider
----
-
-## TODO

--- a/docs/databases/mongodb.md
+++ b/docs/databases/mongodb.md
@@ -55,9 +55,9 @@ To learn more about the accepted configuration, visit the [MongoDB Driver Connec
 
 ## Using MongoDB Provider
 
-The Graphback MongoDB provider exposes a [`createMongoDbProvider`](../api/create-mongodb-provider.md) method, which can be used to create data providers for each of your  data models. 
+The Graphback MongoDB provider exposes a [`createMongoDbProvider`](../api/graphback-runtime-mongodb/modules/_createmongodbprovider_.md) method, which can be used to create data providers for each of your  data models. 
 
-The code below shows how you can create such a data provider creator and how it can be passed to [`buildGraphbackAPI`](../api/build-graphback-api.md).
+The code below shows how you can create such a data provider creator and how it can be passed to [`buildGraphbackAPI`](./api/graphback/modules/_buildgraphbackapi_.md).
 
 ```ts
 import { Db, MongoClient } from "mongodb";
@@ -99,6 +99,6 @@ The highlighted code does the following:
  - Select the `users` database.
  - And finally, create a data provider creator by using the `createMongoDbProvider` API. 
   
-The rest of the code uses [`buildGraphbackAPI`](../api/build-graphback-api) to create Graphback CRUD API based on the defined `userModel` model.
+The rest of the code uses [`buildGraphbackAPI`](./api/graphback/modules/_buildgraphbackapi_.md) to create Graphback CRUD API based on the defined `userModel` model.
 
 Visit [Data Models](../model/datamodel.md) to learn more about how to design your business models.

--- a/docs/databases/postgres.md
+++ b/docs/databases/postgres.md
@@ -58,9 +58,9 @@ Visit [Knex Connection Options](http://knexjs.org/#Installation-client) to learn
 
 # Using Knex Provider
 
-The provider exposes a [`createKnexDbProvider`](../api/create-knexdb-provider.md) method, which can be used to create data providers for each of your data models. 
+The provider exposes a [`createKnexDbProvider`](../api/graphback-runtime-knex/modules/_createknexdbprovider_.md) method, which can be used to create data providers for each of your data models. 
 
-The code below shows how you can create such a data provider creator and how it can be passed to [`buildGraphbackAPI`](../api/build-graphback-api.md).
+The code below shows how you can create such a data provider creator and how it can be passed to [`buildGraphbackAPI`](./api/graphback/modules/_buildgraphbackapi_.md).
 
 ```ts
 import Knex from 'knex';
@@ -114,8 +114,8 @@ The highlighted code does the following:
  - Create a connection to PostgreSQL database using Knex.
  - Define the user model.
  - Perform the migrations using [GraphQL Migrations](../graphql-migrations/intro.md) to create the `user` table.
- - And finally, create a data provider creator by using the `createKnexDbProvider` API. 
+ - And finally, create a data provider creator by using the [`createKnexDbProvider`](../api/graphback-runtime-knex/modules/_createknexdbprovider_.md) API. 
   
-The rest of the code uses [`buildGraphbackAPI`](../api/build-graphback-api) to create Graphback CRUD API based on the defined `userModel` model.
+The rest of the code uses [`buildGraphbackAPI`](../api/graphback/modules/_buildgraphbackapi_.md) to create Graphback CRUD API based on the defined `userModel` model.
 
 Visit [Data Models](../model/datamodel.md) pages to learn more about how to design your business models.

--- a/docs/databases/sqlite.md
+++ b/docs/databases/sqlite.md
@@ -45,9 +45,9 @@ Visit [Knex Connection Options](http://knexjs.org/#Installation-client) to learn
 
 ## Using Knex Provider
 
-The provider exposes a [`SQLiteKnexDBDataProvider`](https://github.com/aerogear/graphback/blob/master/packages/graphback-runtime-knex/src/SQLiteKnexDBDataProvider.ts) API, which can be used to create a SQLite data providers for each of your data models. 
+The provider exposes a [`SQLiteKnexDBDataProvider`](../api/graphback-runtime-knex/classes/_sqliteknexdbdataprovider_.sqliteknexdbdataprovider.md) API, which can be used to create a SQLite data providers for each of your data models. 
 
-The code below shows how to create a data provider creator for a SQLite database and how to use it in [`buildGraphbackAPI`](../api/build-graphback-api.md).
+The code below shows how to create a data provider creator for a SQLite database and how to use it in [`buildGraphbackAPI`](../api/graphback/modules/_buildgraphbackapi_.md).
 
 ```ts
 import Knex from 'knex';
@@ -97,8 +97,8 @@ The highlighted code does the following:
  - Create a connection to SQLite database using Knex.
  - Define the user model.
  - Perform the migrations using [GraphQL Migrations](../graphql-migrations/intro.md) to create the `user` table.
- - And finally, create a data provider creator which will be applied to our model, using the [`SQLiteKnexDBDataProvider`](https://github.com/aerogear/graphback/blob/master/packages/graphback-runtime-knex/src/SQLiteKnexDBDataProvider.ts) API. 
+ - And finally, create a data provider creator which will be applied to our model, using the [`SQLiteKnexDBDataProvider`](../api/graphback-runtime-knex/classes/_sqliteknexdbdataprovider_.sqliteknexdbdataprovider.md) API. 
   
-The rest of the code uses [`buildGraphbackAPI`](../api/build-graphback-api) to create Graphback CRUD API based on the defined `userModel` model.
+The rest of the code uses [`buildGraphbackAPI`](../api/graphback/modules/_buildgraphbackapi_.md) to create Graphback CRUD API based on the defined `userModel` model.
 
 Visit [Data Models](../model/datamodel.md) to learn more about how to design your business models.

--- a/docs/datasync/intro.md
+++ b/docs/datasync/intro.md
@@ -4,7 +4,7 @@ title: Data Synchronization
 sidebar_label: What is Data Synchronization?
 ---
 
-The `@graphback/datasync` package consists of the Data Synchronization Schema plugin and compatible data sources, provides out of the box Data Synchronization strategies for GraphQL clients with offline functionality e.g. [Offix](https://offix.dev). 
+The `@graphback/datasync` package consists of the [Data Synchronization Schema plugin](../api/graphback-datasync/classes/_datasyncplugin_.datasyncplugin.md) and [compatible data sources](../api/graphback-datasync/classes/_providers_datasyncmongodbdataprovider_.datasyncmongodbdataprovider.md), provides out of the box Data Synchronization strategies for GraphQL clients with offline functionality e.g. [Offix](https://offix.dev). 
 
 :::note
 Currently this plugin **only** supports MongoDB data sources, with support for other kinds of data sources coming in a future release.

--- a/docs/getting-started/adding-graphback-to-your-project.md
+++ b/docs/getting-started/adding-graphback-to-your-project.md
@@ -117,7 +117,7 @@ const { typeDefs, resolvers, contextCreator } = buildGraphbackAPI(schema, {
 });
 ```
 
-Check out the [buildGraphbackAPI](../api/build-graphback-api) for more advanced use cases like CRUD configuration and plugin extensions.
+Check out the [buildGraphbackAPI](./api/graphback/modules/_buildgraphbackapi_.md) for more advanced use cases like CRUD configuration and plugin extensions.
 
 ### Finish setup
 

--- a/docs/plugins/client-crud-plugin.md
+++ b/docs/plugins/client-crud-plugin.md
@@ -4,7 +4,7 @@ title: ClientCRUD Plugin
 sidebar_label: ClientCRUD
 ---
 
-The `ClientCRUDPlugin` plugin uses your GraphQL schema to generate queries, mutations, subscriptions and fragments for use in your client-side application. The generated documents are compatible with all major GraphQL providers, such as [Apollo GraphQL](https://www.apollographql.com/) and [urql](https://formidable.com/open-source/urql/).
+The [`ClientCRUDPlugin`](../api/graphback-codegen-client/classes/_clientcrudplugin_.clientcrudplugin.md) plugin uses your GraphQL schema to generate queries, mutations, subscriptions and fragments for use in your client-side application. The generated documents are compatible with all major GraphQL providers, such as [Apollo GraphQL](https://www.apollographql.com/) and [urql](https://formidable.com/open-source/urql/).
 
 ## Installation
 

--- a/docs/plugins/schema-crud-plugin.md
+++ b/docs/plugins/schema-crud-plugin.md
@@ -4,7 +4,7 @@ title: SchemaCRUD Plugin
 sidebar_label: SchemaCRUD
 ---
 
-The `SchemaCRUDPlugin` plugin creates your GraphQL schema with all input types, Query, Mutation and Subscription fields following recommended patterns from [GraphQL CRUD](https://graphqlcrud.org/).
+The [`SchemaCRUDPlugin`](../api/graphback-codegen-schema/classes/_schemacrudplugin_.schemacrudplugin.md) plugin creates your GraphQL schema with all input types, Query, Mutation and Subscription fields following recommended patterns from [GraphQL CRUD](https://graphqlcrud.org/).
 The plugin also creates your CRUD resolvers to use with your GraphQL schema.
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "tslint-config-prettier": "1.18.0",
     "tslint-microsoft-contrib": "6.2.0",
     "typedoc": "0.17.8",
+    "typedoc-plugin-markdown": "2.3.1",
     "typescript": "3.9.6"
   },
   "scripts": {
@@ -42,6 +43,7 @@
     "watch": "lerna run watch",
     "release:prep": "./scripts/prepareRelease.sh",
     "release:validate": "./scripts/validateRelease.sh",
+    "generate:doc": "./scripts/generateApiDoc.sh",
     "publish:canary": "lerna publish --canary",
     "publish": "./scripts/publishRelease.sh",
     "link": "lerna exec npm link .",

--- a/packages/create-graphback/README.md
+++ b/packages/create-graphback/README.md
@@ -1,7 +1,7 @@
 ## Graphback
 
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   Auto generate database structure, <br/>
   GraphQL Resolvers and Queries from GraphQL types 🚀

--- a/packages/graphback-cli/README.md
+++ b/packages/graphback-cli/README.md
@@ -1,7 +1,7 @@
 ## Graphback
 
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   Auto generate database structure, <br/>
   GraphQL Resolvers and Queries from GraphQL types 🚀

--- a/packages/graphback-codegen-client/README.md
+++ b/packages/graphback-codegen-client/README.md
@@ -1,7 +1,7 @@
 ## Grapback Client Generator Plugin
 
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   Auto generate database structure, <br/>
   GraphQL Resolvers and Queries from GraphQL types 🚀

--- a/packages/graphback-codegen-schema/README.md
+++ b/packages/graphback-codegen-schema/README.md
@@ -1,7 +1,7 @@
 ## Graphback Codegen Schema
 
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   Auto generate database structure, <br/>
   GraphQL Resolvers and Queries from GraphQL types 🚀

--- a/packages/graphback-core/README.md
+++ b/packages/graphback-core/README.md
@@ -1,7 +1,7 @@
 ## Graphback
 
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   Auto generate database structure, <br/>
   GraphQL Resolvers and Queries from GraphQL types 🚀

--- a/packages/graphback-datasync/README.md
+++ b/packages/graphback-datasync/README.md
@@ -1,7 +1,7 @@
 ## Graphback Datasync
 
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   Auto generate database structure, <br/>
   GraphQL Resolvers and Queries from GraphQL types 🚀

--- a/packages/graphback-keycloak-authz/README.md
+++ b/packages/graphback-keycloak-authz/README.md
@@ -1,6 +1,6 @@
 ## Graphback Keycloak Authz
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   RBAC Authorization on top of the Graphback Service layer<br/>
   Declarative code and schema driven RBAC for Graphback 🚀

--- a/packages/graphback-runtime-knex/README.md
+++ b/packages/graphback-runtime-knex/README.md
@@ -1,7 +1,7 @@
 ## Graphback
 
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   Auto generate database structure, <br/>
   GraphQL Resolvers and Queries from GraphQL types 🚀

--- a/packages/graphback-runtime-mongodb/README.md
+++ b/packages/graphback-runtime-mongodb/README.md
@@ -1,7 +1,7 @@
 ## Graphback
 
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   Auto generate database structure, <br/>
   GraphQL Resolvers and Queries from GraphQL types 🚀

--- a/packages/graphback-runtime/README.md
+++ b/packages/graphback-runtime/README.md
@@ -1,7 +1,7 @@
 ## Graphback
 
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   Auto generate database structure, <br/>
   GraphQL Resolvers and Queries from GraphQL types 🚀

--- a/packages/graphback/README.md
+++ b/packages/graphback/README.md
@@ -1,7 +1,7 @@
 ## Graphback
 
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   Auto generate database structure, <br/>
   GraphQL Resolvers and Queries from GraphQL types 🚀

--- a/packages/graphql-migrations/README.md
+++ b/packages/graphql-migrations/README.md
@@ -1,7 +1,7 @@
 ## Graphback
 
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   Auto generate database structure, <br/>
   GraphQL Resolvers and Queries from GraphQL types 🚀

--- a/packages/graphql-serve/README.md
+++ b/packages/graphql-serve/README.md
@@ -1,7 +1,7 @@
 ## Graphback
 
 <p align="center">
-  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png">
+  <img width="400" src="https://raw.githubusercontent.com/aerogear/graphback/master/website/static/img/logo.png"/>
   <br/>
   Auto generate database structure, <br/>
   GraphQL Resolvers and Queries from GraphQL types 🚀

--- a/scripts/generateApiDoc.sh
+++ b/scripts/generateApiDoc.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# get names of packages being managed by lerna
+PACKAGES=$(lerna --loglevel=silent ls | awk -F ' ' '{print $1}')
+
+# generate docs for each package
+for package in $PACKAGES; do
+  echo $package
+  # Ignore the "graphback/runtime" package since it is deprecated
+  # Remove this line once https://github.com/aerogear/graphback/issues/1768 is resolved
+  if [ "@graphback/runtime" == "$package" ]; then
+    continue
+  # graphback appears in many of our package hence searching using that pattern will show duplicates results
+  # so let's handle the "graphback" package differently from the rest of our packages
+  elif [ "graphback" == "$package" ]; then
+    outputDirName=$package
+    inputDirName="packages/graphback"
+  else
+    inputDirName=$(lerna --loglevel=silent ls -l | grep $package | awk -F ' ' '{print $3}' | cut -c1-)
+    outputDirName=$(lerna --loglevel=silent ls -l | grep $package | awk -F ' ' '{print $3}' | cut -c10-)
+  fi
+
+  yarn typedoc --excludeNotExported --plugin typedoc-plugin-markdown --skipSidebar --hideBreadcrumbs --theme docusaurus2 --ignoreCompilerErrors --out docs/api/${outputDirName} --inputFiles ${inputDirName}/src
+  echo "API documentation generated for ${package}"
+done

--- a/website/README.md
+++ b/website/README.md
@@ -53,6 +53,16 @@ my-docusaurus/
 1. Execute `yarn doc yourVersion` 
 2. Review docusaurus config and swap any occurence of old version
 
+# Generating API documentation
+
+On `Graphback` project root directory, run the command:
+
+```bash
+yarn generate:doc
+```
+
+This will generate API documentation by leveraging code comments. The generated documentations will be located in
+`docs/api/` folder. 
 
 # Editing Content
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -27,11 +27,21 @@
     ],
     "Authentication": [
       "authentication/intro",
-      "authentication/keycloak"
+      "authentication/keycloak",
+      "api/graphback-keycloak-authz/classes/_keycloakcrudservice_.keycloakcrudservice",
+      "api/graphback-keycloak-authz/modules/_createkeycloakcrudservice_",
+      "api/graphback-keycloak-authz/modules/_keycloakconfig_"
     ],
     "Data Sync": [
       "datasync/intro",
-      "datasync/soft-delete"
+      "datasync/soft-delete",
+      "api/graphback-datasync/interfaces/_providers_datasyncprovider_.datasyncprovider",
+      "api/graphback-datasync/interfaces/_services_datasynccrudservice_.synclist",
+      "api/graphback-datasync/interfaces/_services_createdatasyncservice_.createdatasynccrudserviceoptions",
+      "api/graphback-datasync/classes/_providers_datasyncmongodbdataprovider_.datasyncmongodbdataprovider",
+      "api/graphback-datasync/classes/_services_datasynccrudservice_.datasynccrudservice",
+      "api/graphback-datasync/classes/_datasyncplugin_.datasyncplugin",
+      "api/graphback-datasync/classes/_util_.conflicterror"
     ],
     "GraphQL Migrations": [
       "graphql-migrations/intro",
@@ -49,17 +59,35 @@
       "plugins/crud-client",
       "plugins/create"
     ],
-    "API Reference": [
-      "api/build-graphback-api",
-      "api/create-crud-service",
-      "api/create-knexdb-provider",
-      "api/create-mongodb-provider",
-      "api/graphback-crud-service",
-      "api/graphback-data-provider"
-    ],
     "CLI Reference": [
       "cli/create-graphback",
       "cli/graphback-cli"
+    ],
+    "API Reference": [
+      "api/graphback/modules/_buildgraphbackapi_",
+      "api/graphback/interfaces/_buildgraphbackapi_.graphbackapi",
+      "api/graphback/interfaces/_buildgraphbackapi_.graphbackapiconfig",
+      "api/graphback-core/interfaces/_runtime_createcrudservice_.createcrudserviceoptions",
+      "api/graphback-runtime-knex/modules/_createknexdbprovider_",
+      "api/graphback-runtime-knex/classes/_knexdbdataprovider_.knexdbdataprovider",
+      "api/graphback-runtime-knex/classes/_sqliteknexdbdataprovider_.sqliteknexdbdataprovider",
+      "api/graphback-runtime-mongodb/modules/_createmongodbprovider_",
+      "api/graphback-runtime-mongodb/classes/_mongodbdataprovider_.mongodbdataprovider",
+      "api/graphback-core/interfaces/_runtime_graphbackdataprovider_.graphbackdataprovider",
+      "api/graphback-core/interfaces/_plugin_graphbackpluginengine_.graphbackpluginengineoptions",
+      "api/graphback-core/interfaces/_plugin_graphbackcrudgeneratorconfig_.graphbackcrudgeneratorconfig",
+      "api/graphback-core/interfaces/_runtime_createcrudservice_.createcrudserviceoptions",
+      "api/graphback-core/interfaces/_runtime_interfaces_.graphbackcontext",
+      "api/graphback-core/interfaces/_runtime_graphbackcrudservice_.resultlist",
+      "api/graphback-core/classes/_plugin_graphbackplugin_.graphbackplugin",
+      "api/graphback-core/classes/_runtime_crudservice_.crudservice",
+      "api/graphback-core/classes/_runtime_graphbackproxyservice_.graphbackproxyservice",
+      "api/graphback-core/modules/_runtime_createcrudservice_",
+      "api/graphback-core/interfaces/_runtime_graphbackcrudservice_.graphbackcrudservice",
+      "api/graphback-core/classes/_runtime_crudservice_.crudservice",
+      "api/graphback-core/classes/_runtime_graphbackproxyservice_.graphbackproxyservice",
+      "api/graphback-codegen-schema/classes/_schemacrudplugin_.schemacrudplugin",
+      "api/graphback-codegen-client/classes/_clientcrudplugin_.clientcrudplugin"
     ],
     "Release Notes":[
       "releases"


### PR DESCRIPTION
Fixes https://github.com/aerogear/graphback/issues/1702

To verify:

```bash
yarn 
yarn generate:doc
cd website
yarn start
```

Targeted API:
   - [x] buildGraphbackAPI
   - [x] createCRUDService
   - [x] createKnexDbProvider
   - [x] createMongoDbProvider
   - [x] GraphbackDataProvider
   - [x] GraphbackCRUDService
   - [x] GraphbackPlugin