### PR TITLE
Install knex as a peer dependency

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,6 +12,8 @@ Please follow individual releases for more information.
 
 ### New Features
 
+* Use any `knex` 0.20.x or 0.21.x version in your application ([d826b6f](https://github.com/aerogear/graphback/commit/d826b6fcb3ffb753140f5135d53c56c032cb2503)[#1903](https://github.com/aerogear/graphback/pull/1903))
+
 * Ability to specify composite unique columns in GraphQL Migrations ([#1658](https://github.com/aerogear/graphback/issues/1658)), fixed by ([9c6f34a231e2645c34533d58ea4427ff8f8f634e](https://github.com/aerogear/graphback/commit/9c6f34a231e2645c34533d58ea4427ff8f8f634e))
 
 * Requiring `_id: GraphbackObjectID` primary key for MongoDB ([#1769](https://github.com/aerogear/graphback/pull/1769)). 

--- a/packages/graphback-runtime-knex/package.json
+++ b/packages/graphback-runtime-knex/package.json
@@ -39,10 +39,10 @@
   "dependencies": {
     "@graphback/core": "0.15.1",
     "dataloader": "2.0.0",
-    "graphql-subscriptions": "1.1.0",
-    "knex": "0.21.4"
+    "graphql-subscriptions": "1.1.0"
   },
   "peerDependencies": {
+    "knex": "0.20.x || 0.21.x",
     "graphql": "^14.0.0 || ^15.0.0"
   }
 }

--- a/packages/graphql-migrations/package.json
+++ b/packages/graphql-migrations/package.json
@@ -22,7 +22,6 @@
     "chalk": "3.0.0",
     "glob": "7.1.6",
     "graphql-metadata": "0.7.3",
-    "knex": "0.21.4",
     "lodash": "4.17.20",
     "lodash-es": "4.17.15",
     "node-emoji": "1.10.0",
@@ -44,6 +43,7 @@
     "typescript": "3.9.7"
   },
   "peerDependencies": {
+    "knex": "0.20.x || 0.21.x",
     "graphql": "^14.0.0 || ^15.0.0"
   },
   "engines": {


### PR DESCRIPTION
Resolves #1640

### Verification

To verify, you will want a template outside of this monorepo.

Install Graphback to the project like so:

```
"dependencies": {
  "@graphback/runtime-knex": "/home/username/code/aerogear/graphback/packages/graphback-runtime-knex"
}
```

Now, you can change your Knex version to anything in 0.20.x || 0.21.x and your application will run and you can perform database calls.