### PR TITLE
subscription filtering v2

### DIFF
--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -2,7 +2,7 @@
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import * as DataLoader from "dataloader";
-import { getFieldName, metadataMap, printSchemaWithDirectives, getSubscriptionName, GraphbackCoreMetadata, GraphbackOperationType, GraphbackPlugin, ModelDefinition, addRelationshipFields, extendRelationshipFields, extendOneToManyFieldArguments, getInputTypeName, FieldRelationshipMetadata, GraphbackContext, getSelectedFieldsFromResolverInfo, isModelType, getPrimaryKey, isSpecifiedGraphbackJSONScalarType, graphbackScalarsTypes, GraphbackTimestamp } from '@graphback/core'
+import { getFieldName, metadataMap, printSchemaWithDirectives, getSubscriptionName, GraphbackCoreMetadata, GraphbackOperationType, GraphbackPlugin, ModelDefinition, addRelationshipFields, extendRelationshipFields, extendOneToManyFieldArguments, getInputTypeName, FieldRelationshipMetadata, GraphbackContext, getSelectedFieldsFromResolverInfo, isModelType, getPrimaryKey, isSpecifiedGraphbackJSONScalarType, graphbackScalarsTypes, GraphbackTimestamp, isSpecifiedGraphbackScalarType, FILTER_SUPPORTED_SCALARS } from '@graphback/core'
 import { GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLInt, GraphQLFloat, isScalarType, isSpecifiedScalarType, GraphQLResolveInfo, isObjectType, GraphQLField, GraphQLInputObjectType, GraphQLNamedType, GraphQLScalarType } from 'graphql';
 import { SchemaComposer, NamedTypeComposer } from 'graphql-compose';
 import { IResolvers, IFieldResolver } from '@graphql-tools/utils'
