### PR TITLE
Datasync minor fixes

### DIFF
--- a/docs/datasync/conflict-resolution-intro.md
+++ b/docs/datasync/conflict-resolution-intro.md
@@ -132,7 +132,7 @@ To improve efficiency of queries on the `delta` table, a `deltaTTL` argument (in
 You may only have delta queries for one model while having both delta queries and server-side conflict resolution for another model without them interfering with each other.
 :::
 
-## Example of Issuing Delta Query
+## Example of Issuing a Delta Query
 
 Delta Queries remain the same but with the addition of a `_version` field as outlined in the above sections:
 
@@ -259,6 +259,5 @@ No conflict will occur, even if the version field is out-of-date because the `ti
   }
 }
 ```
-
 
 

--- a/docs/datasync/conflict-resolution-intro.md
+++ b/docs/datasync/conflict-resolution-intro.md
@@ -126,7 +126,7 @@ An example entry in the delta table would look as follows:
 }
 ```
 
-To improve efficiency of queries on the `delta` table, a `deltaTTL` argument (in seconds) is used along with a MongoDB TTL Index to prune older entries from the delta table. In the current configuration, a default strategy of `ClientSideWins` is used. Please check the [docs](conflict-resolution-strategies.md) for more information on using different strategies as well as implementing custom Conflict Resolution strategies.
+To improve efficiency of queries on the `delta` table, a `deltaTTL` argument (in seconds) is used along with a MongoDB TTL Index to prune older entries from the delta table. In the current configuration, a default strategy of `ClientSideWins` is used. Please check the [Conflict Resolution Strategies](conflict-resolution-strategies.md) documentation for more information on using different strategies as well as implementing custom Conflict Resolution strategies.
 
 :::note
 You may only have delta queries for one model while having both delta queries and server-side conflict resolution for another model without them interfering with each other.
@@ -259,5 +259,4 @@ No conflict will occur, even if the version field is out-of-date because the `ti
   }
 }
 ```
-
 

--- a/docs/datasync/delta-queries.md
+++ b/docs/datasync/delta-queries.md
@@ -32,7 +32,7 @@ type Comment {
 }
 ```
 
-The `@datasync` annotation is used infer if a given model requires Delta Queries. If your business logic requires delete mutations, @datasync also ensures that deleted objects are maintained in the database for a given amount of time. This can either be specified by the *optional* `ttl` argument (given in seconds) otherwise defaults to a duration of 2 days (or 172800 seconds) This is done so clients can be informed about deletions in a delta query. The items are eventually deleted using a MongoDB TTL Index.
+The `@datasync` annotation is used infer if a given model requires Delta Queries. If your business logic requires delete mutations, `@datasync` also ensures that deleted objects are maintained in the database for a given amount of time. This can either be specified by the *optional* `ttl` argument (given in seconds) otherwise defaults to a duration of 2 days (or 172800 seconds) This is done so clients can be informed about deletions in a delta query. The items are eventually deleted using a MongoDB TTL Index.
 
 In the default configuration, `@datasync` transforms your model by adding a `_lastUpdatedAt` field to it:
 

--- a/docs/datasync/delta-queries.md
+++ b/docs/datasync/delta-queries.md
@@ -21,7 +21,9 @@ Add the `@datasync` annotation to your model(s) in your GraphQL SDL found in the
 ```graphql {3}
 """ 
 @model
-@datasync
+@datasync(
+  ttl: 5184000
+)
 """
 type Comment {
   _id: GraphbackObjectID!
@@ -30,14 +32,16 @@ type Comment {
 }
 ```
 
-The `@datasync` annotation is used infer if a given model requires Delta Queries.
+The `@datasync` annotation is used infer if a given model requires Delta Queries. If your business logic requires delete mutations, you must specify the `ttl` argument of the `@datasync` annotation as this ensures that deleted objects are maintained in the database for a given amount of time (`ttl` is specified in seconds), before being permanently deleted. This is done so clients can be informed about deletions in a delta query. The items are eventually deleted using a MongoDB TTL Index.
 
 In the default configuration, `@datasync` transforms your model by adding a `_lastUpdatedAt` field to it:
 
 ```graphql {9}
 """ 
 @model
-@datasync 
+@datasync(
+  ttl: 5184000
+)
 """
 type Comment {
   _id: GraphbackObjectID!

--- a/docs/datasync/delta-queries.md
+++ b/docs/datasync/delta-queries.md
@@ -32,7 +32,7 @@ type Comment {
 }
 ```
 
