### PR TITLE
fix(core): avoid stringfying "null" values as `"null"`

### DIFF
--- a/packages/graphback-core/src/db/dataMapper.ts
+++ b/packages/graphback-core/src/db/dataMapper.ts
@@ -35,7 +35,7 @@ export const getDatabaseArguments = (modelMap: ModelTableMap, data?: any): Table
     transFormedData = {};
     for (const key of keys) {
       const value: any = data[key];
-      transFormedData[key] = typeof value === 'object'? JSON.stringify(value) : value;
+      transFormedData[key] = value && typeof value === 'object' ? JSON.stringify(value) : value;
     }
   };
 

--- a/packages/graphback-core/tests/dataMapperTest.ts
+++ b/packages/graphback-core/tests/dataMapperTest.ts
@@ -57,3 +57,37 @@ test('should map to default custom ID field from annotations', () => {
 
     expect(args.idField).toEqual({ name: 'email', value: 'johndoe@gmail.com' })
 });
+
+test('should stringify object values', () => {
+  const schema = buildSchema(`
+  """
+  @model
+  """
+  type User {
+    id: ID!
+    name: String
+    profile: Profile
+  }
+
+  type Profile {
+    email: String
+  }
+
+  `);
+
+  const userModel = schema.getType("User") as GraphQLObjectType;
+
+  const modelTableMap = buildModelTableMap(userModel);
+
+  const data = {
+      id: 1,
+      profile: {
+        email: 'johndoe@gmail.com',
+      },
+      name: null
+  }
+
+  const { data: mappedData } = getDatabaseArguments(modelTableMap, data);
+
+  expect(mappedData).toEqual({ id: 1, name: null, profile: JSON.stringify(data.profile) })
+});

--- a/packages/graphback-runtime-knex/tests/data/KnexDbDataProviderTest.ts
+++ b/packages/graphback-runtime-knex/tests/data/KnexDbDataProviderTest.ts
@@ -4,10 +4,9 @@
 import { unlinkSync, existsSync } from 'fs';
 import { buildSchema } from 'graphql';
 import * as Knex from 'knex';
-import { filterModelTypes, GraphbackDataProvider, GraphbackCoreMetadata } from '@graphback/core';
+import { GraphbackDataProvider, GraphbackCoreMetadata } from '@graphback/core';
 import { SQLiteKnexDBDataProvider } from '../../src/SQLiteKnexDBDataProvider';
 import { migrateDB, removeNonSafeOperationsFilter } from '../../../graphql-migrations/src';
-import { SchemaCRUDPlugin } from '@graphback/codegen-schema';
 
 const dbPath = `${__dirname}/db.sqlite`;
 
@@ -96,12 +95,16 @@ type Todo {
  text: String
 }`)
 
-  const todo = await providers.Todo.create({
-    text: 'create a todo',
-  }, { graphback: { services: {}, options: { selectedFields: fields } } });
+  const context = { graphback: { services: {}, options: { selectedFields: fields } } };
 
-  expect(todo.id === 4);
-  expect(todo.text === 'create a todo');
+  const fullTodo = await providers.Todo.create({ text: 'create a todo' }, context);
+  expect(fullTodo.id).toEqual(1);
+  expect(fullTodo.text).toEqual('create a todo');
+
+  const todoWithNullText = await providers.Todo.create({}, context);
+
+  expect(todoWithNullText.id).toEqual(2);
+  expect(todoWithNullText.text).toBeNull();
 });
 
 test('update Todo', async () => {


### PR DESCRIPTION
A null value type is an object, this was the transformed to "null" by
the fixed logic resulting in errors for non string columns in database.

Fixes https://github.com/aerogear/graphback/issues/1837