@@ -766,10 +766,8 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
 
     schemaComposer.forEach((tc: NamedTypeComposer<any>) => {
       const namedType = tc.getType();
-      if (isScalarType(namedType) && !isSpecifiedScalarType(namedType) && !isSpecifiedGraphbackJSONScalarType(namedType)) {
+      if (isScalarType(namedType) && !isSpecifiedScalarType(namedType) && FILTER_SUPPORTED_SCALARS.includes(namedType.name)) {
         schemaComposer.add(createInputTypeForScalar(namedType));
-
-        return;
       }
 
       const isRootType = ['Query', 'Subscription', 'Mutation'].includes(namedType.name)

--- a/packages/graphback-codegen-schema/tests/GraphQLSchemaCreatorTest.ts
+++ b/packages/graphback-codegen-schema/tests/GraphQLSchemaCreatorTest.ts
@@ -276,5 +276,23 @@ type Comment {
   expect(note.astNode?.directives).toHaveLength(1)
   expect(note.astNode?.directives[0].name.value).toBe('test')
 
-  expect(printSchemaWithDirectives(schema)).toMatchSnapshot()
+  expect(printSchemaWithDirectives(schema)).toMatchSnapshot();
+})
+
+test('schema does not generate filter input for unknown custom scalar', () => {
+  const modelAST = `
+scalar MyCustomScalar
+"""
+@model
+"""
+type TypeWithCustomScalar {
+  id: ID!
+  customField: MyCustomScalar
+}`
+
+  const schemaGenerator = new SchemaCRUDPlugin();
+  const metadata = new GraphbackCoreMetadata({ crudMethods: {} }, buildSchema(modelAST));
+  const schema = schemaGenerator.transformSchema(metadata);
+
+  expect(schema.getType('MyCustomScalarInput')).toBeUndefined()
 })

--- a/packages/graphback-codegen-schema/tests/mock.graphql
+++ b/packages/graphback-codegen-schema/tests/mock.graphql
@@ -67,7 +67,7 @@ See issue https://github.com/aerogear/graphback/issues/1299
   subDelete: false
 )
 """
-type  Issue {
+type Issue {
   id: ID!
   category: IssueCategory
   createdAt: DateTime,

--- a/packages/graphback-core/src/runtime/QueryFilter.ts
+++ b/packages/graphback-core/src/runtime/QueryFilter.ts
@@ -1,7 +1,5 @@
-
-
 /**
- * Filter mapping for scalars that exit
+ * Filter mapping for scalars that exist 
  */
 export type Scalars = {
   ID: string;
@@ -9,7 +7,13 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  DateTime: any;
+  GraphbackJSON: any;
+  GraphbackJSONObject: { [key: string]: any };
+  GraphbackObjectID: string;
+  GraphbackTimestamp: number;
+  GraphbackTime: string;
+  GraphbackDate: Date;
+  GraphbackDateTime: Date;
 };
 
 export type Maybe<T> = T | null;
@@ -64,20 +68,66 @@ export type StringInput = {
   endsWith?: Maybe<Scalars['String']>;
 };
 
-export type DateTimeInput = {
-  ne?: Maybe<Scalars['DateTime']>;
-  eq?: Maybe<Scalars['DateTime']>;
-  le?: Maybe<Scalars['DateTime']>;
-  lt?: Maybe<Scalars['DateTime']>;
-  ge?: Maybe<Scalars['DateTime']>;
-  gt?: Maybe<Scalars['DateTime']>;
-  in?: Maybe<Scalars['DateTime'][]>;
-  between?: Maybe<Scalars['DateTime'][]>;
+export type GraphbackDateInput = {
+  ne?: Maybe<Scalars['GraphbackDate']>;
+  eq?: Maybe<Scalars['GraphbackDate']>;
+  le?: Maybe<Scalars['GraphbackDate']>;
+  lt?: Maybe<Scalars['GraphbackDate']>;
+  ge?: Maybe<Scalars['GraphbackDate']>;
+  gt?: Maybe<Scalars['GraphbackDate']>;
+  in?: Maybe<Scalars['GraphbackDate'][]>;
+  between?: Maybe<Scalars['GraphbackDate'][]>;
 };
+
+export type GraphbackDateTimeInput = {
+  ne?: Maybe<Scalars['GraphbackDateTime']>;
+  eq?: Maybe<Scalars['GraphbackDateTime']>;
+  le?: Maybe<Scalars['GraphbackDateTime']>;
+  lt?: Maybe<Scalars['GraphbackDateTime']>;
+  ge?: Maybe<Scalars['GraphbackDateTime']>;
+  gt?: Maybe<Scalars['GraphbackDateTime']>;
+  in?: Maybe<Scalars['GraphbackDateTime'][]>;
+  between?: Maybe<Scalars['GraphbackDateTime'][]>;
+};
+
+export type GraphbackObjectIdInput = {
+  ne?: Maybe<Scalars['GraphbackObjectID']>;
+  eq?: Maybe<Scalars['GraphbackObjectID']>;
+  le?: Maybe<Scalars['GraphbackObjectID']>;
+  lt?: Maybe<Scalars['GraphbackObjectID']>;
+  ge?: Maybe<Scalars['GraphbackObjectID']>;
+  gt?: Maybe<Scalars['GraphbackObjectID']>;
+  in?: Maybe<Scalars['GraphbackObjectID'][]>;
+  between?: Maybe<Scalars['GraphbackObjectID'][]>;
+};
+
+export type GraphbackTimeInput = {
+  ne?: Maybe<Scalars['GraphbackTime']>;
+  eq?: Maybe<Scalars['GraphbackTime']>;
+  le?: Maybe<Scalars['GraphbackTime']>;
+  lt?: Maybe<Scalars['GraphbackTime']>;
+  ge?: Maybe<Scalars['GraphbackTime']>;
+  gt?: Maybe<Scalars['GraphbackTime']>;
+  in?: Maybe<Scalars['GraphbackTime'][]>;
+  between?: Maybe<Scalars['GraphbackTime'][]>;
+};
+
+export type GraphbackTimestampInput = {
+  ne?: Maybe<Scalars['GraphbackTimestamp']>;
+  eq?: Maybe<Scalars['GraphbackTimestamp']>;
+  le?: Maybe<Scalars['GraphbackTimestamp']>;
+  lt?: Maybe<Scalars['GraphbackTimestamp']>;
+  ge?: Maybe<Scalars['GraphbackTimestamp']>;
+  gt?: Maybe<Scalars['GraphbackTimestamp']>;
+  in?: Maybe<Scalars['GraphbackTimestamp'][]>;
+  between?: Maybe<Scalars['GraphbackTimestamp'][]>;
+};
+
+type GraphbackScalar = GraphbackDateInput | GraphbackDateTimeInput | GraphbackObjectIdInput | GraphbackTimeInput | GraphbackTimestampInput;
 
 /**
  * Query filter used in Graphback services and data providers
  */
 export type QueryFilter<T = any> = {
-  [P in keyof T]?: any | Maybe<IdInput | BooleanInput | StringInput | FloatInput | IntInput | DateTimeInput>;
+  [P in keyof T]?: Maybe<IdInput | BooleanInput | StringInput | FloatInput | IntInput | GraphbackScalar | T | T[]>;
 };

--- a/packages/graphback-core/src/runtime/QueryFilter.ts
+++ b/packages/graphback-core/src/runtime/QueryFilter.ts
@@ -2,14 +2,12 @@ import { ObjectId } from 'mongodb'
 /**
  * Filter mapping for scalars that exist 
  */
-export type Scalars = {
+export type FilterableScalars = {
   ID: string;
   String: string;
   Boolean: boolean;
   Int: number;
   Float: number;
-  GraphbackJSON: any;
-  GraphbackJSONObject: { [key: string]: any };
   GraphbackObjectID: ObjectId | number | string;
   GraphbackTimestamp: number;
   GraphbackTime: string;
@@ -17,111 +15,129 @@ export type Scalars = {
   GraphbackDateTime: Date;
 };
 
+// Names of the scalars that support Graphback filter type generation
+export const FILTER_SUPPORTED_SCALARS = [
+  'ID',
+  'String',
+  'Boolean',
+  'Int',
+  'Float',
+  'GraphbackObjectID',
+  'GraphbackTimestamp',
+  'GraphbackTime',
+  'GraphbackDate',
+  'GraphbackDateTime',
+  'Timestamp',
+  'Time',
+  'Date',
+  'DateTime'
+];
+
 export type Maybe<T> = T | null;
 
 export type BooleanInput = {
-  ne?: Maybe<Scalars['Boolean']>;
-  eq?: Maybe<Scalars['Boolean']>;
+  ne?: Maybe<FilterableScalars['Boolean']>;
+  eq?: Maybe<FilterableScalars['Boolean']>;
 };
 
 export type FloatInput = {
-  ne?: Maybe<Scalars['Float']>;
-  eq?: Maybe<Scalars['Float']>;
-  le?: Maybe<Scalars['Float']>;
-  lt?: Maybe<Scalars['Float']>;
-  ge?: Maybe<Scalars['Float']>;
-  gt?: Maybe<Scalars['Float']>;
-  in?: Maybe<Scalars['Float'][]>;
-  between?: Maybe<Scalars['Float'][]>;
+  ne?: Maybe<FilterableScalars['Float']>;
+  eq?: Maybe<FilterableScalars['Float']>;
+  le?: Maybe<FilterableScalars['Float']>;
+  lt?: Maybe<FilterableScalars['Float']>;
+  ge?: Maybe<FilterableScalars['Float']>;
+  gt?: Maybe<FilterableScalars['Float']>;
+  in?: Maybe<FilterableScalars['Float'][]>;
+  between?: Maybe<FilterableScalars['Float'][]>;
 };
 
 export type IdInput = {
-  ne?: Maybe<Scalars['ID']>;
-  eq?: Maybe<Scalars['ID']>;
-  le?: Maybe<Scalars['ID']>;
-  lt?: Maybe<Scalars['ID']>;
-  ge?: Maybe<Scalars['ID']>;
-  gt?: Maybe<Scalars['ID']>;
-  in?: Maybe<Scalars['ID'][]>;
+  ne?: Maybe<FilterableScalars['ID']>;
+  eq?: Maybe<FilterableScalars['ID']>;
+  le?: Maybe<FilterableScalars['ID']>;
+  lt?: Maybe<FilterableScalars['ID']>;
+  ge?: Maybe<FilterableScalars['ID']>;
+  gt?: Maybe<FilterableScalars['ID']>;
+  in?: Maybe<FilterableScalars['ID'][]>;
 };
 
 export type IntInput = {
-  ne?: Maybe<Scalars['Int']>;
-  eq?: Maybe<Scalars['Int']>;
-  le?: Maybe<Scalars['Int']>;
-  lt?: Maybe<Scalars['Int']>;
-  ge?: Maybe<Scalars['Int']>;
-  gt?: Maybe<Scalars['Int']>;
-  in?: Maybe<Scalars['Int']>;
-  between?: Maybe<Scalars['Int'][]>;
+  ne?: Maybe<FilterableScalars['Int']>;
+  eq?: Maybe<FilterableScalars['Int']>;
+  le?: Maybe<FilterableScalars['Int']>;
+  lt?: Maybe<FilterableScalars['Int']>;
+  ge?: Maybe<FilterableScalars['Int']>;
+  gt?: Maybe<FilterableScalars['Int']>;
+  in?: Maybe<FilterableScalars['Int']>;
+  between?: Maybe<FilterableScalars['Int'][]>;
 };
 
 export type StringInput = {
-  ne?: Maybe<Scalars['String']>;
-  eq?: Maybe<Scalars['String']>;
-  le?: Maybe<Scalars['String']>;
-  lt?: Maybe<Scalars['String']>;
-  ge?: Maybe<Scalars['String']>;
-  gt?: Maybe<Scalars['String']>;
-  in?: Maybe<Scalars['String'][]>;
-  contains?: Maybe<Scalars['String']>;
-  startsWith?: Maybe<Scalars['String']>;
-  endsWith?: Maybe<Scalars['String']>;
+  ne?: Maybe<FilterableScalars['String']>;
+  eq?: Maybe<FilterableScalars['String']>;
+  le?: Maybe<FilterableScalars['String']>;
+  lt?: Maybe<FilterableScalars['String']>;
+  ge?: Maybe<FilterableScalars['String']>;
+  gt?: Maybe<FilterableScalars['String']>;
+  in?: Maybe<FilterableScalars['String'][]>;
+  contains?: Maybe<FilterableScalars['String']>;
+  startsWith?: Maybe<FilterableScalars['String']>;
+  endsWith?: Maybe<FilterableScalars['String']>;
 };
 
 export type GraphbackDateInput = {
-  ne?: Maybe<Scalars['GraphbackDate']>;
-  eq?: Maybe<Scalars['GraphbackDate']>;
-  le?: Maybe<Scalars['GraphbackDate']>;
-  lt?: Maybe<Scalars['GraphbackDate']>;
-  ge?: Maybe<Scalars['GraphbackDate']>;
-  gt?: Maybe<Scalars['GraphbackDate']>;
-  in?: Maybe<Scalars['GraphbackDate'][]>;
-  between?: Maybe<Scalars['GraphbackDate'][]>;
+  ne?: Maybe<FilterableScalars['GraphbackDate']>;
+  eq?: Maybe<FilterableScalars['GraphbackDate']>;
+  le?: Maybe<FilterableScalars['GraphbackDate']>;
+  lt?: Maybe<FilterableScalars['GraphbackDate']>;
+  ge?: Maybe<FilterableScalars['GraphbackDate']>;
+  gt?: Maybe<FilterableScalars['GraphbackDate']>;
+  in?: Maybe<FilterableScalars['GraphbackDate'][]>;
+  between?: Maybe<FilterableScalars['GraphbackDate'][]>;
 };
 
 export type GraphbackDateTimeInput = {
-  ne?: Maybe<Scalars['GraphbackDateTime']>;
-  eq?: Maybe<Scalars['GraphbackDateTime']>;
-  le?: Maybe<Scalars['GraphbackDateTime']>;
-  lt?: Maybe<Scalars['GraphbackDateTime']>;
-  ge?: Maybe<Scalars['GraphbackDateTime']>;
-  gt?: Maybe<Scalars['GraphbackDateTime']>;
-  in?: Maybe<Scalars['GraphbackDateTime'][]>;
-  between?: Maybe<Scalars['GraphbackDateTime'][]>;
+  ne?: Maybe<FilterableScalars['GraphbackDateTime']>;
+  eq?: Maybe<FilterableScalars['GraphbackDateTime']>;
+  le?: Maybe<FilterableScalars['GraphbackDateTime']>;
+  lt?: Maybe<FilterableScalars['GraphbackDateTime']>;
+  ge?: Maybe<FilterableScalars['GraphbackDateTime']>;
+  gt?: Maybe<FilterableScalars['GraphbackDateTime']>;
+  in?: Maybe<FilterableScalars['GraphbackDateTime'][]>;
+  between?: Maybe<FilterableScalars['GraphbackDateTime'][]>;
 };
 
 export type GraphbackObjectIdInput = {
-  ne?: Maybe<Scalars['GraphbackObjectID']>;
-  eq?: Maybe<Scalars['GraphbackObjectID']>;
-  le?: Maybe<Scalars['GraphbackObjectID']>;
-  lt?: Maybe<Scalars['GraphbackObjectID']>;
-  ge?: Maybe<Scalars['GraphbackObjectID']>;
-  gt?: Maybe<Scalars['GraphbackObjectID']>;
-  in?: Maybe<Scalars['GraphbackObjectID'][]>;
-  between?: Maybe<Scalars['GraphbackObjectID'][]>;
+  ne?: Maybe<FilterableScalars['GraphbackObjectID']>;
+  eq?: Maybe<FilterableScalars['GraphbackObjectID']>;
+  le?: Maybe<FilterableScalars['GraphbackObjectID']>;
+  lt?: Maybe<FilterableScalars['GraphbackObjectID']>;
+  ge?: Maybe<FilterableScalars['GraphbackObjectID']>;
+  gt?: Maybe<FilterableScalars['GraphbackObjectID']>;
+  in?: Maybe<FilterableScalars['GraphbackObjectID'][]>;
+  between?: Maybe<FilterableScalars['GraphbackObjectID'][]>;
 };
 
 export type GraphbackTimeInput = {
-  ne?: Maybe<Scalars['GraphbackTime']>;
-  eq?: Maybe<Scalars['GraphbackTime']>;
-  le?: Maybe<Scalars['GraphbackTime']>;
-  lt?: Maybe<Scalars['GraphbackTime']>;
-  ge?: Maybe<Scalars['GraphbackTime']>;
-  gt?: Maybe<Scalars['GraphbackTime']>;
-  in?: Maybe<Scalars['GraphbackTime'][]>;
-  between?: Maybe<Scalars['GraphbackTime'][]>;
+  ne?: Maybe<FilterableScalars['GraphbackTime']>;
+  eq?: Maybe<FilterableScalars['GraphbackTime']>;
+  le?: Maybe<FilterableScalars['GraphbackTime']>;
+  lt?: Maybe<FilterableScalars['GraphbackTime']>;
+  ge?: Maybe<FilterableScalars['GraphbackTime']>;
+  gt?: Maybe<FilterableScalars['GraphbackTime']>;
+  in?: Maybe<FilterableScalars['GraphbackTime'][]>;
+  between?: Maybe<FilterableScalars['GraphbackTime'][]>;
 };
 
 export type GraphbackTimestampInput = {
-  ne?: Maybe<Scalars['GraphbackTimestamp']>;
-  eq?: Maybe<Scalars['GraphbackTimestamp']>;
-  le?: Maybe<Scalars['GraphbackTimestamp']>;
-  lt?: Maybe<Scalars['GraphbackTimestamp']>;
-  ge?: Maybe<Scalars['GraphbackTimestamp']>;
-  gt?: Maybe<Scalars['GraphbackTimestamp']>;
-  in?: Maybe<Scalars['GraphbackTimestamp'][]>;
-  between?: Maybe<Scalars['GraphbackTimestamp'][]>;
+  ne?: Maybe<FilterableScalars['GraphbackTimestamp']>;
+  eq?: Maybe<FilterableScalars['GraphbackTimestamp']>;
+  le?: Maybe<FilterableScalars['GraphbackTimestamp']>;
+  lt?: Maybe<FilterableScalars['GraphbackTimestamp']>;
+  ge?: Maybe<FilterableScalars['GraphbackTimestamp']>;
+  gt?: Maybe<FilterableScalars['GraphbackTimestamp']>;
+  in?: Maybe<FilterableScalars['GraphbackTimestamp'][]>;
+  between?: Maybe<FilterableScalars['GraphbackTimestamp'][]>;
 };
 
 type GraphbackScalar = GraphbackDateInput | GraphbackDateTimeInput | GraphbackObjectIdInput | GraphbackTimeInput | GraphbackTimestampInput;

--- a/packages/graphback-core/src/runtime/QueryFilter.ts
+++ b/packages/graphback-core/src/runtime/QueryFilter.ts
@@ -1,3 +1,4 @@
+import { ObjectId } from 'mongodb'
 /**
  * Filter mapping for scalars that exist 
  */
@@ -9,7 +10,7 @@ export type Scalars = {
   Float: number;
   GraphbackJSON: any;
   GraphbackJSONObject: { [key: string]: any };
-  GraphbackObjectID: string;
+  GraphbackObjectID: ObjectId | number | string;
   GraphbackTimestamp: number;
   GraphbackTime: string;
   GraphbackDate: Date;
@@ -129,5 +130,5 @@ type GraphbackScalar = GraphbackDateInput | GraphbackDateTimeInput | GraphbackOb
  * Query filter used in Graphback services and data providers
  */
 export type QueryFilter<T = any> = {
-  [P in keyof T]?: Maybe<IdInput | BooleanInput | StringInput | FloatInput | IntInput | GraphbackScalar | T | T[]>;
+  [P in keyof T | 'not' | 'and' | 'or']?: Maybe<IdInput | BooleanInput | StringInput | FloatInput | IntInput | GraphbackScalar | T | T[]>;
 };

--- a/packages/graphback-core/src/runtime/createInMemoryFilterPredicate.ts
+++ b/packages/graphback-core/src/runtime/createInMemoryFilterPredicate.ts
@@ -1,3 +1,4 @@
+import { ObjectID } from 'mongodb';
 import { convertType, isDateObject } from '../utils/convertType';
 import { QueryFilter } from './QueryFilter';
 
@@ -20,38 +21,53 @@ interface IPredicate {
 
 const predicateMap: IPredicate = {
   eq: (filterValue: InputType) => (fieldValue: InputType) => {
-    const parsedFieldValue = convertType(fieldValue, typeof filterValue);
-    const parsedFilterValue = convertType(filterValue, typeof parsedFieldValue)
+    const parsedFieldValue = convertType(fieldValue, filterValue);
+    const parsedFilterValue = convertType(filterValue, parsedFieldValue)
 
-    return parsedFieldValue === parsedFilterValue;
+    return parsedFieldValue?.toString() === parsedFilterValue?.toString();
   },
   ne: (filterValue: InputType) => (fieldValue: InputType) => {
-    const parsedFieldValue = convertType(fieldValue, typeof filterValue);
-    const parsedFilterValue = convertType(filterValue, typeof parsedFieldValue)
+    const parsedFieldValue = convertType(fieldValue, filterValue);
+    const parsedFilterValue = convertType(filterValue, parsedFieldValue)
 
-    return parsedFilterValue !== parsedFieldValue;
+    return parsedFilterValue?.toString() !== parsedFieldValue?.toString();
   },
   gt: (filterValue: InputType) => (fieldValue: InputType) => {
-    const parsedFieldValue = convertType(fieldValue, typeof filterValue);
-    const parsedFilterValue = convertType(filterValue, typeof parsedFieldValue)
+    const parsedFieldValue = convertType(fieldValue, filterValue);
+    const parsedFilterValue = convertType(filterValue, parsedFieldValue);
 
     return parsedFieldValue > parsedFilterValue;
   },
   ge: (filterValue: InputType) => (fieldValue: InputType) => {
-    const parsedFieldValue = convertType(fieldValue, typeof filterValue);
-    const parsedFilterValue = convertType(filterValue, typeof parsedFieldValue)
+    const parsedFieldValue = convertType(fieldValue, filterValue);
+    const parsedFilterValue = convertType(filterValue, parsedFieldValue);
+
+    // if values are of MongoDb ObjectID, convert to timestamp before comparison
+    if (parsedFieldValue instanceof ObjectID && parsedFilterValue instanceof ObjectID) {
+      return parsedFieldValue.getTimestamp() >= parsedFilterValue.getTimestamp()
+    }
 
     return parsedFieldValue >= parsedFilterValue;
   },
   le: (filterValue: InputType) => (fieldValue: InputType) => {
-    const parsedFieldValue = convertType(fieldValue, typeof filterValue);
-    const parsedFilterValue = convertType(filterValue, typeof parsedFieldValue)
+    const parsedFieldValue = convertType(fieldValue, filterValue);
+    const parsedFilterValue = convertType(filterValue, parsedFieldValue)
+
+    // if values are of MongoDb ObjectID, convert to timestamp before comparison
+    if (parsedFieldValue instanceof ObjectID && parsedFilterValue instanceof ObjectID) {
+      return parsedFieldValue.getTimestamp() <= parsedFilterValue.getTimestamp()
+    }
 
     return parsedFieldValue <= parsedFilterValue;
   },
   lt: (filterValue: InputType) => (fieldValue: InputType) => {
-    const parsedFieldValue = convertType(fieldValue, typeof filterValue);
-    const parsedFilterValue = convertType(filterValue, typeof parsedFieldValue)
+    const parsedFieldValue = convertType(fieldValue, filterValue);
+    const parsedFilterValue = convertType(filterValue, parsedFieldValue);
+
+    // if values are of MongoDb ObjectID, convert to timestamp before comparison
+    if (parsedFieldValue instanceof ObjectID && parsedFilterValue instanceof ObjectID) {
+      return parsedFieldValue.getTimestamp() < parsedFilterValue.getTimestamp()
+    }
 
     return parsedFieldValue < parsedFilterValue;
   },
@@ -60,11 +76,22 @@ const predicateMap: IPredicate = {
   },
   between: ([fromVal, toVal]: InputType[]) => (fieldValue: InputType) => {
     if (isDateObject(fieldValue)) {
-      const fieldValDate = convertType(fieldValue, typeof fieldValue)
-      const fromValDate = convertType(fromVal, typeof fieldValue)
-      const toValDate = convertType(toVal, typeof fieldValue)
+      const fieldValDate = convertType(fieldValue, fieldValue)
+      const fromValDate = convertType(fromVal, fieldValue)
+      const toValDate = convertType(toVal, fieldValue)
 
       return fieldValDate >= fromValDate && fieldValDate <= toValDate;
+    }
+
+    // if values are of MongoDb ObjectID, convert to timestamp before comparison
+    if (fromVal instanceof ObjectID || toVal instanceof ObjectID || fieldValue instanceof ObjectID) {
+      const toValObjectId = new ObjectID(toVal.toString());
+      const fromValObjectId = new ObjectID(fromVal.toString());
+      const fieldValObjectId = new ObjectID(fieldValue.toString());
+      const fieldValTimestamp = fieldValObjectId.getTimestamp();
+
+      return fieldValTimestamp >= fromValObjectId.getTimestamp() &&
+        fieldValTimestamp <= toValObjectId.getTimestamp();
     }
 
     const parsedFieldValue = Number(fieldValue)

--- a/packages/graphback-core/src/runtime/createInMemoryFilterPredicate.ts
+++ b/packages/graphback-core/src/runtime/createInMemoryFilterPredicate.ts
@@ -164,7 +164,7 @@ function getAndPredicateResult<T>(and: QueryFilter | QueryFilter[], payload: Par
  * @param {QueryFilter|QueryFilter[]} or - Or query filter 
  * @param {Partial<T>} payload - Subscription payload
  */
-function getOrPredicateResult<T>(or: any | any[], payload: Partial<T>): boolean {
+function getOrPredicateResult<T>(or: QueryFilter | QueryFilter[], payload: Partial<T>): boolean {
   let orResult = true;
   if (Array.isArray(or)) {
     for (const orItem of or) {

--- a/packages/graphback-core/src/utils/convertType.ts
+++ b/packages/graphback-core/src/utils/convertType.ts
@@ -1,15 +1,21 @@
+import { ObjectID } from 'mongodb';
+
 /**
  * Helper function to convert a value to another type
  * 
  * @param {any} value - Value to convert
- * @param {string} typeOf - convert value to this type
+ * @param {string} toType - convert value to this type
  */
-export function convertType(value: any, typeOf: "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"): string | number | boolean | BigInt {
+export function convertType(value: any, toType: any): string | number | boolean | BigInt | ObjectID {
   if (!value) {
     return undefined;
   }
-  
-  switch (typeOf) {
+
+  if (toType instanceof ObjectID || value instanceof ObjectID) {
+    return new ObjectID(value);
+  }
+
+  switch (typeof toType) {
     case 'string':
       return String(value);
     case 'number':

--- a/packages/graphback-core/tests/createInMemoryFilterPredicateTest.ts
+++ b/packages/graphback-core/tests/createInMemoryFilterPredicateTest.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
-import { Scalars, Maybe, QueryFilter, StringInput, IdInput, BooleanInput, IntInput, FloatInput, GraphbackDateTimeInput } from '../src/runtime/QueryFilter';
+import { ObjectId } from 'mongodb';
+import { Scalars, Maybe, QueryFilter, StringInput, IdInput, BooleanInput, IntInput, FloatInput, GraphbackDateTimeInput, GraphbackObjectIdInput } from '../src/runtime/QueryFilter';
 import { createInMemoryFilterPredicate } from '../src/runtime/createInMemoryFilterPredicate';
 
 type User = {
@@ -10,6 +11,7 @@ type User = {
   age?: Scalars['Int'];
   score?: Scalars['Float'];
   createdAt?: Scalars['GraphbackDateTime'];
+  objectId?: Scalars['GraphbackObjectID'];
 };
 
 export type UserSubscriptionFilter = {
@@ -19,602 +21,831 @@ export type UserSubscriptionFilter = {
   age?: Maybe<IntInput>;
   score?: Maybe<FloatInput>;
   createdAt?: Maybe<GraphbackDateTimeInput>;
+  objectId?: Maybe<GraphbackObjectIdInput>;
   and?: Maybe<UserSubscriptionFilter[]>;
   or?: Maybe<UserSubscriptionFilter[]>;
   not?: Maybe<UserSubscriptionFilter>;
 };
 
-describe('inMemoryFilter', () => {
-
-  describe('ID', () => {
-    test('id eq', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        id: {
-          eq: 1
+describe('createInMemoryFilterPredicate', () => {
+  describe('Default scalars', () => {
+    describe('ID', () => {
+      test('id eq', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          id: {
+            eq: 1
+          }
         }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
 
-      expect(filterSubscription({ id: '1' })).toEqual(true);
-      expect(filterSubscription({ id: '0' })).toEqual(false);
+        expect(filterSubscription({ id: '1' })).toEqual(true);
+        expect(filterSubscription({ id: '0' })).toEqual(false);
+      });
+
+      test('id ne', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          id: {
+            ne: 1
+          }
+        }
+
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ id: '2' })).toEqual(true);
+        expect(filterSubscription({ id: '1' })).toEqual(false);
+      });
+
+      test('id le', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          id: {
+            le: 10
+          }
+        }
+
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ id: '9' })).toEqual(true);
+        expect(filterSubscription({ id: '10' })).toEqual(true);
+      });
+
+      test('id lt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          id: {
+            lt: 10
+          }
+        }
+
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ id: '9' })).toEqual(true);
+        expect(filterSubscription({ id: '10' })).toEqual(false);
+      });
+
+      test('id le', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          id: {
+            le: 10
+          }
+        }
+
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ id: '9' })).toEqual(true);
+        expect(filterSubscription({ id: '10' })).toEqual(true);
+      });
+
+      test('id gt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          id: {
+            lt: 10
+          }
+        }
+
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ id: '9' })).toEqual(true);
+        expect(filterSubscription({ id: '10' })).toEqual(false);
+      });
+
+      test('id gt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          id: {
+            ge: 10
+          }
+        }
+
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ id: '9' })).toEqual(false);
+        expect(filterSubscription({ id: '10' })).toEqual(true);
+        expect(filterSubscription({ id: '11' })).toEqual(true);
+      });
     });
 
-    test('id ne', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        id: {
-          ne: 1
+    describe('String', () => {
+      test('name eq', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          name: {
+            eq: 'Homer Simpson'
+          }
         }
-      }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
 
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+        expect(filterSubscription({ name: undefined })).toEqual(false)
+        expect(filterSubscription({ name: 'Homer Thompson' })).toEqual(false);
+        expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(true);
+      });
 
-      expect(filterSubscription({ id: '2' })).toEqual(true);
-      expect(filterSubscription({ id: '1' })).toEqual(false);
+      test('name ne', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          name: {
+            ne: 'Homer Simpson'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: undefined })).toEqual(true)
+        expect(filterSubscription({ name: 'Homer Thompson' })).toEqual(true);
+        expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(false);
+      });
+
+      test('name le', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          name: {
+            le: 'Bart Simpson'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: undefined })).toEqual(false)
+        expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(true);
+        expect(filterSubscription({ name: 'Bart Arnold' })).toEqual(true);
+        expect(filterSubscription({ name: 'Homer Thompson' })).toEqual(false);
+      });
+
+      test('name lt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          name: {
+            lt: 'Bart Simpson'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: undefined })).toEqual(false)
+        expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(false);
+        expect(filterSubscription({ name: 'Apu Nahasapeemapetilon' })).toEqual(true);
+        expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(false);
+      });
+
+      test('name gt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          name: {
+            gt: 'Bart Simpson'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: undefined })).toEqual(false);
+        expect(filterSubscription({ name: 'Apu Nahasapeemapetilon' })).toEqual(false);
+        expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(false);
+        expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(true);
+      });
+
+      test('name ge', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          name: {
+            ge: 'Bart Simpson'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: undefined })).toEqual(false);
+        expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(true);
+        expect(filterSubscription({ name: 'Apu Nahasapeemapetilond' })).toEqual(false);
+        expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(true);
+      });
+
+      test('name in', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          name: {
+            in: ['Bart Simpson', 'Homer Simpson']
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(true);
+        expect(filterSubscription({ name: 'Bumblebee Man' })).toEqual(false);
+        expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(true);
+      });
+
+      test('name contains', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          name: {
+            contains: 'Bart'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: undefined })).toEqual(false);
+        expect(filterSubscription({ name: 'Bart' })).toEqual(true);
+        expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(true);
+        expect(filterSubscription({ name: 'Bartholemew' })).toEqual(true);
+        expect(filterSubscription({ name: 'Die Bart Die' })).toEqual(true);
+        expect(filterSubscription({ name: 'Simpson Bart' })).toEqual(true);
+        expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(false);
+      });
+
+      test('name startsWith', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          name: {
+            startsWith: 'Bart'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: undefined })).toEqual(false);
+        expect(filterSubscription({ name: 'Bart' })).toEqual(true);
+        expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(true);
+        expect(filterSubscription({ name: 'BartSimpson' })).toEqual(true);
+        expect(filterSubscription({ name: 'Mr. Bart Simpson' })).toEqual(false);
+        expect(filterSubscription({ name: 'Simpson Bart' })).toEqual(false);
+      });
+
+      test('name endsWith', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          name: {
+            endsWith: 'Simpson'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: undefined })).toEqual(false);
+        expect(filterSubscription({ name: 'Maggie' })).toEqual(false);
+        expect(filterSubscription({ name: 'Lisa Simpson' })).toEqual(true);
+        expect(filterSubscription({ name: 'HomerSimpson' })).toEqual(true);
+        expect(filterSubscription({ name: 'The Simpsons' })).toEqual(false);
+      });
     });
 
-    test('id le', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        id: {
-          le: 10
+    describe('Boolean', () => {
+      test('verified', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          verified: {
+            eq: true
+          }
         }
-      }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
 
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ id: '9' })).toEqual(true);
-      expect(filterSubscription({ id: '10' })).toEqual(true);
+        expect(filterSubscription({ verified: true })).toEqual(true);
+        expect(filterSubscription({ verified: false })).toEqual(false);
+      });
     });
 
-    test('id lt', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        id: {
-          lt: 10
+    describe('Int', () => {
+      test('age eq', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          age: {
+            eq: 38
+          }
         }
-      }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
 
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+        expect(filterSubscription({ name: 'Lenny', age: 38 })).toEqual(true)
+        expect(filterSubscription({ name: 'Carl', age: 39 })).toEqual(false)
+      });
 
-      expect(filterSubscription({ id: '9' })).toEqual(true);
-      expect(filterSubscription({ id: '10' })).toEqual(false);
+      test('age ne', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          age: {
+            ne: 38
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: 'Lenny', age: 38 })).toEqual(false)
+        expect(filterSubscription({ name: 'Carl', age: 39 })).toEqual(true)
+      });
+
+      test('age lt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          age: {
+            lt: 8
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: 'Maggie', age: 1 })).toEqual(true)
+        expect(filterSubscription({ name: 'Lisa', age: 8 })).toEqual(false)
+        expect(filterSubscription({ name: 'Bart', age: 10 })).toEqual(false)
+      });
+
+      test('age le', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          age: {
+            le: 8
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: 'Maggie', age: 1 })).toEqual(true)
+        expect(filterSubscription({ name: 'Lisa', age: 8 })).toEqual(true)
+        expect(filterSubscription({ name: 'Bart', age: 10 })).toEqual(false)
+      });
+
+      test('age gt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          age: {
+            gt: 8
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: 'Maggie', age: 1 })).toEqual(false)
+        expect(filterSubscription({ name: 'Lisa', age: 8 })).toEqual(false)
+        expect(filterSubscription({ name: 'Bart', age: 10 })).toEqual(true)
+      });
+
+      test('age ge', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          age: {
+            ge: 8
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ name: 'Maggie', age: 1 })).toEqual(false)
+        expect(filterSubscription({ name: 'Lisa', age: 8 })).toEqual(true)
+        expect(filterSubscription({ name: 'Bart', age: 10 })).toEqual(true)
+      });
+
+      test('age in', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          age: {
+            in: [1, 8, 10]
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ age: 1 })).toEqual(true)
+        expect(filterSubscription({ age: 10 })).toEqual(true)
+        expect(filterSubscription({ age: 11 })).toEqual(false)
+      });
+
+      test('age between', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          age: {
+            between: [1, 10]
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ age: 0 })).toEqual(false)
+        expect(filterSubscription({ age: 1 })).toEqual(true)
+        expect(filterSubscription({ age: 8 })).toEqual(true)
+        expect(filterSubscription({ age: 10 })).toEqual(true)
+        expect(filterSubscription({ age: 11 })).toEqual(false)
+      });
     });
 
-    test('id in', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        id: {
-          in: [1, 4, 5, 7, 8, 9]
+    describe('Float', () => {
+      test('score eq', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          score: {
+            eq: 90
+          }
         }
-      }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
 
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+        expect(filterSubscription({ score: undefined })).toEqual(false);
+        expect(filterSubscription({ score: 89.99 })).toEqual(false)
+        expect(filterSubscription({ score: 90.00 })).toEqual(true)
+        expect(filterSubscription({ score: 90.50 })).toEqual(false)
+        expect(filterSubscription({ score: 91 })).toEqual(false)
+      });
 
-      expect(filterSubscription({ id: '0' })).toEqual(false);
-      expect(filterSubscription({ id: '1' })).toEqual(true);
-      expect(filterSubscription({ id: '9' })).toEqual(true);
-      expect(filterSubscription({ id: '6' })).toEqual(false);
-      expect(filterSubscription({ id: '10' })).toEqual(false);
+      test('score ne', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          score: {
+            ne: 90
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ score: undefined })).toEqual(true);
+        expect(filterSubscription({ score: 89.99 })).toEqual(true)
+        expect(filterSubscription({ score: 90.00 })).toEqual(false)
+      });
+
+      test('score lt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          score: {
+            lt: 90.01
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ score: undefined })).toEqual(false);
+        expect(filterSubscription({ score: 89.99 })).toEqual(true)
+        expect(filterSubscription({ score: 90.01 })).toEqual(false)
+        expect(filterSubscription({ score: 90.50 })).toEqual(false)
+      });
+
+      test('score le', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          score: {
+            le: 90.05
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ score: undefined })).toEqual(false);
+        expect(filterSubscription({ score: 89.99 })).toEqual(true)
+        expect(filterSubscription({ score: 90.00 })).toEqual(true)
+        expect(filterSubscription({ score: 90.05 })).toEqual(true)
+        expect(filterSubscription({ score: 91.06 })).toEqual(false)
+      });
+
+      test('score gt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          score: {
+            gt: 90.50
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ score: undefined })).toEqual(false);
+        expect(filterSubscription({ score: 89 })).toEqual(false)
+        expect(filterSubscription({ score: 90.50 })).toEqual(false)
+        expect(filterSubscription({ score: 90.51 })).toEqual(true)
+      });
+
+      test('score ge', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          score: {
+            ge: 90.50
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ score: undefined })).toEqual(false);
+        expect(filterSubscription({ score: 89.99 })).toEqual(false)
+        expect(filterSubscription({ score: 90.50 })).toEqual(true)
+        expect(filterSubscription({ score: 90.51 })).toEqual(true)
+      });
+
+      test('score in', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          score: {
+            in: [50, 55, 75, 90, 95]
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ score: undefined })).toEqual(false);
+        expect(filterSubscription({ score: 49 })).toEqual(false)
+        expect(filterSubscription({ score: 50 })).toEqual(true)
+        expect(filterSubscription({ score: 95 })).toEqual(true)
+        expect(filterSubscription({ score: 100 })).toEqual(false)
+      });
+
+      test('score between', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          score: {
+            between: [75, 95]
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ score: undefined })).toEqual(false);
+        expect(filterSubscription({ score: 74 })).toEqual(false)
+        expect(filterSubscription({ score: 75 })).toEqual(true)
+        expect(filterSubscription({ score: 76 })).toEqual(true)
+        expect(filterSubscription({ score: 94 })).toEqual(true)
+        expect(filterSubscription({ score: 95 })).toEqual(true)
+        expect(filterSubscription({ score: 96 })).toEqual(false)
+      });
     });
-  });
-
-  describe('String', () => {
-    test('name eq', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        name: {
-          eq: 'Homer Simpson'
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: undefined })).toEqual(false)
-      expect(filterSubscription({ name: 'Homer Thompson' })).toEqual(false);
-      expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(true);
-    });
-
-    test('name ne', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        name: {
-          ne: 'Homer Simpson'
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: undefined })).toEqual(true)
-      expect(filterSubscription({ name: 'Homer Thompson' })).toEqual(true);
-      expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(false);
-    });
-
-    test('name le', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        name: {
-          le: 'Bart Simpson'
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: undefined })).toEqual(false)
-      expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(true);
-      expect(filterSubscription({ name: 'Bart Arnold' })).toEqual(true);
-      expect(filterSubscription({ name: 'Homer Thompson' })).toEqual(false);
-    });
-
-    test('name lt', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        name: {
-          lt: 'Bart Simpson'
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: undefined })).toEqual(false)
-      expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(false);
-      expect(filterSubscription({ name: 'Apu Nahasapeemapetilon' })).toEqual(true);
-      expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(false);
-    });
-
-    test('name gt', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        name: {
-          gt: 'Bart Simpson'
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: undefined })).toEqual(false);
-      expect(filterSubscription({ name: 'Apu Nahasapeemapetilon' })).toEqual(false);
-      expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(false);
-      expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(true);
-    });
-
-    test('name ge', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        name: {
-          ge: 'Bart Simpson'
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: undefined })).toEqual(false);
-      expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(true);
-      expect(filterSubscription({ name: 'Apu Nahasapeemapetilond' })).toEqual(false);
-      expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(true);
-    });
-
-    test('name in', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        name: {
-          in: ['Bart Simpson', 'Homer Simpson']
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(true);
-      expect(filterSubscription({ name: 'Bumblebee Man' })).toEqual(false);
-      expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(true);
-    });
-
-    test('name contains', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        name: {
-          contains: 'Bart'
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: undefined })).toEqual(false);
-      expect(filterSubscription({ name: 'Bart' })).toEqual(true);
-      expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(true);
-      expect(filterSubscription({ name: 'Bartholemew' })).toEqual(true);
-      expect(filterSubscription({ name: 'Die Bart Die' })).toEqual(true);
-      expect(filterSubscription({ name: 'Simpson Bart' })).toEqual(true);
-      expect(filterSubscription({ name: 'Homer Simpson' })).toEqual(false);
-    });
-
-    test('name startsWith', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        name: {
-          startsWith: 'Bart'
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: undefined })).toEqual(false);
-      expect(filterSubscription({ name: 'Bart' })).toEqual(true);
-      expect(filterSubscription({ name: 'Bart Simpson' })).toEqual(true);
-      expect(filterSubscription({ name: 'BartSimpson' })).toEqual(true);
-      expect(filterSubscription({ name: 'Mr. Bart Simpson' })).toEqual(false);
-      expect(filterSubscription({ name: 'Simpson Bart' })).toEqual(false);
-    });
-
-    test('name endsWith', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        name: {
-          endsWith: 'Simpson'
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: undefined })).toEqual(false);
-      expect(filterSubscription({ name: 'Maggie' })).toEqual(false);
-      expect(filterSubscription({ name: 'Lisa Simpson' })).toEqual(true);
-      expect(filterSubscription({ name: 'HomerSimpson' })).toEqual(true);
-      expect(filterSubscription({ name: 'The Simpsons' })).toEqual(false);
-    });
-  });
-
-  describe('Boolean', () => {
-    test('verified', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        verified: {
-          eq: true
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ verified: true })).toEqual(true);
-      expect(filterSubscription({ verified: false })).toEqual(false);
-    });
-  });
-
-  describe('Int', () => {
-    test('age eq', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        age: {
-          eq: 38
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: 'Lenny', age: 38 })).toEqual(true)
-      expect(filterSubscription({ name: 'Carl', age: 39 })).toEqual(false)
-    });
-
-    test('age ne', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        age: {
-          ne: 38
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: 'Lenny', age: 38 })).toEqual(false)
-      expect(filterSubscription({ name: 'Carl', age: 39 })).toEqual(true)
-    });
-
-    test('age lt', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        age: {
-          lt: 8
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: 'Maggie', age: 1 })).toEqual(true)
-      expect(filterSubscription({ name: 'Lisa', age: 8 })).toEqual(false)
-      expect(filterSubscription({ name: 'Bart', age: 10 })).toEqual(false)
-    });
-
-    test('age le', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        age: {
-          le: 8
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: 'Maggie', age: 1 })).toEqual(true)
-      expect(filterSubscription({ name: 'Lisa', age: 8 })).toEqual(true)
-      expect(filterSubscription({ name: 'Bart', age: 10 })).toEqual(false)
-    });
-
-    test('age gt', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        age: {
-          gt: 8
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: 'Maggie', age: 1 })).toEqual(false)
-      expect(filterSubscription({ name: 'Lisa', age: 8 })).toEqual(false)
-      expect(filterSubscription({ name: 'Bart', age: 10 })).toEqual(true)
-    });
-
-    test('age ge', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        age: {
-          ge: 8
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ name: 'Maggie', age: 1 })).toEqual(false)
-      expect(filterSubscription({ name: 'Lisa', age: 8 })).toEqual(true)
-      expect(filterSubscription({ name: 'Bart', age: 10 })).toEqual(true)
-    });
-
-    test('age in', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        age: {
-          in: [1, 8, 10]
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ age: 1 })).toEqual(true)
-      expect(filterSubscription({ age: 10 })).toEqual(true)
-      expect(filterSubscription({ age: 11 })).toEqual(false)
-    });
-
-    test('age between', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        age: {
-          between: [1, 10]
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ age: 0 })).toEqual(false)
-      expect(filterSubscription({ age: 1 })).toEqual(true)
-      expect(filterSubscription({ age: 8 })).toEqual(true)
-      expect(filterSubscription({ age: 10 })).toEqual(true)
-      expect(filterSubscription({ age: 11 })).toEqual(false)
-    });
-  });
-
-  describe('Float', () => {
-    test('score eq', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        score: {
-          eq: 90
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ score: undefined })).toEqual(false);
-      expect(filterSubscription({ score: 89.99 })).toEqual(false)
-      expect(filterSubscription({ score: 90.00 })).toEqual(true)
-      expect(filterSubscription({ score: 90.50 })).toEqual(false)
-      expect(filterSubscription({ score: 91 })).toEqual(false)
-    });
-
-    test('score ne', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        score: {
-          ne: 90
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ score: undefined })).toEqual(true);
-      expect(filterSubscription({ score: 89.99 })).toEqual(true)
-      expect(filterSubscription({ score: 90.00 })).toEqual(false)
-    });
-
-    test('score lt', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        score: {
-          lt: 90.01
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ score: undefined })).toEqual(false);
-      expect(filterSubscription({ score: 89.99 })).toEqual(true)
-      expect(filterSubscription({ score: 90.01 })).toEqual(false)
-      expect(filterSubscription({ score: 90.50 })).toEqual(false)
-    });
-
-    test('score le', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        score: {
-          le: 90.05
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ score: undefined })).toEqual(false);
-      expect(filterSubscription({ score: 89.99 })).toEqual(true)
-      expect(filterSubscription({ score: 90.00 })).toEqual(true)
-      expect(filterSubscription({ score: 90.05 })).toEqual(true)
-      expect(filterSubscription({ score: 91.06 })).toEqual(false)
-    });
-
-    test('score gt', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        score: {
-          gt: 90.50
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ score: undefined })).toEqual(false);
-      expect(filterSubscription({ score: 89 })).toEqual(false)
-      expect(filterSubscription({ score: 90.50 })).toEqual(false)
-      expect(filterSubscription({ score: 90.51 })).toEqual(true)
-    });
-
-    test('score ge', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        score: {
-          ge: 90.50
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ score: undefined })).toEqual(false);
-      expect(filterSubscription({ score: 89.99 })).toEqual(false)
-      expect(filterSubscription({ score: 90.50 })).toEqual(true)
-      expect(filterSubscription({ score: 90.51 })).toEqual(true)
-    });
-
-    test('score in', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        score: {
-          in: [50, 55, 75, 90, 95]
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ score: undefined })).toEqual(false);
-      expect(filterSubscription({ score: 49 })).toEqual(false)
-      expect(filterSubscription({ score: 50 })).toEqual(true)
-      expect(filterSubscription({ score: 95 })).toEqual(true)
-      expect(filterSubscription({ score: 100 })).toEqual(false)
-    });
-
-    test('score between', () => {
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        score: {
-          between: [75, 95]
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ score: undefined })).toEqual(false);
-      expect(filterSubscription({ score: 74 })).toEqual(false)
-      expect(filterSubscription({ score: 75 })).toEqual(true)
-      expect(filterSubscription({ score: 76 })).toEqual(true)
-      expect(filterSubscription({ score: 94 })).toEqual(true)
-      expect(filterSubscription({ score: 95 })).toEqual(true)
-      expect(filterSubscription({ score: 96 })).toEqual(false)
-    });
-  });
-
-  describe('Date', () => {
-    test('createdAt eq', () => {
-
-      const now = new Date()
-
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        createdAt: {
-          eq: now
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ createdAt: undefined })).toEqual(false);
-      expect(filterSubscription({ createdAt: now })).toBe(true);
-      expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(false)
-      expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(false)
-    })
-
-    test('createdAt ne', () => {
-
-      const now = new Date()
-
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        createdAt: {
-          ne: now
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ createdAt: undefined })).toEqual(true);
-      expect(filterSubscription({ createdAt: now })).toEqual(false);
-      expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(true)
-      expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(true)
-    })
-
-    test('createdAt lt', () => {
-
-      const now = new Date()
-
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        createdAt: {
-          lt: now
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ createdAt: undefined })).toEqual(false);
-      expect(filterSubscription({ createdAt: now })).toBe(false);
-      expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(true)
-      expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(false)
-    })
-
-    test('createdAt le', () => {
-
-      const now = new Date()
-
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        createdAt: {
-          le: now
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ createdAt: undefined })).toEqual(false);
-      expect(filterSubscription({ createdAt: now })).toBe(true);
-      expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(true)
-      expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(false)
-    })
-
-    test('createdAt gt', () => {
-
-      const now = new Date()
-
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        createdAt: {
-          gt: now
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ createdAt: undefined })).toEqual(false);
-      expect(filterSubscription({ createdAt: now })).toBe(false);
-      expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(false)
-      expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(true)
-    })
-
-    test('createdAt ge', () => {
-      const now = new Date()
-
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        createdAt: {
-          ge: now
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ createdAt: undefined })).toEqual(false);
-      expect(filterSubscription({ createdAt: now })).toEqual(true);
-      expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(false)
-      expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(true)
-    })
-
-    test('createdAt in', () => {
-      const now = new Date()
-
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        createdAt: {
-          in: [now, new Date(now.getTime() - 1000 * 60), new Date(now.getTime() + 1000 * 60)]
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ createdAt: undefined })).toEqual(false);
-      expect(filterSubscription({ createdAt: now })).toEqual(true);
-      expect(filterSubscription({ createdAt: new Date(now.getDate() - 2000 * 60) })).toEqual(false);
-      expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(true)
-      expect(filterSubscription({ createdAt: new Date(now.getDate() + 2000 * 60) })).toEqual(false)
-    })
-
-    test('createdAt between', () => {
-      const now = new Date()
-
-      const filter: QueryFilter<UserSubscriptionFilter> = {
-        createdAt: {
-          between: [now, new Date(now.getTime() + 1000 * 600)]
-        }
-      }
-      const filterSubscription = createInMemoryFilterPredicate<User>(filter)
-
-      expect(filterSubscription({ createdAt: undefined })).toEqual(false);
-      expect(filterSubscription({ createdAt: now })).toEqual(true);
-      expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(false)
-      expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 600) })).toEqual(true)
-      expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 601) })).toEqual(false)
-    })
   })
+
+  describe('Graphback scalars', () => {
+    describe('GraphbackDateTime', () => {
+      test('createdAt eq', () => {
+
+        const now = new Date()
+
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          createdAt: {
+            eq: now
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ createdAt: undefined })).toEqual(false);
+        expect(filterSubscription({ createdAt: now })).toBe(true);
+        expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(false)
+        expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(false)
+      })
+
+      test('createdAt ne', () => {
+        const now = new Date()
+
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          createdAt: {
+            ne: now
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ createdAt: undefined })).toEqual(true);
+        expect(filterSubscription({ createdAt: now })).toEqual(false);
+        expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(true)
+        expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(true)
+      })
+
+      test('createdAt lt', () => {
+
+        const now = new Date()
+
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          createdAt: {
+            lt: now
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ createdAt: undefined })).toEqual(false);
+        expect(filterSubscription({ createdAt: now })).toBe(false);
+        expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(true)
+        expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(false)
+      })
+
+      test('createdAt le', () => {
+
+        const now = new Date()
+
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          createdAt: {
+            le: now
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ createdAt: undefined })).toEqual(false);
+        expect(filterSubscription({ createdAt: now })).toBe(true);
+        expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(true)
+        expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(false)
+      })
+
+      test('createdAt gt', () => {
+
+        const now = new Date()
+
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          createdAt: {
+            gt: now
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ createdAt: undefined })).toEqual(false);
+        expect(filterSubscription({ createdAt: now })).toBe(false);
+        expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(false)
+        expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(true)
+      })
+
+      test('createdAt ge', () => {
+        const now = new Date()
+
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          createdAt: {
+            ge: now
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ createdAt: undefined })).toEqual(false);
+        expect(filterSubscription({ createdAt: now })).toEqual(true);
+        expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(false)
+        expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(true)
+      })
+
+      test('createdAt in', () => {
+        const now = new Date()
+
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          createdAt: {
+            in: [now, new Date(now.getTime() - 1000 * 60), new Date(now.getTime() + 1000 * 60)]
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ createdAt: undefined })).toEqual(false);
+        expect(filterSubscription({ createdAt: now })).toEqual(true);
+        expect(filterSubscription({ createdAt: new Date(now.getDate() - 2000 * 60) })).toEqual(false);
+        expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 60) })).toEqual(true)
+        expect(filterSubscription({ createdAt: new Date(now.getDate() + 2000 * 60) })).toEqual(false)
+      })
+
+      test('createdAt between', () => {
+        const now = new Date()
+
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          createdAt: {
+            between: [now, new Date(now.getTime() + 1000 * 600)]
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ createdAt: undefined })).toEqual(false);
+        expect(filterSubscription({ createdAt: now })).toEqual(true);
+        expect(filterSubscription({ createdAt: new Date(now.getTime() - 1000 * 60) })).toEqual(false)
+        expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 600) })).toEqual(true)
+        expect(filterSubscription({ createdAt: new Date(now.getTime() + 1000 * 601) })).toEqual(false)
+      })
+    })
+
+    describe('GraphbackObjectID', () => {
+      test('objectId eq', () => {
+
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            eq: new ObjectId('5f33fe525ad68ca5954944be')
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: '5f33fe525ad68ca5954944be' })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f34001a967d8ed61dde6e21' })).toEqual(false);
+        expect(filterSubscription({ objectId: new ObjectId('5f34001a967d8ed61dde6e21') })).toEqual(false);
+      });
+
+      test('objectId string eq', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            eq: '5f33fe525ad68ca5954944be'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: '5f33fe525ad68ca5954944be' })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f34001a967d8ed61dde6e21' })).toEqual(false);
+        expect(filterSubscription({ objectId: new ObjectId('5f34001a967d8ed61dde6e21') })).toEqual(false);
+      });
+
+      test('objectId ne', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            ne: new ObjectId('5f33fe525ad68ca5954944be')
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: '5f33fe525ad68ca5954944be' })).toEqual(false);
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f34001a967d8ed61dde6e21' })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f34001a967d8ed61dde6e21') })).toEqual(true);
+      });
+
+      test('objectId string ne', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            ne: '5f33fe525ad68ca5954944be'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: '5f33fe525ad68ca5954944be' })).toEqual(false);
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f34001a967d8ed61dde6e21' })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f34001a967d8ed61dde6e21') })).toEqual(true);
+      });
+
+      test('objectId le', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            le: new ObjectId('5f34032bb0c5675c6287aae1')
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f34032bb0c5675c6287aae1') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f34033f6cf30f6f2e6c9da4') })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f33fe525ad68ca5954944be' })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f34032bb0c5675c6287aae1' })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f34033f6cf30f6f2e6c9da4' })).toEqual(false);
+      });
+
+      test('objectId string le', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            le: '5f34032bb0c5675c6287aae1'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f34032bb0c5675c6287aae1') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f34033f6cf30f6f2e6c9da4') })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f33fe525ad68ca5954944be' })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f34032bb0c5675c6287aae1' })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f34033f6cf30f6f2e6c9da4' })).toEqual(false);
+      });
+
+      test('objectId le', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            le: new ObjectId('5f34032bb0c5675c6287aae1')
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f34032bb0c5675c6287aae1') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f34033f6cf30f6f2e6c9da4') })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f33fe525ad68ca5954944be' })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f34032bb0c5675c6287aae1' })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f34033f6cf30f6f2e6c9da4' })).toEqual(false);
+      });
+
+      test('objectId lt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            lt: new ObjectId('5f34032bb0c5675c6287aae1')
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f34032bb0c5675c6287aae1') })).toEqual(false);
+        expect(filterSubscription({ objectId: new ObjectId('5f34033f6cf30f6f2e6c9da4') })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f33fe525ad68ca5954944be' })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f34032bb0c5675c6287aae1' })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f34033f6cf30f6f2e6c9da4' })).toEqual(false);
+      });
+
+      test('objectId string lt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            lt: '5f34032bb0c5675c6287aae1'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f34032bb0c5675c6287aae1') })).toEqual(false);
+        expect(filterSubscription({ objectId: new ObjectId('5f34033f6cf30f6f2e6c9da4') })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f33fe525ad68ca5954944be' })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f34032bb0c5675c6287aae1' })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f34033f6cf30f6f2e6c9da4' })).toEqual(false);
+      });
+
+      test('objectId gt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            gt: new ObjectId('5f34032bb0c5675c6287aae1')
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(false);
+        expect(filterSubscription({ objectId: new ObjectId('5f34032bb0c5675c6287aae1') })).toEqual(false);
+        expect(filterSubscription({ objectId: new ObjectId('5f34033f6cf30f6f2e6c9da4') })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f33fe525ad68ca5954944be' })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f34032bb0c5675c6287aae1' })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f34033f6cf30f6f2e6c9da4' })).toEqual(true);
+      });
+
+      test('objectId string gt', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            gt: '5f34032bb0c5675c6287aae1'
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(false);
+        expect(filterSubscription({ objectId: new ObjectId('5f34032bb0c5675c6287aae1') })).toEqual(false);
+        expect(filterSubscription({ objectId: new ObjectId('5f34033f6cf30f6f2e6c9da4') })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f33fe525ad68ca5954944be' })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f34032bb0c5675c6287aae1' })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f34033f6cf30f6f2e6c9da4' })).toEqual(true);
+      });
+
+      test('objectId in', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            in: ['5f34032bb0c5675c6287aae1', new ObjectId('5f33fe525ad68ca5954944be')],
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f34032bb0c5675c6287aae1') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f34033f6cf30f6f2e6c9da4') })).toEqual(false);
+        expect(filterSubscription({ objectId: '5f33fe525ad68ca5954944be' })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f34032bb0c5675c6287aae1' })).toEqual(true);
+        expect(filterSubscription({ objectId: '5f34033f6cf30f6f2e6c9da4' })).toEqual(false);
+      });
+
+      test('objectId between', () => {
+        const filter: QueryFilter<UserSubscriptionFilter> = {
+          objectId: {
+            between: ['5f340dafa0a27b6597115911', new ObjectId('5f340dc32fd6f81adb85d9bf')],
+          }
+        }
+        const filterSubscription = createInMemoryFilterPredicate<User>(filter)
+
+        expect(filterSubscription({ objectId: new ObjectId('5f33fe525ad68ca5954944be') })).toEqual(false);
+        expect(filterSubscription({ objectId: new ObjectId('5f340dafa0a27b6597115911') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f340dc32fd6f81adb85d9bf') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f340db5385d04649e7f7666') })).toEqual(true);
+        expect(filterSubscription({ objectId: new ObjectId('5f340e092f713e77f7804103') })).toEqual(false);
+      });
+    })
+  });
 
   test('combination filter', () => {
     const filter: QueryFilter<UserSubscriptionFilter> = {

--- a/packages/graphback-core/tests/createInMemoryFilterPredicateTest.ts
+++ b/packages/graphback-core/tests/createInMemoryFilterPredicateTest.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { Scalars, Maybe, QueryFilter, StringInput, IdInput, BooleanInput, IntInput, FloatInput, DateTimeInput } from '../src/runtime/QueryFilter';
+import { Scalars, Maybe, QueryFilter, StringInput, IdInput, BooleanInput, IntInput, FloatInput, GraphbackDateTimeInput } from '../src/runtime/QueryFilter';
 import { createInMemoryFilterPredicate } from '../src/runtime/createInMemoryFilterPredicate';
 
 type User = {
@@ -9,7 +9,7 @@ type User = {
   verified?: Maybe<Scalars['Boolean']>;
   age?: Scalars['Int'];
   score?: Scalars['Float'];
-  createdAt?: Scalars['DateTime'];
+  createdAt?: Scalars['GraphbackDateTime'];
 };
 
 export type UserSubscriptionFilter = {
@@ -18,7 +18,7 @@ export type UserSubscriptionFilter = {
   verified?: Maybe<BooleanInput>;
   age?: Maybe<IntInput>;
   score?: Maybe<FloatInput>;
-  createdAt?: Maybe<DateTimeInput>;
+  createdAt?: Maybe<GraphbackDateTimeInput>;
   and?: Maybe<UserSubscriptionFilter[]>;
   or?: Maybe<UserSubscriptionFilter[]>;
   not?: Maybe<UserSubscriptionFilter>;

--- a/packages/graphback-core/tests/createInMemoryFilterPredicateTest.ts
+++ b/packages/graphback-core/tests/createInMemoryFilterPredicateTest.ts
@@ -1,17 +1,17 @@
 /* eslint-disable max-lines */
 import { ObjectId } from 'mongodb';
-import { Scalars, Maybe, QueryFilter, StringInput, IdInput, BooleanInput, IntInput, FloatInput, GraphbackDateTimeInput, GraphbackObjectIdInput } from '../src/runtime/QueryFilter';
+import { FilterableScalars, Maybe, QueryFilter, StringInput, IdInput, BooleanInput, IntInput, FloatInput, GraphbackDateTimeInput, GraphbackObjectIdInput } from '../src/runtime/QueryFilter';
 import { createInMemoryFilterPredicate } from '../src/runtime/createInMemoryFilterPredicate';
 
 type User = {
   __typename?: 'User';
-  id?: Scalars['ID'];
-  name?: Scalars['String'];
-  verified?: Maybe<Scalars['Boolean']>;
-  age?: Scalars['Int'];
-  score?: Scalars['Float'];
-  createdAt?: Scalars['GraphbackDateTime'];
-  objectId?: Scalars['GraphbackObjectID'];
+  id?: FilterableScalars['ID'];
+  name?: FilterableScalars['String'];
+  verified?: Maybe<FilterableScalars['Boolean']>;
+  age?: FilterableScalars['Int'];
+  score?: FilterableScalars['Float'];
+  createdAt?: FilterableScalars['GraphbackDateTime'];
+  objectId?: FilterableScalars['GraphbackObjectID'];
 };
 
 export type UserSubscriptionFilter = {
@@ -28,7 +28,7 @@ export type UserSubscriptionFilter = {
 };
 
 describe('createInMemoryFilterPredicate', () => {
-  describe('Default scalars', () => {
+  describe('Default FilterableScalars', () => {
     describe('ID', () => {
       test('id eq', () => {
         const filter: QueryFilter<UserSubscriptionFilter> = {
@@ -507,7 +507,7 @@ describe('createInMemoryFilterPredicate', () => {
     });
   })
 
-  describe('Graphback scalars', () => {
+  describe('Graphback FilterableScalars', () => {
     describe('GraphbackDateTime', () => {
       test('createdAt eq', () => {
 

--- a/packages/graphback-runtime-knex/package.json
+++ b/packages/graphback-runtime-knex/package.json
@@ -29,6 +29,7 @@
     "graphql-migrations": "0.15.1",
     "jest": "26.3.0",
     "@graphback/codegen-schema": "0.15.0",
+    "sqlite3": "5.0.0",
     "rimraf": "3.0.2",
     "ts-jest": "26.2.0",
     "ts-node": "8.10.2",


### PR DESCRIPTION
- feat(datasync): restore _version field
- feat(datasync): remove conflicts and use specific _lastUpdatedAt
- docs(datasync): update docs
- test(datasync): added additional tests
- fix(datasync): fix problems with existing scalars
- test(datasync): add integration test for datasync
- fix(datasync): use GraphQLObjectType instead of ObjectTypeComposer in creating DeltaType
- feat(datasync): add limit to delta queries
- docs: add release notes for datasync
- fix(deps): update dependency chokidar to v3.4.2
- fix(deps): update dependency tslib to v2.0.1
- perf: add benchmark scripts (#1824)
- chore(deps): update all
- fix(deps): update apollo graphql packages to v2.16.1
- fix(deps): update dependency @hapi/hapi to v18.4.1
- perf: review relationship builder to avoid parsing annotation several times (#1818)
- perf: use dataloader to resolve oneToOne or manyToOne relationships
- chore(deps): update dependency @types/react to v16.9.45
- fix(deps): update all
- fix(deps): update dependency graphql-compose to v7.19.3
- fix(deps): update dependency wait-on to v5.2.0
- chore(deps): update dependency typedoc to v0.18.0
- chore(deps): update dependency jest to v26.3.0
- fix(deps): update dependency knex to v0.21.4 (#1848)
- fix(core): avoid stringfying "null" values as `"null"`
- feat(graphql-migrations): add support for composite unique columns (#1846)
- chore(deps): update dependency @types/react to v16.9.46
- fix(deps): update dependency graphql-compose to v7.19.4
- fix(deps): update graphql-tools monorepo to v6.0.17
- test(schema-plugin): add a test case for directives that uses enums
- fix(deps): update dependency @graphql-inspector/core to v2.2.0
- docs(release): update release notes (#1854)
- chore(deps): update dependency ts-jest to v26.2.0
- fix(deps): update graphql-tools monorepo to v6.0.18
- chore(deps): update graphqlcodegenerator monorepo to v1.17.8
- fix: add a null / undefined check before loading relationship with dataloader
- fix: make sure relationship field is added when retrieving in oneToOne or ManyToOne
- feat(schema-plugin): use GraphbackDateTime scalar for generated createdAt updatedAt fields
- feat: create index for the lastUpdateAt field
- feat: subscription filtering (#1835)
- feat(core): add Graphback scalar filter types
- feat: predicate filtering on ObjectID type
- feat(schema): disable filter input generation for user custom scalars
- chore: add sqlite as devDependency for tests
