### PR TITLE
feat(graphqlserve): add conflicts to --datasync

### DIFF
--- a/docs/graphqlserve/graphqlserve.md
+++ b/docs/graphqlserve/graphqlserve.md
@@ -107,6 +107,21 @@ Once we have a model with datasync capabilities, we can run our GraphQL server b
 ```bash
 gqlserve serve Note.graphql --datasync
 ```
+
+Conflict resolution strategies for datasync enabled models can be specified via the --conflict option:
+
+```bash
+gqlserve serve Note.graphql --datasync --conflict=clientSideWins
+```
+
+This defaults to ClientSideWins, if unset.
+
+The TTL for delta tables, can also be set using the --deltaTTL option:
+```bash
+gqlserve serve Note.graphql --datasync --deltaTTL=172800
+```
+
+This value defaults to `172800` when unused
  
 ### Printing your GraphQL schema
 

--- a/packages/graphback-datasync/src/util.ts
+++ b/packages/graphback-datasync/src/util.ts
@@ -1,9 +1,14 @@
 import { ModelDefinition, GraphbackCRUDService, GraphbackOperationType } from '@graphback/core';
 import { parseMetadata } from 'graphql-metadata';
+import { GraphQLObjectType } from 'graphql';
 import { DataSyncCRUDService } from "./services";
 
 export function isDataSyncModel(model: ModelDefinition): boolean {
-  return !!(parseMetadata('datasync', model.graphqlType))
+  return isDataSyncType(model.graphqlType);
+}
+
+export function isDataSyncType(graphqlType: GraphQLObjectType) {
+  return !!(parseMetadata('datasync', graphqlType))
 }
 
 export function getDataSyncAnnotationData(model: ModelDefinition): any {

--- a/packages/graphql-serve/src/GraphbackServer.ts
+++ b/packages/graphql-serve/src/GraphbackServer.ts
@@ -4,7 +4,7 @@ import * as getPort from "get-port";
 import * as cors from "cors";
 import * as express from "express";
 import * as http from "http";
-import { createRuntime, createMongoDBClient } from './runtime';
+import { createRuntime, createMongoDBClient, DataSyncServeConfig } from './runtime';
 import { MongoClient } from 'mongodb';
 import { GraphbackDataProvider, GraphbackCRUDService } from 'graphback';
 
@@ -100,7 +100,7 @@ export class GraphbackServer {
   }
 }
 
