### PR TITLE
feat(resolvers): allow resolving relationship field directly without hitting the database

### DIFF
--- a/integration/mongodb-model.graphql
+++ b/integration/mongodb-model.graphql
@@ -43,6 +43,7 @@ type Task {
 
 type Query {
   helloWorld: String
+  getNoteWithFullDataSet: Note
 }
 
 scalar GraphbackTimestamp

--- a/integration/postgres-model.graphql
+++ b/integration/postgres-model.graphql
@@ -42,7 +42,8 @@ type Task {
 }
 
 type Query {
-  helloWorld: String
+  helloWorld: String,
+  getNoteWithFullDataSet: Note
 }
 
 scalar GraphbackTimestamp

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -694,6 +694,10 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const model = modelNameToModelDefinition[modelName];
 
     resolverObj[relationOwner] = (parent: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
+      if (parent[relationOwner]) {
+        return parent[relationOwner];
+      }
+
       if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
@@ -727,8 +731,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const relationOwner = relationship.ownerField.name;
     const model = modelNameToModelDefinition[modelName];
 
-    // construct a unique key to identify the dataloader
     resolverObj[relationOwner] = (parent: any, _: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
+      if (parent[relationOwner]) {
+        return parent[relationOwner];
+      }
+
       if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
@@ -739,6 +746,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
 
       const fetchedKeys = selectedFields.join('-');
 
+      // construct a unique key to identify the dataloader
       const dataLoaderName = `${modelName}-${relationship.kind}-${relationIdField.name}-${relationship.relationForeignKey}-${fetchedKeys}-DataLoader`;
 
       if (!context[dataLoaderName]) {


### PR DESCRIPTION

When the parent object contains the relationship field, it is more interesting to resolve it
directly without hitting the database. This gives user an ability to write custom resolvers that
fetch full dataset in whatever way they wish e.g via join statements and having that data returned
directly without querying again the database to resolve relationship field

Resolves https://github.com/aerogear/graphback/issues/1925