### PR TITLE
revert: chore: disable automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "ora",
     "chalk"
   ],
-  "automerge": false,
+  "automerge": true,
   "major": {
     "automerge": false
   },


### PR DESCRIPTION
This reverts commit fefa6f83c65acf2651459b2a028d28f3bbc9ad67.

Re-enable auto-merging of dependencies with minor and patch releases.