-export async function buildGraphbackServer(modelDir: string, enableDataSync: boolean): Promise<GraphbackServer> {
+export async function buildGraphbackServer(modelDir: string, dataSyncServeConfig: DataSyncServeConfig): Promise<GraphbackServer> {
   const app = express();
 
   app.use(cors());
@@ -108,7 +108,7 @@ export async function buildGraphbackServer(modelDir: string, enableDataSync: boo
   const dbClient = await createMongoDBClient();
   const db = dbClient.db('test')
 
-  const { typeDefs, resolvers, contextCreator } = await createRuntime(modelDir, db, enableDataSync);
+  const { typeDefs, resolvers, contextCreator } = await createRuntime(modelDir, db, dataSyncServeConfig);
 
   const apolloConfig = {
     typeDefs,

--- a/packages/graphql-serve/src/commands/serve.ts
+++ b/packages/graphql-serve/src/commands/serve.ts
@@ -1,7 +1,5 @@
 import yargs from 'yargs';
-import { serveHandler } from '../components/serveHandler';
-
-type Params = { model?: string, port?: number, datasync: boolean };
+import { serveHandler, GraphQLServeParams } from '../components/serveHandler';
 
 export const command = 'serve [modelDir] [options]';
 
@@ -25,9 +23,20 @@ export const builder = (args: yargs.Argv): void => {
     type: 'boolean',
     alias: 'ds'
   })
+
+  args.option('conflict', {
+    describe:"Specify a conflict resolution strategy with --datasync",
+    type: 'string',
+    choices: ["clientSideWins", "serverSideWins"]
+  })
+
+  args.option('deltaTTL', {
+    describe: "Specify a TTL for delta tables with --datasync",
+    type: "number"
+  })
   args.example('$0 serve . -p 8080', 'generate schema from data model files in current directory and start GraphQL server on port 8080')
 }
 
-export async function handler(args: Params): Promise<void> {
+export async function handler(args: GraphQLServeParams): Promise<void> {
   await serveHandler(args);
 }

--- a/packages/graphql-serve/src/components/serveHandler.ts
+++ b/packages/graphql-serve/src/components/serveHandler.ts
@@ -1,7 +1,11 @@
 import { buildGraphbackServer, GraphbackServer } from "../GraphbackServer";
+import { ConflictResolutionStrategyName, DataSyncServeConfig } from "../runtime";
 
-export const serveHandler = async (argv: { model?: string, port?: number, datasync }): Promise<GraphbackServer> => {
-  const server = await buildGraphbackServer(argv.model, !!argv.datasync);
+export type GraphQLServeParams = { model?: string, port?: number, datasync: boolean, conflict?: ConflictResolutionStrategyName, deltaTTL?: number };
+
+export const serveHandler = async (argv: GraphQLServeParams): Promise<GraphbackServer> => {
+  const datasyncServeConfig: DataSyncServeConfig = { datasync: !!argv.datasync, conflict: argv.conflict, deltaTTL: argv.deltaTTL}
+  const server = await buildGraphbackServer(argv.model, datasyncServeConfig);
 
   if ('port' in argv) {
     const portNumber = argv.port;

--- a/packages/graphql-serve/src/runtime.ts
+++ b/packages/graphql-serve/src/runtime.ts
@@ -1,12 +1,20 @@
 
-import { GraphbackAPI, buildGraphbackAPI } from 'graphback'
+import { GraphbackAPI, buildGraphbackAPI, filterModelTypes } from 'graphback'
 import { createMongoDbProvider } from '@graphback/runtime-mongo'
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { MongoClient, Db } from 'mongodb';
 import { loadModel } from './loadModel';
-import { GraphQLSchema } from 'graphql';
-import { DataSyncPlugin, createDataSyncMongoDbProvider, createDataSyncCRUDService } from "@graphback/datasync"
-import { PubSub } from 'graphql-subscriptions';
+import { GraphQLSchema, GraphQLObjectType } from 'graphql';
+import { createDataSyncAPI, DataSyncModelConfigMap, ClientSideWins, ServerSideWins, ConflictResolutionStrategy, isDataSyncType } from "@graphback/datasync"
+
+
+export type ConflictResolutionStrategyName = "clientSideWins"|"serverSideWins";
+
+export interface DataSyncServeConfig {
+  datasync: boolean,
+  conflict?: ConflictResolutionStrategyName,
+  deltaTTL?: number
+}
 
 export interface Runtime {
   schema: GraphQLSchema;
@@ -25,19 +33,48 @@ export const createMongoDBClient = async (): Promise<MongoClient> => {
   return client
 }
 
+export function getConflictMapForModels(model: GraphQLSchema, conflictResolutionStrategy: ConflictResolutionStrategy, deltaTTL: number): DataSyncModelConfigMap {
+  const map: DataSyncModelConfigMap = {};
+
+  const dataSyncModelTypes = filterModelTypes(model).filter(isDataSyncType);
+
+  dataSyncModelTypes.forEach((type: GraphQLObjectType) => {
+    map[type.name] = {
+      enabled: true,
+      deltaTTL: deltaTTL,
+      conflictResolution: conflictResolutionStrategy
+    }
+  })
+
+  return map
+}
+
 /**
  * Method used to create runtime schema
  * It will be part of the integration tests
  */
-export const createRuntime = async (modelDir: string, db: Db, datasync: boolean): Promise<GraphbackAPI> => {
+export const createRuntime = async (modelDir: string, db: Db, datasyncServeConfig: DataSyncServeConfig): Promise<GraphbackAPI> => {
   const model = await loadModel(modelDir);
 
   let graphbackAPI;
-  if (datasync) {
-    graphbackAPI = buildGraphbackAPI(model, {
-      serviceCreator: createDataSyncCRUDService({ pubSub: new PubSub() }),
-      dataProviderCreator: createDataSyncMongoDbProvider(db),
-      plugins: [new DataSyncPlugin()]
+  if (datasyncServeConfig.datasync) {
+    let conflictResolutionStrategy = ClientSideWins;
+    let deltaTTL = 172800;
+    if (datasyncServeConfig.conflict === "clientSideWins") {
+      conflictResolutionStrategy = ClientSideWins;
+    }
+    if (datasyncServeConfig.conflict === "serverSideWins") {
+      conflictResolutionStrategy = ServerSideWins;
+    }
+
+    if (datasyncServeConfig.deltaTTL !== undefined && datasyncServeConfig.deltaTTL !== null) {
+      deltaTTL = datasyncServeConfig.deltaTTL
+    }
+    const modelConflictMap = getConflictMapForModels(model, conflictResolutionStrategy, deltaTTL);
+
+    graphbackAPI = createDataSyncAPI(model, {
+      db,
+      dataSyncConflictMap: modelConflictMap
     })
 
   } else {


### PR DESCRIPTION
This PR adds conflicts to --datasync option of graphql serve with default strategy of clientsidewins which can be overridden by the --conflict=client or --conflict=server option