### PR TITLE
chore: make the benchmark package private to avoid publishing it

### DIFF
--- a/performance/package.json
+++ b/performance/package.json
@@ -1,6 +1,7 @@
 {
   "name": "graphback-benchmarks",
   "version": "0.15.1",
+  "private": true,
   "description": "Benchmarks for Graphback, a fast and low-overhead web framework.",
   "scripts": {
     "start": "yarn bench && yarn compare:stats",


### PR DESCRIPTION
The package was published as https://www.npmjs.com/package/graphback-benchmarks, let's make it
private to avoid such cases.