-The `@datasync` annotation is used infer if a given model requires Delta Queries. If your business logic requires delete mutations, you must specify the `ttl` argument of the `@datasync` annotation as this ensures that deleted objects are maintained in the database for a given amount of time (`ttl` is specified in seconds), before being permanently deleted. This is done so clients can be informed about deletions in a delta query. The items are eventually deleted using a MongoDB TTL Index.
+The `@datasync` annotation is used infer if a given model requires Delta Queries. If your business logic requires delete mutations, @datasync also ensures that deleted objects are maintained in the database for a given amount of time. This can either be specified by the *optional* `ttl` argument (given in seconds) otherwise defaults to a duration of 2 days (or 172800 seconds) This is done so clients can be informed about deletions in a delta query. The items are eventually deleted using a MongoDB TTL Index.
 
 In the default configuration, `@datasync` transforms your model by adding a `_lastUpdatedAt` field to it:
 

--- a/packages/graphback-datasync/src/providers/DatasyncMongoDBDataProvider.ts
+++ b/packages/graphback-datasync/src/providers/DatasyncMongoDBDataProvider.ts
@@ -29,8 +29,9 @@ export class DataSyncMongoDBDataProvider<Type = any> extends MongoDBDataProvider
     });
     const DataSyncAnnotationData = getDataSyncAnnotationData(model);
     this.TTLinSeconds = parseInt(DataSyncAnnotationData.ttl, 10);
-    if (model.crudOptions.delete && isNaN(this.TTLinSeconds)) {
-      throw Error(`TTL for model:"${model.graphqlType.name}" not found in the schema`);
+    if (isNaN(this.TTLinSeconds)) {
+      // Default TTL of 2 days
+      this.TTLinSeconds = 172800
     }
     this.coerceTSFields = true;
   }

--- a/packages/graphback-datasync/src/providers/DatasyncMongoDBDataProvider.ts
+++ b/packages/graphback-datasync/src/providers/DatasyncMongoDBDataProvider.ts
@@ -29,7 +29,7 @@ export class DataSyncMongoDBDataProvider<Type = any> extends MongoDBDataProvider
     });
     const DataSyncAnnotationData = getDataSyncAnnotationData(model);
     this.TTLinSeconds = parseInt(DataSyncAnnotationData.ttl, 10);
-    if (isNaN(this.TTLinSeconds)) {
+    if (model.crudOptions.delete && isNaN(this.TTLinSeconds)) {
       throw Error(`TTL for model:"${model.graphqlType.name}" not found in the schema`);
     }
     this.coerceTSFields = true;

--- a/packages/graphback-datasync/tests/DataSyncMongoDBTests.ts
+++ b/packages/graphback-datasync/tests/DataSyncMongoDBTests.ts
@@ -129,6 +129,31 @@ describe('Soft deletion test', () => {
     expect(deletedPost[DataSyncFieldNames.ttl] instanceof Date).toEqual(true);
   })
 
+  it('can function without specified TTL when delete mutations are disabled', async () => {
+    context = await createTestingContext(`
+    """
+    @model(
+      delete: false
+    )
+    @datasync
+    """
+    type Post {
+      _id: GraphbackObjectID!
+      text: String
+      description: String
+    }
+
+    scalar GraphbackObjectID
+    `);
+
+    const { Post } = context.providers;
+    await Post.create({ text: 'TestPost' }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.lastUpdatedAt]}}});
+
+    // check count
+    const count = await Post.count({});
+    expect(count).toEqual(1);
+  })
+
   it('cannot update a deleted document', async () => {
     context = await createTestingContext(postSchema);
 


### PR DESCRIPTION
Some minor fixes for DataSync as well as updated docs for TTL

Fixes #1890 

## Fixes
- [x] Make TTL optional
- [x] Ensure to throw NoDataError when server side document cannot be fetched
- [x] Ensure to throw Conflict Error when base document cannot be found
- [x] add TTL to docs