### PR TITLE
feat(datasync): add conflicts by version

### DIFF
--- a/integration/tests/runtime-workflow-datasync-conflicts.ts
+++ b/integration/tests/runtime-workflow-datasync-conflicts.ts
@@ -40,7 +40,7 @@ beforeAll(async () => {
     mkdirSync("./output-datasync-conflict-mongo");
     mkdirSync("./output-datasync-conflict-mongo/client")
 
-    mongoClient = new MongoClient('mongodb://mongodb:mongo@localhost:27018/users?authSource=admin', { useUnifiedTopology: true });
+    mongoClient = new MongoClient('mongodb://mongodb:mongo@localhost:27017/users?authSource=admin', { useUnifiedTopology: true });
     await mongoClient.connect();
     db = mongoClient.db('users');
     graphbackApi = createDataSyncAPI(modelText, { db, dataSyncConflictMap: { Note: { enabled: true } }, graphbackAPIConfig: {

--- a/integration/tests/runtime-workflow-datasync-conflicts.ts
+++ b/integration/tests/runtime-workflow-datasync-conflicts.ts
@@ -26,6 +26,22 @@ let graphbackApi: GraphbackAPI;
 
 let documents: DocumentNode;
 
+const SYNC_NOTES = gql`
+query syncNotes($lastSync: GraphbackTimestamp!, $filter: NoteFilter, $limit: Int) {
+    syncNotes(lastSync: $lastSync, filter: $filter, limit: $limit) {
+        items {
+          _id
+          title
+          description
+          ${DataSyncFieldNames.lastUpdatedAt}
+          ${DataSyncFieldNames.deleted}
+          ${DataSyncFieldNames.version}
+        },
+        lastSync
+    }
+}
+`
+
 const notesId = [];
 const commentId = [];
 const metadataId = [];
@@ -44,10 +60,10 @@ beforeAll(async () => {
     await mongoClient.connect();
     db = mongoClient.db('users');
     graphbackApi = createDataSyncAPI(modelText, { db, dataSyncConflictMap: { Note: { enabled: true } }, graphbackAPIConfig: {
-        plugins: [
-            new SchemaCRUDPlugin({ outputPath: "./output-datasync-conflict-mongo/schema/schema.graphql" }),
-            new ClientCRUDPlugin({ outputFile: './output-datasync-conflict-mongo/client/graphback.graphql' }),
-        ]
+      plugins: [
+        new SchemaCRUDPlugin({ outputPath: "./output-datasync-conflict-mongo/schema/schema.graphql" }),
+        new ClientCRUDPlugin({ outputFile: './output-datasync-conflict-mongo/client/graphback.graphql' }),
+      ]
     } });
     
     await seedDatabase(db);
@@ -106,9 +122,9 @@ async function seedDatabase(db: Db) {
     const { ops } = await db.collection("note").insertOne(note);
     notesId.push(ops[0]._id);
     await db.collection(getDeltaTableName('note')).insert({
-        docId: ops[0]._id,
-        [DataSyncFieldNames.version]: 1,
-        document: ops[0]
+      docId: ops[0]._id,
+      [DataSyncFieldNames.version]: 1,
+      document: ops[0]
     })
   }
 }
@@ -143,6 +159,103 @@ test('Client side should win when conflict occurs', async () => {
   expect(secondUpdateResponse.data.updateNote.title).toEqual(secondUpdateTitle);
 })
 
+test('force deletes on delete conflicts', async () => {
+  const noteTitle = 'Note C';
+  const noteDescription = "Note C Description";
+  const createResponse = await createNote(client, { title: noteTitle, description: noteDescription });
+
+  expect(createResponse.data?.createNote).toBeDefined();
+  expect(createResponse.data.createNote.title).toEqual(noteTitle);
+
+  const {_id} = createResponse.data.createNote;
+  
+  const updatedTitle = "Note C v2";
+  await updateNote({ _id, title: updatedTitle, [DataSyncFieldNames.version]: 1 }, client);
+
+  await deleteNote(client, { _id, [DataSyncFieldNames.version]: 1 })
+
+  const { data, errors } = await client.query({ query: SYNC_NOTES , variables: {
+    lastSync: 0,
+    filter: {
+      title: {
+        eq: updatedTitle
+      }
+    }
+  }});
+  console.log(errors);
+  expect(data.syncNotes.items).toBeDefined();
+  expect(data.syncNotes.items[0]._id).toEqual(_id);
+  expect(data.syncNotes.items[0][DataSyncFieldNames.deleted]).toEqual(true);
+});
+
+test('deletes document when no conflicts occur', async () => {
+  const noteTitle = 'Note D';
+  const noteDescription = "Note D Description";
+  const createResponse = await createNote(client, { title: noteTitle, description: noteDescription });
+
+  expect(createResponse.data?.createNote).toBeDefined();
+  expect(createResponse.data.createNote.title).toEqual(noteTitle);
+
+  const { _id, [DataSyncFieldNames.version]: version } = createResponse.data.createNote;
+  
+  const updatedTitle = "Note D v2";
+  const updateResponse = await updateNote({ _id, title: updatedTitle, [DataSyncFieldNames.version]: version }, client);
+
+  expect(updateResponse.data?.updateNote).toBeDefined();
+
+  const {[DataSyncFieldNames.version]: updatedVersion} = updateResponse.data.updateNote;
+
+  await deleteNote(client, { _id, [DataSyncFieldNames.version]: updatedVersion })
+
+  const { data } = await client.query({ query: SYNC_NOTES , variables: {
+    lastSync: 0,
+    filter: {
+      title: {
+        eq: updatedTitle
+      }
+    }
+  }});
+
+  expect(data.syncNotes.items).toBeDefined();
+  expect(data.syncNotes.items[0]._id).toEqual(_id);
+  expect(data.syncNotes.items[0][DataSyncFieldNames.deleted]).toEqual(true);
+
+});
+
+test('restores document when server-side deleted', async () => {
+  const noteTitle = 'Note E';
+  const noteDescription = "Note E Description";
+  const createResponse = await createNote(client, { title: noteTitle, description: noteDescription });
+
+  expect(createResponse.data?.createNote).toBeDefined();
+  expect(createResponse.data.createNote.title).toEqual(noteTitle);
+
+  const { _id, [DataSyncFieldNames.version]: version } = createResponse.data.createNote;
+  
+  const deleteResponse = await deleteNote(client, { _id, [DataSyncFieldNames.version]: version })
+  expect(deleteResponse.data.deleteNote).toBeDefined();
+
+  const updatedTitle = "Note E v2";
+  const updateResponse = await updateNote({ _id, title: updatedTitle, [DataSyncFieldNames.version]: version }, client);
+
+  expect(updateResponse.data?.updateNote).toBeDefined();
+
+  const { data } = await client.query({ query: SYNC_NOTES , variables: {
+    lastSync: 0,
+    filter: {
+      title: {
+        eq: updatedTitle
+      }
+    }
+  }});
+
+  expect(data.syncNotes.items).toBeDefined();
+  expect(data.syncNotes.items[0]._id).toEqual(_id);
+  expect(data.syncNotes.items[0].title).toEqual(updatedTitle);
+  expect(data.syncNotes.items[0][DataSyncFieldNames.deleted]).toEqual(false);
+
+});
+
 
 
 async function updateNote(input: any, client: ApolloServerTestClient) {
@@ -164,11 +277,11 @@ async function createNote(client: ApolloServerTestClient, input: any) {
   return response;
 }
 
-async function deleteNote(client: ApolloServerTestClient, _id:  string | number) {
+async function deleteNote(client: ApolloServerTestClient, input: any) {
   const response = await client.mutate({
     operationName: "deleteNote",
     mutation: documents,
-    variables: { input: { _id } }
+    variables: { input }
   });
 
   return response;

--- a/integration/tests/runtime-workflow-datasync-conflicts.ts
+++ b/integration/tests/runtime-workflow-datasync-conflicts.ts
@@ -1,0 +1,175 @@
+/* eslint-disable max-lines */
+/* eslint-disable no-null/no-null */
+/* eslint-disable no-shadow */
+/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable import/no-extraneous-dependencies */
+import { mkdirSync, readFileSync, rmdirSync } from 'fs';
+import * as path from 'path';
+import { ApolloServer, gql } from "apollo-server";
+import { createTestClient, ApolloServerTestClient } from 'apollo-server-testing';
+import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader'
+import { loadDocuments } from '@graphql-tools/load'
+import { buildGraphbackAPI, GraphbackAPI } from "graphback";
+import { DocumentNode } from 'graphql';
+import { MongoClient, Db, ObjectID } from 'mongodb';
+import { PubSub } from "graphql-subscriptions";
+import { getDeltaTableName, DataSyncFieldNames, createDataSyncAPI } from "../../packages/graphback-datasync";
+import { SchemaCRUDPlugin } from '../../packages/graphback-codegen-schema';
+import { ClientCRUDPlugin } from '../../packages/graphback-codegen-client';
+
+/** global config */
+let db: Db;
+let mongoClient: MongoClient;
+let server: ApolloServer;
+let client: ApolloServerTestClient;
+let graphbackApi: GraphbackAPI;
+
+let documents: DocumentNode;
+
+const notesId = [];
+const commentId = [];
+const metadataId = [];
+
+const modelText = readFileSync("./datasync-mongodb-model.graphql").toString();
+const startTS = new Date(1596622318448);
+const updatedTS2 = new Date(1596622363886);
+const objectId = new ObjectID("507f191e810c19729de860ea");
+
+beforeAll(async () => {
+  try {
+    mkdirSync("./output-datasync-conflict-mongo");
+    mkdirSync("./output-datasync-conflict-mongo/client")
+
+    mongoClient = new MongoClient('mongodb://mongodb:mongo@localhost:27018/users?authSource=admin', { useUnifiedTopology: true });
+    await mongoClient.connect();
+    db = mongoClient.db('users');
+    graphbackApi = createDataSyncAPI(modelText, { db, dataSyncConflictMap: { Note: { enabled: true } }, graphbackAPIConfig: {
+        plugins: [
+            new SchemaCRUDPlugin({ outputPath: "./output-datasync-conflict-mongo/schema/schema.graphql" }),
+            new ClientCRUDPlugin({ outputFile: './output-datasync-conflict-mongo/client/graphback.graphql' }),
+        ]
+    } });
+    
+    await seedDatabase(db);
+    
+    const source = await loadDocuments(path.resolve(`./output-datasync-conflict-mongo/client/graphback.graphql`), {
+      loaders: [
+        new GraphQLFileLoader()
+      ]
+    });
+    documents = source[0].document;
+  } catch (e) {
+    throw e;
+  }
+})
+
+beforeEach(() => {
+  const { typeDefs, resolvers, contextCreator } = graphbackApi;
+  server = new ApolloServer({
+    typeDefs,
+    resolvers,
+    context: contextCreator
+  });
+  
+  client = createTestClient(server);
+})
+
+afterEach(() => server.stop())
+
+afterAll(async () => {
+  rmdirSync(path.resolve('./output-datasync-conflict-mongo'), { recursive: true });
+  const dropCollections = ["note", getDeltaTableName("note")].map((name: string) => db.dropCollection(name));
+  await Promise.all(dropCollections);
+
+  return mongoClient.close();
+});
+
+async function seedDatabase(db: Db) {
+  const notes = [
+    {
+      title: 'Note A',
+      description: 'Note A Description',
+      [DataSyncFieldNames.lastUpdatedAt]: startTS.valueOf(),
+      [DataSyncFieldNames.deleted]: false,
+      [DataSyncFieldNames.version]: 1
+    },
+    {
+      title: 'Note B',
+      description: 'Note B Description',
+      [DataSyncFieldNames.lastUpdatedAt]: startTS.valueOf(),
+      [DataSyncFieldNames.deleted]: false,
+      [DataSyncFieldNames.version]: 1
+    }
+  ]
+
+  for (const note of notes) {
+    const { ops } = await db.collection("note").insertOne(note);
+    notesId.push(ops[0]._id);
+    await db.collection(getDeltaTableName('note')).insert({
+        docId: ops[0]._id,
+        [DataSyncFieldNames.version]: 1,
+        document: ops[0]
+    })
+  }
+}
+
+
+test('Should update successfully when no conflict', async () => {
+  const updatedTitle = 'Note A v2';
+  const firstUpdateResponse = await updateNote({ _id: notesId[0], title: updatedTitle, [DataSyncFieldNames.version]: 1 }, client);
+
+  expect(firstUpdateResponse.data?.updateNote).toBeDefined();
+  expect(firstUpdateResponse.data.updateNote.title).toEqual(updatedTitle);
+
+  const updatedDescription = "Note A Description v2";
+  const secondUpdateResponse = await updateNote({ _id: notesId[0], description: updatedDescription, [DataSyncFieldNames.version]: 1 }, client);
+
+  expect(secondUpdateResponse.data?.updateNote).toBeDefined();
+  expect(secondUpdateResponse.data.updateNote.description).toEqual(updatedDescription);
+})
+
+test('Client side should win when conflict occurs', async () => {
+  const updatedTitle = 'Note B v2';
+  const firstUpdateResponse = await updateNote({ _id: notesId[0], title: updatedTitle, [DataSyncFieldNames.version]: 1 }, client);
+
+  expect(firstUpdateResponse.data?.updateNote).toBeDefined();
+  expect(firstUpdateResponse.data.updateNote.title).toEqual(updatedTitle);
+
+  
+  const secondUpdateTitle = "Note B v3";
+  const secondUpdateResponse = await updateNote({ _id: notesId[0], title: secondUpdateTitle, [DataSyncFieldNames.version]: 1 }, client);
+
+  expect(secondUpdateResponse.data?.updateNote).toBeDefined();
+  expect(secondUpdateResponse.data.updateNote.title).toEqual(secondUpdateTitle);
+})
+
+
+
+async function updateNote(input: any, client: ApolloServerTestClient) {
+  const response = await client.mutate({
+    operationName: "updateNote",
+    mutation: documents,
+    variables: { input }
+  });
+
+  return response;
+}
+
+async function createNote(client: ApolloServerTestClient, input: any) {
+  const response = await client.mutate({
+    operationName: "createNote",
+    mutation: documents, variables: { input }
+  });
+
+  return response;
+}
+
+async function deleteNote(client: ApolloServerTestClient, _id:  string | number) {
+  const response = await client.mutate({
+    operationName: "deleteNote",
+    mutation: documents,
+    variables: { input: { _id } }
+  });
+
+  return response;
+}

--- a/packages/graphback-datasync/package.json
+++ b/packages/graphback-datasync/package.json
@@ -36,6 +36,7 @@
     "typescript": "3.9.7"
   },
   "dependencies": {
+    "graphback": "0.15.1",
     "@graphback/codegen-schema": "0.15.1",
     "@graphback/core": "0.15.1",
     "@graphback/runtime-mongo": "0.15.1",

--- a/packages/graphback-datasync/src/DataSyncPlugin.ts
+++ b/packages/graphback-datasync/src/DataSyncPlugin.ts
@@ -132,7 +132,7 @@ export class DataSyncPlugin extends GraphbackPlugin {
       }
     });
 
-    const modelUsesVersion = !!this.config.modelConfigMap[model.graphqlType.name]?.enabled;
+    const modelUsesVersion = this.config.modelConfigMap[model.graphqlType.name]?.enabled;
     if (modelUsesVersion) {
       modelTC.addFields({
         [DataSyncFieldNames.version]: {

--- a/packages/graphback-datasync/src/DataSyncPlugin.ts
+++ b/packages/graphback-datasync/src/DataSyncPlugin.ts
@@ -147,7 +147,7 @@ export class DataSyncPlugin extends GraphbackPlugin {
     // Add _version argument to UpdateInputType
     const updateInputType = schemaComposer.getITC(getInputTypeName(model.graphqlType.name, GraphbackOperationType.UPDATE));
     const modelUsesVersion = this.config.modelConfigMap[model.graphqlType.name]?.enabled;
-    if ((modelUsesVersion) && updateInputType) {
+    if (modelUsesVersion && updateInputType) {
       updateInputType.addFields({
         [DataSyncFieldNames.version]: {
           type: GraphQLNonNull(GraphQLInt)

--- a/packages/graphback-datasync/src/deltaHelper.ts
+++ b/packages/graphback-datasync/src/deltaHelper.ts
@@ -1,0 +1,46 @@
+import { ModelDefinition, getTableName } from '@graphback/core';
+import { Db, Collection, ObjectId } from "mongodb";
+import { DataSyncFieldNames } from './util';
+
+export function getDeltaTableName(tableName: string) {
+  return `${tableName}Delta`
+}
+
+/**
+ * M
+ */
+export class MongoDeltaHelper {
+  protected db: Db;
+  protected collectionName: string;
+  public constructor(model: ModelDefinition, db: Db) {
+    this.db = db;
+    this.collectionName = getDeltaTableName(getTableName(model.graphqlType));
+  }
+
+  public async insertDiff(updatedDocument: any) {
+    const version = updatedDocument[DataSyncFieldNames.version];
+    const { _id } = updatedDocument;
+
+    const diff: any = {
+      docId: _id,
+      [DataSyncFieldNames.version]: version,
+      document: updatedDocument
+    }
+    await this.db.collection(this.collectionName).insertOne(diff);
+  }
+
+  public async findBaseForConflicts(updateDocument: any) {
+    if (updateDocument._id === undefined || updateDocument[DataSyncFieldNames.version] === undefined) {
+      throw new Error('Both _id and version field are needed for finding base');
+    }
+
+    const filter = {
+      docId: updateDocument._id,
+      [DataSyncFieldNames.version]: updateDocument[DataSyncFieldNames.version]
+    };
+
+    const result = await this.db.collection(this.collectionName).findOne(filter);
+
+    return result?.document;
+  }
+}

--- a/packages/graphback-datasync/src/deltaHelper.ts
+++ b/packages/graphback-datasync/src/deltaHelper.ts
@@ -18,8 +18,7 @@ export class MongoDeltaHelper {
   }
 
   public async insertDiff(updatedDocument: any) {
-    const version = updatedDocument[DataSyncFieldNames.version];
-    const { _id } = updatedDocument;
+const { _id, [DataSyncFieldNames.version]: version } = updatedDocument;
 
     const diff: any = {
       docId: _id,
@@ -30,8 +29,8 @@ export class MongoDeltaHelper {
   }
 
   public async findBaseForConflicts(updateDocument: any) {
-    if (updateDocument._id === undefined || updateDocument[DataSyncFieldNames.version] === undefined) {
-      throw new Error('Both _id and version field are needed for finding base');
+    if (!updateDocument._id || !updateDocument[DataSyncFieldNames.version]) {
+      throw new Error(`Both _id and ${DataSyncFieldNames.version} field are needed for finding base`);
     }
 
     const filter = {

--- a/packages/graphback-datasync/src/deltaSource.ts
+++ b/packages/graphback-datasync/src/deltaSource.ts
@@ -7,9 +7,10 @@ export function getDeltaTableName(tableName: string) {
 }
 
 /**
- * M
+ * Provides the ability to insert delta snapshots into MongoDB collections
+ * and get base for conflict resolution
  */
-export class MongoDeltaHelper {
+export class MongoDeltaSource<Type = any> {
   protected db: Db;
   protected collectionName: string;
   public constructor(model: ModelDefinition, db: Db) {
@@ -17,8 +18,8 @@ export class MongoDeltaHelper {
     this.collectionName = getDeltaTableName(getTableName(model.graphqlType));
   }
 
-  public async insertDiff(updatedDocument: any) {
-const { _id, [DataSyncFieldNames.version]: version } = updatedDocument;
+  public async insertDiff(updatedDocument: Type) {
+    const { _id, [DataSyncFieldNames.version]: version } = (updatedDocument as any);
 
     const diff: any = {
       docId: _id,
@@ -28,7 +29,7 @@ const { _id, [DataSyncFieldNames.version]: version } = updatedDocument;
     await this.db.collection(this.collectionName).insertOne(diff);
   }
 
-  public async findBaseForConflicts(updateDocument: any) {
+  public async findBaseForConflicts(updateDocument: any): Promise<Type> {
     if (!updateDocument._id || !updateDocument[DataSyncFieldNames.version]) {
       throw new Error(`Both _id and ${DataSyncFieldNames.version} field are needed for finding base`);
     }

--- a/packages/graphback-datasync/src/helpers/createDataSync.ts
+++ b/packages/graphback-datasync/src/helpers/createDataSync.ts
@@ -1,0 +1,23 @@
+import { GraphQLSchema } from 'graphql';
+import { Db } from 'mongodb';
+import { GraphbackAPIConfig, GraphbackAPI, buildGraphbackAPI, GraphbackConfig } from "graphback";
+import { PubSub } from 'graphql-subscriptions';
+import { createDataSyncMongoDbProvider, createDataSyncConflictProviderCreator } from '../providers';
+import { ConflictError, ConflictMetadata, DataSyncModelConflictConfig } from "../util";
+import { createDataSyncCRUDService } from '../services';
+import { DataSyncPlugin } from '../DataSyncPlugin';
+
+type DataSyncGraphbackConfig = Partial<GraphbackConfig>
+
+export function createDataSyncAPI(model: string | GraphQLSchema, db: Db, dataSyncConfigMap: { [modelName: string]: DataSyncModelConflictConfig} = {}, graphbackConfig: DataSyncGraphbackConfig = {}): GraphbackAPI {
+
+  return buildGraphbackAPI(model, {
+    serviceCreator: createDataSyncCRUDService({ pubSub: new PubSub() }),
+    ...graphbackConfig,
+    dataProviderCreator: createDataSyncConflictProviderCreator(db, dataSyncConfigMap),
+    plugins:[
+      ...graphbackConfig.plugins || [],
+      new DataSyncPlugin({ modelConfigMap: dataSyncConfigMap })
+    ]
+  });
+}

--- a/packages/graphback-datasync/src/helpers/createDataSync.ts
+++ b/packages/graphback-datasync/src/helpers/createDataSync.ts
@@ -10,7 +10,10 @@ import { DataSyncPlugin } from '../DataSyncPlugin';
 type DataSyncGraphbackAPIConfig = Omit<GraphbackAPIConfig, "dataProviderCreator">
 
 export function createDataSyncAPI(model: string | GraphQLSchema, createDataSyncConfig: { db: Db,  dataSyncConflictMap?: DataSyncModelConfigMap, graphbackAPIConfig?: DataSyncGraphbackAPIConfig }): GraphbackAPI {
-  const { db, dataSyncConflictMap, graphbackAPIConfig } = createDataSyncConfig
+  const { db, dataSyncConflictMap, graphbackAPIConfig } = {
+    dataSyncConflictMap: {},
+    ...createDataSyncConfig
+  }
 
   return buildGraphbackAPI(model, {
     ...graphbackAPIConfig,

--- a/packages/graphback-datasync/src/index.ts
+++ b/packages/graphback-datasync/src/index.ts
@@ -3,6 +3,7 @@ export * from './providers';
 export * from './services';
 export * from './util';
 export * from './helpers/createDataSync';
+export * from './deltaSource';
 
 //Required for plugins
 export { DataSyncPlugin as Plugin } from './DataSyncPlugin'

--- a/packages/graphback-datasync/src/index.ts
+++ b/packages/graphback-datasync/src/index.ts
@@ -2,6 +2,7 @@ export * from './DataSyncPlugin'
 export * from './providers';
 export * from './services';
 export * from './util';
+export * from './helpers/createDataSync';
 
 //Required for plugins
 export { DataSyncPlugin as Plugin } from './DataSyncPlugin'

--- a/packages/graphback-datasync/src/providers/DataSyncConflictProvider.ts
+++ b/packages/graphback-datasync/src/providers/DataSyncConflictProvider.ts
@@ -66,7 +66,7 @@ export class DataSyncConflictMongoDBDataProvider<Type = any> extends DataSyncMon
       // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
       resolvedUpdate[DataSyncFieldNames.version] = serverData[DataSyncFieldNames.version] + 1
 
-      resolvedUpdate[DataSyncFieldNames.lastUpdatedAt] = new Date();
+      resolvedUpdate[DataSyncFieldNames.lastUpdatedAt] = Date.now();
 
       const { value } = await this.db.collection(this.collectionName).findOneAndUpdate(updateFilter, { $set: resolvedUpdate }, { returnOriginal: false });
       if (value) {

--- a/packages/graphback-datasync/src/providers/DataSyncConflictProvider.ts
+++ b/packages/graphback-datasync/src/providers/DataSyncConflictProvider.ts
@@ -1,16 +1,17 @@
 import { ModelDefinition, GraphbackContext, TransformType, FieldTransform, NoDataError, GraphbackOperationType } from '@graphback/core';
 import { DataSyncModelConflictConfig, DataSyncFieldNames, ConflictMetadata, ConflictError } from '../util';
-import { MongoDeltaHelper } from '../deltaHelper';
+import { MongoDeltaSource } from '../deltaSource';
 import { DataSyncMongoDBDataProvider } from './DatasyncMongoDBDataProvider';
 
 export const MAX_RETRIES = 3;
 
 /**
- * Da
+ * Data Provider with update conflicts and optional conflict resolution
+ * that connects to the MongoDB database
  */
 export class DataSyncConflictMongoDBDataProvider<Type = any> extends DataSyncMongoDBDataProvider<Type> {
   protected conflictConfig: DataSyncModelConflictConfig
-  protected deltaHelper: MongoDeltaHelper
+  protected deltaSource: MongoDeltaSource
 
   public constructor(model: ModelDefinition, client: any, dataSyncConflictConfig: DataSyncModelConflictConfig) {
     super(model, client);
@@ -24,19 +25,18 @@ export class DataSyncConflictMongoDBDataProvider<Type = any> extends DataSyncMon
       }
     }
 
-    this.deltaHelper = new MongoDeltaHelper(model, client);
+    this.deltaSource = new MongoDeltaSource(model, client);
 
   }
 
   public async create(data: any, context: GraphbackContext): Promise<Type> {
-    const contextWithoutSelectedFields: GraphbackContext = { ...context }
-    contextWithoutSelectedFields.graphback.options.selectedFields = [];
+    context.graphback.options.selectedFields = []
 
     data[DataSyncFieldNames.version] = 1;
 
-    const result = await super.create(data, contextWithoutSelectedFields);
+    const result = await super.create(data, context);
 
-    await this.deltaHelper.insertDiff(result).catch((e: any) => { console.error(`Error in inserting delta: ${e}`) });
+    await this.deltaSource.insertDiff(result).catch((e: any) => { console.error(`Error in inserting delta: ${e}`) });
 
 
     return result;
@@ -48,15 +48,14 @@ export class DataSyncConflictMongoDBDataProvider<Type = any> extends DataSyncMon
     for(let i = 0; i < MAX_RETRIES; i++) {
       
       const serverData = await this.db.collection(this.collectionName).findOne({ _id, [DataSyncFieldNames.deleted]: false});
-      const base = await this.deltaHelper.findBaseForConflicts(updateDocument);
-      const clientData = updateDocument;
+      const base = await this.deltaSource.findBaseForConflicts(updateDocument);
 
       let resolvedUpdate = Object.assign({}, updateDocument);
 
       const updateFilter = { _id, [DataSyncFieldNames.version]: serverData[DataSyncFieldNames.version] }
 
-      if (serverData[DataSyncFieldNames.version] !== clientData[DataSyncFieldNames.version]){
-        const conflict = this.checkForConflict(clientData, base, serverData, GraphbackOperationType.UPDATE);
+      if (serverData[DataSyncFieldNames.version] !== updateDocument[DataSyncFieldNames.version]){
+        const conflict = this.checkForConflict(updateDocument, base, serverData, GraphbackOperationType.UPDATE);
 
         if (conflict) {
           resolvedUpdate = this.conflictConfig.conflictResolution.resolveUpdate(conflict);
@@ -73,7 +72,7 @@ export class DataSyncConflictMongoDBDataProvider<Type = any> extends DataSyncMon
 
       const { value } = await this.db.collection(this.collectionName).findOneAndUpdate(updateFilter, { $set: resolvedUpdate }, { returnOriginal: false });
       if (value) {
-        await this.deltaHelper.insertDiff(value);
+        await this.deltaSource.insertDiff(value);
 
         return value;
       }
@@ -88,29 +87,26 @@ export class DataSyncConflictMongoDBDataProvider<Type = any> extends DataSyncMon
     const clientDiff: any = {};
     const serverDiff: any = {};
 
-    let isConflict = false;
+    let conflictFound = false;
 
+    // Calculate clientDiff and serverDiff
     for (const key of Object.keys(clientData)) {
-      if (base[key] !== clientData[key]) {
-        if (!ignoredKeys.includes(key)) {
+      if (!ignoredKeys.includes(key)) {
+        if (base[key] !== clientData[key]) {
           clientDiff[key] = clientData[key];
         }
-      }
-    }
 
-    // calculate server diff
-    for (const key of Object.keys(clientData)) {
-      if (base[key] !== serverData[key]) {
-        if (!ignoredKeys.includes(key)) {
+        if (base[key] !== serverData[key]) {
           serverDiff[key] = serverData[key];
           if (clientDiff[key]) {
-            isConflict = true;
+            conflictFound = true;
           }
         }
       }
     }
 
-    if (isConflict) {
+
+    if (conflictFound) {
       return {
         base,
         server: serverData,

--- a/packages/graphback-datasync/src/providers/DataSyncConflictProvider.ts
+++ b/packages/graphback-datasync/src/providers/DataSyncConflictProvider.ts
@@ -53,7 +53,7 @@ export class DataSyncConflictMongoDBDataProvider<Type = any> extends DataSyncMon
 
       let resolvedUpdate = Object.assign({}, updateDocument);
 
-      const updateFilter: any = { _id, [DataSyncFieldNames.version]: serverData[DataSyncFieldNames.version] }
+      const updateFilter = { _id, [DataSyncFieldNames.version]: serverData[DataSyncFieldNames.version] }
 
       if (serverData[DataSyncFieldNames.version] !== clientData[DataSyncFieldNames.version]){
         const conflict = this.checkForConflict(clientData, base, serverData, GraphbackOperationType.UPDATE);

--- a/packages/graphback-datasync/src/providers/DataSyncConflictProvider.ts
+++ b/packages/graphback-datasync/src/providers/DataSyncConflictProvider.ts
@@ -1,0 +1,126 @@
+import { ModelDefinition, GraphbackContext, TransformType, FieldTransform, NoDataError, GraphbackOperationType } from '@graphback/core';
+import { DataSyncModelConflictConfig, DataSyncFieldNames, ConflictMetadata, ConflictError } from '../util';
+import { MongoDeltaHelper } from '../deltaHelper';
+import { DataSyncMongoDBDataProvider } from './DatasyncMongoDBDataProvider';
+
+export const MAX_RETRIES = 3;
+
+/**
+ * Da
+ */
+export class DataSyncConflictMongoDBDataProvider<Type = any> extends DataSyncMongoDBDataProvider<Type> {
+  protected conflictConfig: DataSyncModelConflictConfig
+  protected deltaHelper: MongoDeltaHelper
+
+  public constructor(model: ModelDefinition, client: any, dataSyncConflictConfig: DataSyncModelConflictConfig) {
+    super(model, client);
+    this.conflictConfig = dataSyncConflictConfig;
+
+    if (!this.conflictConfig.conflictResolution?.resolveUpdate) {
+      this.conflictConfig.conflictResolution = {
+        resolveUpdate(conflict: ConflictMetadata) {
+          throw new ConflictError(conflict)
+        }
+      }
+    }
+
+    this.deltaHelper = new MongoDeltaHelper(model, client);
+
+  }
+
+  public async create(data: any, context: GraphbackContext): Promise<Type> {
+    const contextWithoutSelectedFields: GraphbackContext = { ...context }
+    contextWithoutSelectedFields.graphback.options.selectedFields = [];
+
+    data[DataSyncFieldNames.version] = 1;
+
+    const result = await super.create(data, contextWithoutSelectedFields);
+
+    await this.deltaHelper.insertDiff(result).catch((e: any) => { console.error(`Error in inserting delta: ${e}`) });
+
+
+    return result;
+  }
+
+  public async update(updateDocument: any, context: GraphbackContext): Promise<Type> {
+    const { _id } = updateDocument;
+
+    for(let i = 0; i < MAX_RETRIES; i++) {
+      
+      const serverData = await this.db.collection(this.collectionName).findOne({ _id, [DataSyncFieldNames.deleted]: false});
+      const base = await this.deltaHelper.findBaseForConflicts(updateDocument);
+      const clientData = updateDocument;
+
+      let resolvedUpdate = Object.assign({}, updateDocument);
+
+      const updateFilter: any = { _id, [DataSyncFieldNames.version]: serverData[DataSyncFieldNames.version] }
+
+      if (serverData[DataSyncFieldNames.version] !== clientData[DataSyncFieldNames.version]){
+        const conflict = this.checkForConflict(clientData, base, serverData, GraphbackOperationType.UPDATE);
+
+        if (conflict) {
+          resolvedUpdate = this.conflictConfig.conflictResolution.resolveUpdate(conflict);
+        }
+
+      }
+
+      if (Object.keys(resolvedUpdate).length === 0) {
+        return serverData;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+      resolvedUpdate[DataSyncFieldNames.version] = serverData[DataSyncFieldNames.version] + 1
+
+      const { value } = await this.db.collection(this.collectionName).findOneAndUpdate(updateFilter, { $set: resolvedUpdate }, { returnOriginal: false });
+      if (value) {
+        await this.deltaHelper.insertDiff(value);
+
+        return value;
+      }
+    }
+
+    throw new Error(`Cannot update ${this.collectionName}`);
+  }
+
+  public checkForConflict(clientData: any, base: any, serverData: any, operation: GraphbackOperationType): ConflictMetadata|undefined {
+    const ignoredKeys = [DataSyncFieldNames.lastUpdatedAt, DataSyncFieldNames.version, DataSyncFieldNames.deleted];
+
+    const clientDiff: any = {};
+    const serverDiff: any = {};
+
+    let isConflict = false;
+
+    for (const key of Object.keys(clientData)) {
+      if (base[key] !== clientData[key]) {
+        if (!ignoredKeys.includes(key)) {
+          clientDiff[key] = clientData[key];
+        }
+      }
+    }
+
+    // calculate server diff
+    for (const key of Object.keys(clientData)) {
+      if (base[key] !== serverData[key]) {
+        if (!ignoredKeys.includes(key)) {
+          serverDiff[key] = serverData[key];
+          if (clientDiff[key]) {
+            isConflict = true;
+          }
+        }
+      }
+    }
+
+    if (isConflict) {
+      return {
+        base,
+        server: serverData,
+        client: clientData,
+        serverDiff,
+        clientDiff,
+        operation
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/packages/graphback-datasync/src/providers/DatasyncMongoDBDataProvider.ts
+++ b/packages/graphback-datasync/src/providers/DatasyncMongoDBDataProvider.ts
@@ -1,7 +1,7 @@
 import { getDatabaseArguments, metadataMap, GraphbackContext, NoDataError, TransformType, FieldTransform, GraphbackOrderBy, GraphbackPage, QueryFilter, StringInput, ModelDefinition } from '@graphback/core';
 import { ObjectId } from 'mongodb';
 import { MongoDBDataProvider, applyIndexes } from '@graphback/runtime-mongo';
-import { ConflictError, ConflictStateMap, DataSyncFieldNames } from "../util";
+import { DataSyncFieldNames } from "../util";
 import { DataSyncProvider } from "./DataSyncProvider";
 
 /**

--- a/packages/graphback-datasync/src/providers/createDataSyncMongoDbProvider.ts
+++ b/packages/graphback-datasync/src/providers/createDataSyncMongoDbProvider.ts
@@ -1,8 +1,9 @@
 import { Db } from 'mongodb';
 import { ModelDefinition, GraphbackDataProvider } from '@graphback/core';
 import { MongoDBDataProvider } from "@graphback/runtime-mongo"
-import { isDataSyncModel } from '../util';
+import { isDataSyncModel, DataSyncModelConflictConfig } from '../util';
 import { DataSyncMongoDBDataProvider } from './DatasyncMongoDBDataProvider';
+import { DataSyncConflictMongoDBDataProvider } from "./DataSyncConflictProvider";
 
 /**
  * Creates a new Data synchronisation data provider for MongoDb
@@ -12,6 +13,21 @@ import { DataSyncMongoDBDataProvider } from './DatasyncMongoDBDataProvider';
 export function createDataSyncMongoDbProvider(db: Db): (...args: any[]) => GraphbackDataProvider {
   return (model: ModelDefinition): GraphbackDataProvider => {
     if (isDataSyncModel(model)) {
+      return new DataSyncMongoDBDataProvider(model, db);
+    } else {
+      return new MongoDBDataProvider(model, db);
+    }
+  }
+}
+
+export function createDataSyncConflictProviderCreator(db: Db, datasyncConfigMap: { [modelName: string]: DataSyncModelConflictConfig } = {}) : (...args: any[]) => GraphbackDataProvider {
+  return (model: ModelDefinition): GraphbackDataProvider => {
+    if (isDataSyncModel(model)) {
+      const dataSyncModelConfig = datasyncConfigMap[model.graphqlType.name];
+      if (dataSyncModelConfig !== undefined && dataSyncModelConfig.enabled) {
+        return new DataSyncConflictMongoDBDataProvider(model, db, dataSyncModelConfig);
+      }
+
       return new DataSyncMongoDBDataProvider(model, db);
     } else {
       return new MongoDBDataProvider(model, db);

--- a/packages/graphback-datasync/src/providers/createDataSyncMongoDbProvider.ts
+++ b/packages/graphback-datasync/src/providers/createDataSyncMongoDbProvider.ts
@@ -28,7 +28,7 @@ export function createDataSyncMongoDbProvider(db: Db): (...args: any[]) => Graph
  * @param {Db} db - MongoDB Db object
  * @param {DataSyncModelConfigMap} datasyncConfigMap - Object for configuring conflicts for individual models
  */
-export function createDataSyncConflictProviderCreator(db: Db, datasyncConfigMap: DataSyncModelConfigMap = {}) : (...args: any[]) => GraphbackDataProvider {
+export function createDataSyncConflictProviderCreator(db: Db, datasyncConfigMap: DataSyncModelConfigMap = {}) : (model: ModelDefinition) => GraphbackDataProvider {
   return (model: ModelDefinition): GraphbackDataProvider => {
     if (isDataSyncModel(model)) {
       const dataSyncModelConfig = datasyncConfigMap[model.graphqlType.name];

--- a/packages/graphback-datasync/src/providers/createDataSyncMongoDbProvider.ts
+++ b/packages/graphback-datasync/src/providers/createDataSyncMongoDbProvider.ts
@@ -1,7 +1,7 @@
 import { Db } from 'mongodb';
 import { ModelDefinition, GraphbackDataProvider } from '@graphback/core';
 import { MongoDBDataProvider } from "@graphback/runtime-mongo"
-import { isDataSyncModel, DataSyncModelConflictConfig } from '../util';
+import { isDataSyncModel, DataSyncModelConfigMap } from '../util';
 import { DataSyncMongoDBDataProvider } from './DatasyncMongoDBDataProvider';
 import { DataSyncConflictMongoDBDataProvider } from "./DataSyncConflictProvider";
 
@@ -20,7 +20,15 @@ export function createDataSyncMongoDbProvider(db: Db): (...args: any[]) => Graph
   }
 }
 
-export function createDataSyncConflictProviderCreator(db: Db, datasyncConfigMap: { [modelName: string]: DataSyncModelConflictConfig } = {}) : (...args: any[]) => GraphbackDataProvider {
+
+/**
+ * Creates a new Data Synchronization data provider creator for MongoDB with
+ * optionally specified per-model conflict configuration
+ * 
+ * @param {Db} db - MongoDB Db object
+ * @param {DataSyncModelConfigMap} datasyncConfigMap - Object for configuring conflicts for individual models
+ */
+export function createDataSyncConflictProviderCreator(db: Db, datasyncConfigMap: DataSyncModelConfigMap = {}) : (...args: any[]) => GraphbackDataProvider {
   return (model: ModelDefinition): GraphbackDataProvider => {
     if (isDataSyncModel(model)) {
       const dataSyncModelConfig = datasyncConfigMap[model.graphqlType.name];

--- a/packages/graphback-datasync/src/providers/index.ts
+++ b/packages/graphback-datasync/src/providers/index.ts
@@ -1,3 +1,4 @@
 export * from "./DataSyncProvider";
 export * from './DatasyncMongoDBDataProvider';
 export * from './createDataSyncMongoDbProvider';
+export * from './DataSyncConflictProvider';

--- a/packages/graphback-datasync/src/services/createDataSyncService.ts
+++ b/packages/graphback-datasync/src/services/createDataSyncService.ts
@@ -1,5 +1,5 @@
 import { ModelDefinition, CRUDService, CRUDServiceConfig, GraphbackCRUDService, GraphbackDataProvider } from '@graphback/core';
-import { PubSubEngine } from 'graphql-subscriptions';
+import { PubSubEngine, PubSub } from 'graphql-subscriptions';
 import { isDataSyncModel } from '../util';
 import { DataSyncProvider } from '../providers';
 import { DataSyncCRUDService } from './DataSyncCRUDService';
@@ -15,10 +15,11 @@ export interface CreateDataSyncCRUDServiceOptions {
  *
  * @param config
  */
-export function createDataSyncCRUDService(config: CreateDataSyncCRUDServiceOptions) {
+export function createDataSyncCRUDService(config?: CreateDataSyncCRUDServiceOptions) {
   return (model: ModelDefinition, dataProvider: GraphbackDataProvider): GraphbackCRUDService => {
 
     const serviceConfig: CRUDServiceConfig = {
+      pubSub: new PubSub(),
       ...config,
       crudOptions: model.crudOptions
     }

--- a/packages/graphback-datasync/src/util.ts
+++ b/packages/graphback-datasync/src/util.ts
@@ -74,15 +74,8 @@ export const ServerSideWins: ConflictResolutionStrategy = {
     return resolved
   },
   resolveDelete(conflict: ConflictMetadata): any {
-    const { serverData } = conflict;
 
-    if (serverData[DataSyncFieldNames.deleted] === true) {
-      throw new ConflictError(conflict);
-    }
-
-    const resolved = serverData;
-
-    return resolved
+    throw new ConflictError(conflict);
   }
 }
 

--- a/packages/graphback-datasync/src/util.ts
+++ b/packages/graphback-datasync/src/util.ts
@@ -1,7 +1,6 @@
 import { ModelDefinition, GraphbackCRUDService, GraphbackOperationType } from '@graphback/core';
 import { parseMetadata } from 'graphql-metadata';
 import { DataSyncCRUDService } from "./services";
-import { MongoDeltaHelper } from './deltaHelper';
 
 export function isDataSyncModel(model: ModelDefinition): boolean {
   return !!(parseMetadata('datasync', model.graphqlType))
@@ -51,6 +50,10 @@ export const DataSyncFieldNames = {
 export interface DataSyncModelConflictConfig {
   enabled: boolean
   conflictResolution?: ConflictResolutionStrategy
+}
+
+export interface DataSyncModelConfigMap {
+  [modelName: string]: DataSyncModelConflictConfig
 }
 
 export interface ConflictResolutionStrategy {

--- a/packages/graphback-datasync/src/util.ts
+++ b/packages/graphback-datasync/src/util.ts
@@ -94,9 +94,13 @@ export const ClientSideWins: ConflictResolutionStrategy = {
   resolveDelete(conflict: ConflictMetadata): any {
     const { serverData, clientData } = conflict;
 
-    if (serverData[DataSyncFieldNames.deleted] === true || clientData[DataSyncFieldNames.deleted] === true) {
+    if (serverData[DataSyncFieldNames.deleted] === true) {
       throw new ConflictError(conflict);
     }
+
+    const resolved = Object.assign(serverData, { [DataSyncFieldNames.deleted]: true });
+
+    return resolved
   }
 }
 

--- a/packages/graphback-datasync/tests/DataSyncConflictProviderTest.ts
+++ b/packages/graphback-datasync/tests/DataSyncConflictProviderTest.ts
@@ -4,7 +4,7 @@ import { MongoClient, Db } from 'mongodb';
 import { buildSchema } from 'graphql';
 import { GraphbackCoreMetadata } from '@graphback/core';
 import { SchemaCRUDPlugin } from "@graphback/codegen-schema";
-import { createDataSyncConflictProviderCreator, DataSyncPlugin, ConflictError, DataSyncFieldNames, DataSyncModelConfigMap, DataSyncProvider } from '../src';
+import { createDataSyncConflictProviderCreator, DataSyncPlugin, ConflictError, DataSyncFieldNames, DataSyncModelConfigMap, DataSyncProvider, ServerSideWins } from '../src';
 
 export interface Context {
   providers: { [modelname: string]: DataSyncProvider };
@@ -144,6 +144,98 @@ describe('Client Side wins Conflict resolution', () => {
 
   it ('throw error on deletes if conflict occurs', async () => {
     context = await createTestingContext(postSchema, { conflictConfigMap: { Post: { enabled: true } } });
+
+    const { Post } = context.providers;
+
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+
+    const updatedTitle = "Post 1 v2";
+    await Post.update({ _id, title: updatedTitle,  [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.deleted]}}})
+
+    await expect(Post.delete({ _id, [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: fields}}})).rejects.toThrowError(ConflictError);
+  });
+});
+
+describe('Server Side wins Conflict resolution', () => {
+  let context: Context;
+  afterEach(async () => context.server.stop());
+  const fields = ["_id", "title"];
+  const postSchema = `
+  """
+  @model
+  @datasync
+  """
+  type Post {
+    _id: GraphbackObjectID!
+    title: String!
+    content: String
+  }
+
+  scalar GraphbackObjectID
+  `;
+
+  it ('updates successfully when correct version passed', async () => {
+    context = await createTestingContext(postSchema, { conflictConfigMap: { Post: { enabled: true, conflictResolution: ServerSideWins } } });
+
+    const { Post } = context.providers;
+
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+
+    const updateTitle = "Post 1 v2";
+    const { title, [DataSyncFieldNames.version]: updatedVersion } = await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.version] }}})
+
+    expect(title).toEqual(updateTitle);
+    expect(updatedVersion).toEqual(version + 1);
+  });
+
+  it ('server data wins when conflict occurs', async () => {
+    context = await createTestingContext(postSchema, { conflictConfigMap: { Post: { enabled: true, conflictResolution: ServerSideWins } } });
+
+    const { Post } = context.providers;
+
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+
+    const updateTitle = "Post 1 v2";
+    await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}})
+
+    const finalUpdateTitle = "Post 1 v3";
+    const updatedPost = await Post.update({ _id, title: finalUpdateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}});
+
+    expect(updatedPost.title).toEqual(updateTitle);
+  });
+
+  it('throws error on update when server-side deleted', async () => {
+    context = await createTestingContext(postSchema, { conflictConfigMap: { Post: { enabled: true, conflictResolution: ServerSideWins } } });
+
+    const { Post } = context.providers;
+
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+
+    await Post.delete({ _id, [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: fields}}});
+
+    const updatedTitle = "Post 1 v2";
+    await expect(Post.update({ _id, title: updatedTitle,  [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.deleted]}}})).rejects.toThrowError(ConflictError);
+  });
+
+  it ('merges changes when no conflict', async () => {
+    context = await createTestingContext(postSchema, { conflictConfigMap: { Post: { enabled: true, conflictResolution: ServerSideWins } } });
+
+    const { Post } = context.providers;
+
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+
+    const updatedContent = "Post 1 content v2";
+    await Post.update({ _id, content: updatedContent, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}})
+
+    const updateTitle = "Post 1 v2";
+    const updatedPost = await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}});
+
+    expect(updatedPost.title).toEqual(updateTitle);
+    expect(updatedPost.content).toEqual(updatedContent);
+  });
+
+  it ('throw error on deletes if conflict occurs', async () => {
+    context = await createTestingContext(postSchema, { conflictConfigMap: { Post: { enabled: true, conflictResolution: ServerSideWins } } });
 
     const { Post } = context.providers;
 

--- a/packages/graphback-datasync/tests/DataSyncConflictProviderTest.ts
+++ b/packages/graphback-datasync/tests/DataSyncConflictProviderTest.ts
@@ -1,0 +1,157 @@
+/* eslint-disable max-lines */
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoClient, Db } from 'mongodb';
+import { buildSchema } from 'graphql';
+import { GraphbackCoreMetadata } from '@graphback/core';
+import { SchemaCRUDPlugin } from "@graphback/codegen-schema";
+import { createDataSyncConflictProviderCreator, DataSyncPlugin, ConflictError, DataSyncFieldNames, DataSyncModelConfigMap, DataSyncProvider } from '../src';
+
+export interface Context {
+  providers: { [modelname: string]: DataSyncProvider };
+  server: MongoMemoryServer,
+  db: Db
+}
+
+export async function createTestingContext(schemaStr: string, config?: { seedData?: { [collection: string]: any[] }, conflictConfigMap?: DataSyncModelConfigMap }): Promise<Context> {
+  // Setup graphback
+  const schema = buildSchema(schemaStr);
+
+  const server = new MongoMemoryServer();
+  const client = new MongoClient(await server.getConnectionString(), { useUnifiedTopology: true });
+  await client.connect();
+  const db = client.db('test');
+
+  const defautConfig = {
+    "create": true,
+    "update": true,
+    "findOne": true,
+    "find": true,
+    "delete": true,
+    "subCreate": true,
+    "subUpdate": true,
+    "subDelete": true
+  }
+
+  const schemaGenerator = new SchemaCRUDPlugin();
+  const DataSyncGenerator = new DataSyncPlugin({ modelConfigMap: config?.conflictConfigMap || {}});
+  const metadata = new GraphbackCoreMetadata({
+    crudMethods: defautConfig
+  }, schema)
+  metadata.setSchema(schemaGenerator.transformSchema(metadata));
+  metadata.setSchema(DataSyncGenerator.transformSchema(metadata));
+
+  const createProvider = createDataSyncConflictProviderCreator(db, config?.conflictConfigMap);
+
+  const providers: { [name: string]: DataSyncProvider } = {}
+  const models = metadata.getModelDefinitions();
+  for (const model of models) {
+    providers[model.graphqlType.name] = createProvider(model) as DataSyncProvider;
+  }
+
+  // if seed data is supplied, insert it into collections
+  if (config?.seedData) {
+    const collectionNames = Object.keys(config.seedData);
+    for (const collectionName of collectionNames) {
+      for (const element of config.seedData[collectionName]) {
+        await providers[collectionName].create(element, {graphback: {services: {}, options: { selectedFields: ["_id"]}}});
+      }
+    };
+  }
+
+  return { server, providers, db }
+}
+
+
+describe('Client Side wins Conflict resolution', () => {
+  let context: Context;
+  afterEach(async () => context.server.stop());
+  const fields = ["_id", "title"];
+  const postSchema = `
+  """
+  @model
+  @datasync
+  """
+  type Post {
+    _id: GraphbackObjectID!
+    title: String!
+    content: String
+  }
+
+  scalar GraphbackObjectID
+  `;
+
+  it ('updates successfully when correct version passed', async () => {
+    context = await createTestingContext(postSchema, { conflictConfigMap: { Post: { enabled: true } } });
+
+    const { Post } = context.providers;
+
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+
+    const updateTitle = "Post 1 v2";
+    const { title, [DataSyncFieldNames.version]: updatedVersion } = await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.version] }}})
+
+    expect(title).toEqual(updateTitle);
+    expect(updatedVersion).toEqual(version + 1);
+  });
+
+  it ('client data wins when conflict occurs', async () => {
+    context = await createTestingContext(postSchema, { conflictConfigMap: { Post: { enabled: true } } });
+
+    const { Post } = context.providers;
+
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+
+    await Post.update({ _id, title: "Post 1 v2", [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}})
+
+    const finalUpdateTitle = "Post 1 v3";
+    const updatedPost = await Post.update({ _id, title: finalUpdateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}});
+
+    expect(updatedPost.title).toEqual(finalUpdateTitle);
+  });
+
+  it('restore document on update when server-side deleted', async () => {
+    context = await createTestingContext(postSchema, { conflictConfigMap: { Post: { enabled: true } } });
+
+    const { Post } = context.providers;
+
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+
+    await Post.delete({ _id, [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: fields}}});
+
+    const updatedTitle = "Post 1 v2";
+    const updatedPost = await Post.update({ _id, title: updatedTitle,  [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.deleted]}}})
+
+    expect(updatedPost.title).toEqual(updatedTitle);
+    expect(updatedPost[DataSyncFieldNames.deleted]).toEqual(false);
+  });
+
+  it ('merges changes when no conflict', async () => {
+    context = await createTestingContext(postSchema, { conflictConfigMap: { Post: { enabled: true } } });
+
+    const { Post } = context.providers;
+
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+
+    const updatedContent = "Post 1 content v2";
+    await Post.update({ _id, content: updatedContent, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}})
+
+    const updateTitle = "Post 1 v2";
+    const updatedPost = await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}});
+
+    expect(updatedPost.title).toEqual(updateTitle);
+    expect(updatedPost.content).toEqual(updatedContent);
+  });
+
+  it ('throw error on deletes if conflict occurs', async () => {
+    context = await createTestingContext(postSchema, { conflictConfigMap: { Post: { enabled: true } } });
+
+    const { Post } = context.providers;
+
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+
+    const updatedTitle = "Post 1 v2";
+    await Post.update({ _id, title: updatedTitle,  [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.deleted]}}})
+
+    await expect(Post.delete({ _id, [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: fields}}})).rejects.toThrowError(ConflictError);
+  });
+});

--- a/packages/graphback-datasync/tests/DataSyncPluginTest.ts
+++ b/packages/graphback-datasync/tests/DataSyncPluginTest.ts
@@ -65,3 +65,39 @@ it('uses existing GraphbackTimestamp scalars', async () => {
   const schema = datasync.transformSchema(metadata)
   expect(printSchema(schema)).toMatchSnapshot();
 });
+
+it('adds version when conflicts are enabled', async () => {
+  const defautConfig = {
+    "create": true,
+    "update": true,
+    "findOne": true,
+    "find": true,
+    "delete": true,
+    "subCreate": true,
+    "subUpdate": true,
+    "subDelete": true
+  }
+
+  const schemaPlugin =  new SchemaCRUDPlugin();
+  const datasync = new DataSyncPlugin({ modelConfigMap: { Comment: { enabled: true } } })
+  const metadata = new GraphbackCoreMetadata({
+    crudMethods: defautConfig
+  }, buildSchema(
+    `
+    """
+    @model
+    @datasync
+    """
+    type Comment {
+      id: ID!
+      title: String!
+      description: String!
+    }
+
+    scalar GraphbackTimestamp
+    `
+  ))
+  metadata.setSchema(schemaPlugin.transformSchema(metadata))
+  const schema = datasync.transformSchema(metadata)
+  expect(printSchema(schema)).toMatchSnapshot();
+});

--- a/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
+++ b/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
@@ -265,9 +265,12 @@ type CommentResultList {
 }
 
 input CommentSubscriptionFilter {
-  id: ID
-  title: String
-  description: String
+  and: [CommentSubscriptionFilter!]
+  or: [CommentSubscriptionFilter!]
+  not: CommentSubscriptionFilter
+  id: IDInput
+  title: StringInput
+  description: StringInput
 }
 
 input CreateCommentInput {

--- a/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
+++ b/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
@@ -216,6 +216,132 @@ type Subscription {
 "
 `;
 
+exports[`adds version when conflicts are enabled 1`] = `
+"\\"\\"\\"
+@model
+@datasync
+\\"\\"\\"
+type Comment {
+  id: ID!
+  title: String!
+  description: String!
+  _lastUpdatedAt: GraphbackTimestamp
+  _version: Int
+}
+
+type CommentDelta {
+  id: ID!
+  title: String!
+  description: String!
+  _lastUpdatedAt: GraphbackTimestamp
+  _version: Int
+  _deleted: Boolean
+}
+
+type CommentDeltaList {
+  items: [CommentDelta]!
+  lastSync: GraphbackTimestamp!
+  limit: Int
+}
+
+input CommentFilter {
+  id: IDInput
+  title: StringInput
+  description: StringInput
+  and: [CommentFilter!]
+  or: [CommentFilter!]
+  not: CommentFilter
+}
+
+type CommentResultList {
+  items: [Comment]!
+  offset: Int
+  limit: Int
+  count: Int
+}
+
+input CommentSubscriptionFilter {
+  id: ID
+  title: String
+  description: String
+}
+
+input CreateCommentInput {
+  id: ID
+  title: String!
+  description: String!
+}
+
+\\"\\"\\"
+The javascript \`Date\` as integer. Type represents date and time as number of milliseconds from start of UNIX epoch.
+\\"\\"\\"
+scalar GraphbackTimestamp
+
+input IDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  in: [ID!]
+}
+
+input MutateCommentInput {
+  id: ID!
+  title: String
+  description: String
+  _version: Int!
+}
+
+type Mutation {
+  createComment(input: CreateCommentInput!): Comment
+  updateComment(input: MutateCommentInput!): Comment
+  deleteComment(input: MutateCommentInput!): Comment
+}
+
+input OrderByInput {
+  field: String!
+  order: SortDirectionEnum = ASC
+}
+
+input PageRequest {
+  limit: Int
+  offset: Int
+}
+
+type Query {
+  getComment(id: ID!): Comment
+  findComments(filter: CommentFilter, page: PageRequest, orderBy: OrderByInput): CommentResultList!
+  syncComments(lastSync: GraphbackTimestamp!, filter: CommentFilter, limit: Int): CommentDeltaList!
+}
+
+enum SortDirectionEnum {
+  DESC
+  ASC
+}
+
+input StringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  in: [String!]
+  contains: String
+  startsWith: String
+  endsWith: String
+}
+
+type Subscription {
+  newComment(filter: CommentSubscriptionFilter): Comment!
+  updatedComment(filter: CommentSubscriptionFilter): Comment!
+  deletedComment(filter: CommentSubscriptionFilter): Comment!
+}
+"
+`;
+
 exports[`uses existing GraphbackTimestamp scalars 1`] = `
 "\\"\\"\\"
 @model

--- a/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
+++ b/packages/graphback-datasync/tests/__snapshots__/DataSyncPluginTest.ts.snap
@@ -225,6 +225,8 @@ type Comment {
   id: ID!
   title: String!
   description: String!
+
+  \\"\\"\\"@index(name: 'Datasync_lastUpdatedAt')\\"\\"\\"
   _lastUpdatedAt: GraphbackTimestamp
   _version: Int
 }
@@ -233,6 +235,8 @@ type CommentDelta {
   id: ID!
   title: String!
   description: String!
+
+  \\"\\"\\"@index(name: 'Datasync_lastUpdatedAt')\\"\\"\\"
   _lastUpdatedAt: GraphbackTimestamp
   _version: Int
   _deleted: Boolean

--- a/templates/ts-apollo-mongodb-datasync-backend/src/index.ts
+++ b/templates/ts-apollo-mongodb-datasync-backend/src/index.ts
@@ -6,7 +6,7 @@ import { ApolloServer } from "apollo-server-express"
 import { buildGraphbackAPI } from 'graphback'
 import { loadSchemaSync } from '@graphql-tools/load'
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader'
-import { createDataSyncMongoDbProvider, createDataSyncCRUDService, DataSyncPlugin } from '@graphback/datasync'
+import { createDataSyncAPI, ServerSideConflictResolution } from '@graphback/datasync'
 // eslint-disable-next-line @typescript-eslint/tslint/config
 import cors from "cors"
 // eslint-disable-next-line @typescript-eslint/tslint/config
@@ -27,13 +27,7 @@ async function start() {
 
   const db = await connectDB()
 
-  const { typeDefs, resolvers, contextCreator } = buildGraphbackAPI(modelDefs, {
-    dataProviderCreator: createDataSyncMongoDbProvider(db),
-    serviceCreator: createDataSyncCRUDService({ pubSub: new PubSub() }),
-    plugins: [
-      new DataSyncPlugin()
-    ]
-  });
+  const { typeDefs, resolvers, contextCreator } = createDataSyncAPI(modelDefs, db, { Comment: { enabled: true, conflictResolution: ServerSideConflictResolution }});
 
   const apolloServer = new ApolloServer({
     typeDefs,

--- a/templates/ts-apollo-mongodb-datasync-backend/src/index.ts
+++ b/templates/ts-apollo-mongodb-datasync-backend/src/index.ts
@@ -3,10 +3,9 @@ require('dotenv').config()
 import path from 'path'
 import http from "http"
 import { ApolloServer } from "apollo-server-express"
-import { buildGraphbackAPI } from 'graphback'
 import { loadSchemaSync } from '@graphql-tools/load'
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader'
-import { createDataSyncAPI, ServerSideConflictResolution } from '@graphback/datasync'
+import { createDataSyncAPI } from '@graphback/datasync'
 // eslint-disable-next-line @typescript-eslint/tslint/config
 import cors from "cors"
 // eslint-disable-next-line @typescript-eslint/tslint/config
@@ -27,7 +26,7 @@ async function start() {
 
   const db = await connectDB()
 
-  const { typeDefs, resolvers, contextCreator } = createDataSyncAPI(modelDefs, db, { Comment: { enabled: true, conflictResolution: ServerSideConflictResolution }});
+  const { typeDefs, resolvers, contextCreator } = createDataSyncAPI(modelDefs, { db, dataSyncConflictMap:{ Comment: { enabled: true }}});
 
   const apolloServer = new ApolloServer({
     typeDefs,


### PR DESCRIPTION
Rather hopeful about this one :crossed_fingers: 

```typescript
const { typeDefs, resolvers, contextCreator } = createDataSync(modelDefs, db, { Comment: { enabled: true, conflictResolution: serverSideConflictResolution }});
```

## TODOS

- [x] Agreement on if this is how it should be
- [ ] Delete Conflicts?
- [ ] Tests
- [ ] Docs