### PR TITLE
chore(templates): map Mongo container to port 27018

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,7 +47,7 @@
         "DB_USER": "mongodb",
         "DB_PASSWORD": "mongo",
         "DB_HOST": "localhost",
-        "DB_PORT": "27017",
+        "DB_PORT": "27018",
         "DB_DATABASE": "users",
         "DB_AUTHSOURCE": "admin"
       },
@@ -70,7 +70,7 @@
         "DB_USER": "mongodb",
         "DB_PASSWORD": "mongo",
         "DB_HOST": "localhost",
-        "DB_PORT": "27017",
+        "DB_PORT": "27018",
         "DB_DATABASE": "users",
         "DB_AUTHSOURCE": "admin"
       },

--- a/templates/ts-apollo-mongodb-backend/.env
+++ b/templates/ts-apollo-mongodb-backend/.env
@@ -1,6 +1,6 @@
 DB_USER=mongodb
 DB_PASSWORD=mongo
 DB_HOST=localhost
-DB_PORT=27017
+DB_PORT=27018
 DB_DATABASE=users
 DB_AUTHSOURCE=admin

--- a/templates/ts-apollo-mongodb-backend/docker-compose.yml
+++ b/templates/ts-apollo-mongodb-backend/docker-compose.yml
@@ -10,5 +10,5 @@ services:
           - MONGO_INITDB_ROOT_USERNAME=mongodb
           - MONGO_INITDB_ROOT_PASSWORD=mongo
         ports:
-            - 27017:27017
+            - 27018:27017
         command: mongod

--- a/templates/ts-apollo-mongodb-datasync-backend/.env
+++ b/templates/ts-apollo-mongodb-datasync-backend/.env
@@ -1,6 +1,6 @@
 DB_USER=mongodb
 DB_PASSWORD=mongo
 DB_HOST=localhost
-DB_PORT=27017
+DB_PORT=27018
 DB_DATABASE=users
 DB_AUTHSOURCE=admin

--- a/templates/ts-apollo-mongodb-datasync-backend/docker-compose.yml
+++ b/templates/ts-apollo-mongodb-datasync-backend/docker-compose.yml
@@ -10,5 +10,5 @@ services:
           - MONGO_INITDB_ROOT_USERNAME=mongodb
           - MONGO_INITDB_ROOT_PASSWORD=mongo
         ports:
-            - 27017:27017
+            - 27018:27017
         command: mongod


### PR DESCRIPTION
The Docker Compose files were mapping to the local port 27017 (the default MongoDB port)

This should be reserved for MongoDB as it is highly possible that the developer might have MongoDB running.

We already map the Postgres containers to a different port (55432).