### PR TITLE
fix(schema-plugin): make sure that "null"/"undefined" relationship values are considered resolved

### DIFF
--- a/integration/tests/runtime-workflow-mongo.ts
+++ b/integration/tests/runtime-workflow-mongo.ts
@@ -49,6 +49,20 @@ const customNoteWithFullDataSet = {
       opened: true
     },
     ratings: [3, 9, 10]
+  },
+  {
+    _id: objectId.toHexString(),
+    text: "text",
+    description: "second-comment-description",
+    metadata: null, // this should resolve to null
+    ratings: [3, 9, 10]
+  },
+  {
+    _id: objectId.toHexString(),
+    text: "text",
+    description: "third-comment-description",
+    metadata: undefined, // this should resolve to null
+    ratings: [3, 9, 10]
   }]
 };
 
@@ -556,6 +570,7 @@ test('Delete Note 1', async () => {
 
 test('get full dataset from custom query without querying the database again', async () => {
   const { data } = await client.query({ operationName:"getNoteWithFullDataSet", query: GET_NOTE_WITH_CUSTOM_QUERY });
+  customNoteWithFullDataSet.comments[2].metadata = null;
   expect(data.getNoteWithFullDataSet).toEqual(customNoteWithFullDataSet);
 })
 

--- a/integration/tests/runtime-workflow-postgres.ts
+++ b/integration/tests/runtime-workflow-postgres.ts
@@ -47,6 +47,20 @@ const customNoteWithFullDataSet = {
       opened: true
     },
     ratings: [3, 9, 10]
+  },
+  {
+    id: "1",
+    text: "text",
+    description: "second-comment-description",
+    metadata: null, // this should resolve to null
+    ratings: [3, 9, 10]
+  },
+  {
+    id: "2",
+    text: "text",
+    description: "third-comment-description",
+    metadata: undefined, // this should resolve to null
+    ratings: [3, 9, 10]
   }]
 };
 
@@ -610,6 +624,7 @@ test('getComment in simultaneous with different resolvers pinfo', async () => {
 
 test('get full dataset from custom query without querying the database again', async () => {
   const { data } = await client.query({ operationName:"getNoteWithFullDataSet", query: GET_NOTE_WITH_CUSTOM_QUERY });
+  customNoteWithFullDataSet.comments[2].metadata = null;
   expect(data.getNoteWithFullDataSet).toEqual(customNoteWithFullDataSet);
 })
 

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -694,7 +694,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const model = modelNameToModelDefinition[modelName];
 
     resolverObj[relationOwner] = (parent: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      if (parent[relationOwner]) {
+      if (Object.keys(parent).includes(relationOwner)) {
         return parent[relationOwner];
       }
 
@@ -732,7 +732,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const model = modelNameToModelDefinition[modelName];
 
     resolverObj[relationOwner] = (parent: any, _: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      if (parent[relationOwner]) {
+      if (Object.keys(parent).includes(relationOwner)) {
         return parent[relationOwner];
       }
 


### PR DESCRIPTION
Improve the condition that checked if parent object has the relationship resolved. This also take
care of when the relationship field is "undefined" or "null". With the previous check, we'll query
the database again which seemed wrong. I've added a some data values in the previous tests.

Related to https://github.com/aerogear/graphback/pull/1933 and
https://github.com/aerogear/graphback/pull/1925