### PR TITLE
Pass context and info to CRUD service, which will handle selected fields, aggregations etc.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -173,6 +173,25 @@
       "windows": {
         "program": "${workspaceFolder}/node_modules/jest/bin/jest",
       }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Integration Test File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": [
+        "--runInBand"
+      ],
+      "env": {
+        "PORT": "55432"
+      },
+      "cwd": "${workspaceFolder}/integration",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      }
     }
   ]
 }

--- a/docs/plugins/creating-your-own-plugin.md
+++ b/docs/plugins/creating-your-own-plugin.md
@@ -133,22 +133,14 @@ export class MyGraphbackPlugin extends GraphbackPlugin {
         const crudService = context.graphback.services[modelName];
 
         // create a filter in the GraphQLCRUD format to retrieve only archived Notes
-        const filter: QueryFilter = {
+        const customFilter: QueryFilter = {
           archived: {
             eq: true
           }
         };
 
-        // retrieve user selected fields from GraphQLResolveInfo which will be used to query the database for specific fields
-        // avoiding overfetching. This is optional, as passing just the context to the database query will retrieve all fields.
-        const selectedFields = getSelectedFieldsFromResolverInfo(info, model);
-        const graphback = {
-          services: context.graphback.services,
-          options: { selectedFields }
-        };
-
         // use the model service created by Graphback to query the database
-        const { items } = await crudService.findBy(filter, { ...context, graphback });
+        const { items } = await crudService.findBy({ filter: customFilter });
 
         return items;
       }

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -59,7 +59,7 @@ See [Graphback Scalars](https://graphback.dev/docs/model/scalars/) for the list 
 
 ```patch
 - findBy(filter: QueryFilter<Type>, context: GraphbackContext, page?: GraphbackPage, orderBy?: any): Promise<ResultList<Type>>;
-+ findBy(args?: FindByArgs, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<ResultList<Type>>;
++ findBy(args?: FindByArgs, context?: GraphbackContext, info?: GraphQLResolveInfo, path?: string): Promise<ResultList<Type>>;
 ```
 
 **args**
@@ -83,7 +83,7 @@ await noteService.findBy({
 })
 ```
 
-**context**
+**context (optional)**
 
 The context parameter is now optional.
 
@@ -94,6 +94,24 @@ You can now optionally pass the `GraphQLResolveInfo` info object to the CRUD ser
 ```ts
 await noteService.findBy(filter, context, info);
 ```
+
+**path (optional)**
+
+The root path of the query to get the selected fields from. For example, to get `id`, `title`, `description` fields from the following query, you would set the path to `items`.
+
+```graphql
+query findNotes {
+  findNotes {
+    items {
+      id
+      title
+      description
+    }
+  }
+} 
+```
+
+The path variable is optional, as it will automatically resolve to the root field of the entire query.
 
 #### `context` parameter removed from `subscribeToCreate`, `subscribeToDelete`, `subscribeToUpdate` methods in GraphbackCRUDService.
 
@@ -133,7 +151,7 @@ await noteService.findBy({
 
 #### Remove resolver options from GraphbackContext
 
-Resolver options was removed from the context because the `count` aggregation and `selectedFields` extraction logic was moved to the CRUDService method.
+Resolver options (`context.graphback.options`) was removed from the context because the `count` aggregation and `selectedFields` extraction logic was moved to the CRUDService method.
 
 #### CRUDService, DataSyncCRUDService now accepts a `ModelDefinition` as the first constructor parameter.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -55,6 +55,115 @@ See [Graphback Scalars](https://graphback.dev/docs/model/scalars/) for the list 
 
 * Replace `@db(skip: true)` field annotation with `@transient` [85d50f3c](https://github.com/aerogear/graphback/commit/85d50f3c332ee35c46fbe8e6c3e81d97ae60db7b)
 
+#### Changed GraphbackCRUDService `findBy` method signature. This also applies to all services that implement this interface.
+
+```patch
+- findBy(filter: QueryFilter<Type>, context: GraphbackContext, page?: GraphbackPage, orderBy?: any): Promise<ResultList<Type>>;
++ findBy(args?: FindByArgs, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<ResultList<Type>>;
+```
+
+**args**
+
+`findBy` now accepts a new interface, `FindByArgs`, which wraps the `filter`, `page` and `orderBy` optional arguments.
+
+```ts
+await noteService.findBy({
+  filter: {
+    id: {
+      gt: 100
+    }
+  },
+  page: {
+    offset: 0,
+    limit: 10
+  },
+  orderBy: {
+    field: 'id'
+  }
+})
+```
+
+**context**
+
+The context parameter is now optional.
+
+**info**
+
+You can now optionally pass the `GraphQLResolveInfo` info object to the CRUD service, to perform extra optimizations like retrieving only the selected fields from the query.
+
+```ts
+await noteService.findBy(filter, context, info);
+```
+
+#### `context` parameter removed from `subscribeToCreate`, `subscribeToDelete`, `subscribeToUpdate` methods in GraphbackCRUDService.
+
+This method was unused.
+
+#### Removed `context` parameter from all GraphbackDataProvider methods. This also applies to all providers that implement this interface.
+
+All CRUD methods in `GraphbackDataProvider` had a `context` parameter used to get the selected fields. 
+These have been replaced with (optional) `selectedFields` - you can pass a string array of the fields you want to select from the database.
+
+```ts
+await noteProvider.findBy(filter, ['id', 'name']);
+```
+
+#### Changed GraphbackDataProvider `findBy` method signature. This also applies to all providers that implement this interface.
+
+**args**
+
+`findBy` now accepts a new interface, `FindByArgs`, which wraps the `filter`, `page` and `orderBy` optional arguments.
+
+```ts
+await noteService.findBy({
+  filter: {
+    id: {
+      gt: 100
+    }
+  },
+  page: {
+    offset: 0,
+    limit: 10
+  },
+  orderBy: {
+    field: 'id'
+  }
+})
+```
+
+#### Remove resolver options from GraphbackContext
+
+Resolver options was removed from the context because the `count` aggregation and `selectedFields` extraction logic was moved to the CRUDService method.
+
+#### CRUDService, DataSyncCRUDService now accepts a `ModelDefinition` as the first constructor parameter.
+
+To instantiate a CRUDService you must pass the full `ModelDefinition` instead of the model name.
+
+```ts
+const myService = new CRUDService(modelDefinition, ...);
+```
+
+#### KeycloakCrudService now accepts a `ModelDefinition` as the first constructor parameter.
+
+To instantiate a CRUDService you must pass the full `ModelDefinition` instead of the model name.
+
+```ts
+const myService = new KeycloakCrudService(modelDefinition, ...);
+```
+
+#### DataSyncProvider `sync` method signature has been changed
+
+```patch
+- sync(lastSync: Date, context: GraphbackContext, filter?: any, limit?: number): Promise<Type[]>;
++ sync(lastSync: Date, selectedFields?: string[], filter?: QueryFilter, limit?: number): Promise<Type[]>;
+```
+
+The `context` argument has been replaced with (optional) `selectedFields`.
+
+#### `context` parameter is removed from the `create` method in `MongoDBDataProvider` and `DatasyncMongoDBDataProvider` providers.
+
+This parameter did not do anything.
+
 # 0.15.1
 
 ### Bug Fixes

--- a/integration/tests/runtime-workflow-mongo.ts
+++ b/integration/tests/runtime-workflow-mongo.ts
@@ -95,6 +95,25 @@ query getNoteWithFullDataSet {
     }
 }`;
 
+const FIND_NOTES_WITH_COUNT = gql`
+query findNotes {
+  findNotes {
+    items {
+      _id
+    }
+    count
+  }
+}`;
+
+const FIND_NOTES_WITHOUT_COUNT = gql`
+query findNotes {
+  findNotes {
+    items {
+      _id
+    }
+  }
+}`;
+
 beforeAll(async () => {
   try {
     mkdirSync("./output-mongo");
@@ -194,8 +213,8 @@ async function seedDatabase(db: Db) {
       description: 'Note A Comment Description',
       createdAt,
       objectId,
-      noteId:  notesId[0],
-      metadataId:  metadataId[0],
+      noteId: notesId[0],
+      metadataId: metadataId[0],
       ratings: [4, 4, 5, 2]
     },
     {
@@ -204,8 +223,8 @@ async function seedDatabase(db: Db) {
       createdAt,
       objectId,
       ratings: null,
-      noteId:  notesId[0],
-      metadataId:  metadataId[1]
+      noteId: notesId[0],
+      metadataId: metadataId[1]
     }
   ]
 
@@ -221,14 +240,14 @@ test('Find all notes', async () => {
   expect(data.findNotes).toEqual({
     items: [
       {
-        _id:  notesId[0],
+        _id: notesId[0],
         createdAt,
         title: 'Note A',
         description: 'Note A Description',
         tasks: [],
         comments: [
           {
-            _id:  commentId[0],
+            _id: commentId[0],
             objectId,
             createdAt: createdAt.getTime(),
             text: 'Note A Comment',
@@ -236,7 +255,7 @@ test('Find all notes', async () => {
             ratings: [4, 4, 5, 2]
           },
           {
-            _id:  commentId[1],
+            _id: commentId[1],
             objectId,
             createdAt: createdAt.getTime(),
             text: 'Note A Comment 2',
@@ -246,7 +265,7 @@ test('Find all notes', async () => {
         ]
       },
       {
-        _id:  notesId[1],
+        _id: notesId[1],
         title: 'Note B',
         createdAt,
         description: 'Note B Description',
@@ -267,6 +286,26 @@ test('Find all notes', async () => {
   })
 })
 
+test('Find all notes with count', async () => {
+  const { data } = await client.query({
+    operationName: 'findNotes',
+    query: FIND_NOTES_WITH_COUNT
+  })
+
+  expect(data).toBeDefined()
+  expect(data.findNotes.count).toBeDefined()
+})
+
+test('Find all notes without count', async () => {
+  const { data } = await client.query({
+    operationName: 'findNotes',
+    query: FIND_NOTES_WITHOUT_COUNT
+  })
+
+  expect(data).toBeDefined()
+  expect(data.findNotes.count).toBeUndefined()
+})
+
 test('Find all notes except the first', async () => {
   const { data } = await client.query({
     operationName: 'findNotes',
@@ -278,7 +317,7 @@ test('Find all notes except the first', async () => {
   expect(data.findNotes).toEqual({
     items: [
       {
-        _id:  notesId[1],
+        _id: notesId[1],
         createdAt,
         title: 'Note B',
         description: 'Note B Description',
@@ -310,14 +349,14 @@ test('Find at most one note', async () => {
   expect(data.findNotes).toEqual({
     items: [
       {
-        _id:  notesId[0],
+        _id: notesId[0],
         createdAt,
         title: 'Note A',
         description: 'Note A Description',
         tasks: [],
         comments: [
           {
-            _id:  commentId[0],
+            _id: commentId[0],
             objectId,
             createdAt: createdAt.getTime(),
             text: 'Note A Comment',
@@ -325,7 +364,7 @@ test('Find at most one note', async () => {
             ratings: [4, 4, 5, 2]
           },
           {
-            _id:  commentId[1],
+            _id: commentId[1],
             objectId,
             createdAt: createdAt.getTime(),
             text: 'Note A Comment 2',
@@ -348,38 +387,38 @@ test('Find all comments', async () => {
   expect(data.findComments).toEqual({
     items: [
       {
-        _id:  commentId[0],
+        _id: commentId[0],
         objectId,
         createdAt: createdAt.getTime(),
         text: 'Note A Comment',
         description: 'Note A Comment Description',
         ratings: [4, 4, 5, 2],
         note: {
-          _id:  notesId[0],
+          _id: notesId[0],
           createdAt,
           title: 'Note A',
           description: 'Note A Description'
         },
         metadata: {
-          _id:  metadataId[0],
+          _id: metadataId[0],
           opened: true
         }
       },
       {
-        _id:  commentId[1],
+        _id: commentId[1],
         objectId,
         createdAt: createdAt.getTime(),
         text: 'Note A Comment 2',
         description: 'Note A Comment Description',
         ratings: null,
         note: {
-          _id:  notesId[0],
+          _id: notesId[0],
           createdAt,
           title: 'Note A',
           description: 'Note A Description'
         },
         metadata: {
-          _id:  metadataId[1],
+          _id: metadataId[1],
           opened: false
         }
       }
@@ -391,51 +430,53 @@ test('Find all comments', async () => {
 })
 
 test('filter comments using built in scalars', async () => {
-  const { data } = await client.query({ operationName: "findComments", query: documents,
-  variables: {
-    filter: {
-      createdAt: {
-        eq: createdAt.getTime()
+  const { data } = await client.query({
+    operationName: "findComments", query: documents,
+    variables: {
+      filter: {
+        createdAt: {
+          eq: createdAt.getTime()
+        }
       }
     }
-  } });
+  });
 
   expect(data).toBeDefined();
   expect(data.findComments).toEqual({
     items: [
       {
-        _id:  commentId[0],
+        _id: commentId[0],
         createdAt: createdAt.getTime(),
         objectId,
         text: 'Note A Comment',
         description: 'Note A Comment Description',
         ratings: [4, 4, 5, 2],
         note: {
-          _id:  notesId[0],
+          _id: notesId[0],
           createdAt,
           title: 'Note A',
           description: 'Note A Description'
         },
         metadata: {
-          _id:  metadataId[0],
+          _id: metadataId[0],
           opened: true
         }
       },
       {
-        _id:  commentId[1],
+        _id: commentId[1],
         createdAt: createdAt.getTime(),
         objectId,
         text: 'Note A Comment 2',
         description: 'Note A Comment Description',
         ratings: null,
         note: {
-          _id:  notesId[0],
+          _id: notesId[0],
           createdAt,
           title: 'Note A',
           description: 'Note A Description'
         },
         metadata: {
-          _id:  metadataId[1],
+          _id: metadataId[1],
           opened: false
         }
       }
@@ -451,14 +492,14 @@ test('Note 1 should be defined', async () => {
   expect(response.data).toBeDefined();
   const notes = response.data.getNote;
   expect(notes).toEqual({
-    _id:  notesId[0],
+    _id: notesId[0],
     title: 'Note A',
     createdAt,
     description: 'Note A Description',
     tasks: [],
     comments: [
       {
-        _id:  commentId[0],
+        _id: commentId[0],
         createdAt: createdAt.getTime(),
         objectId,
         text: 'Note A Comment',
@@ -466,7 +507,7 @@ test('Note 1 should be defined', async () => {
         ratings: [4, 4, 5, 2]
       },
       {
-        _id:  commentId[1],
+        _id: commentId[1],
         createdAt: createdAt.getTime(),
         objectId,
         text: 'Note A Comment 2',
@@ -481,7 +522,7 @@ test('Find at most one comment on Note 1', async () => {
   const response = await client.query({
     operationName: "findComments",
     query: documents,
-    variables: { filter: { noteId:  { eq: notesId[0] } }, page: { limit: 1 } }
+    variables: { filter: { noteId: { eq: notesId[0] } }, page: { limit: 1 } }
   });
 
   expect(response.data).toBeDefined()
@@ -489,19 +530,19 @@ test('Find at most one comment on Note 1', async () => {
   expect(comments.items).toHaveLength(1);
   expect(comments.items).toEqual([
     {
-      _id:  commentId[0],
+      _id: commentId[0],
       createdAt: createdAt.getTime(),
       objectId,
       text: 'Note A Comment',
       description: 'Note A Comment Description',
       ratings: [4, 4, 5, 2],
       metadata: {
-        _id:  metadataId[0],
+        _id: metadataId[0],
         opened: true,
       },
       note: {
         description: "Note A Description",
-        _id:  notesId[0],
+        _id: notesId[0],
         createdAt,
         title: "Note A",
       },
@@ -513,7 +554,7 @@ test('Find comments on Note 1 except first', async () => {
   const response = await client.query({
     operationName: "findComments",
     query: documents,
-    variables: { filter: { noteId:  { eq: notesId[0] } }, page: { offset: 1 } }
+    variables: { filter: { noteId: { eq: notesId[0] } }, page: { offset: 1 } }
   });
 
   expect(response.data).toBeDefined()
@@ -522,7 +563,7 @@ test('Find comments on Note 1 except first', async () => {
   expect(notes).toEqual({
     items: [
       {
-        _id:  commentId[1],
+        _id: commentId[1],
         createdAt: createdAt.getTime(),
         objectId,
         text: 'Note A Comment 2',
@@ -547,7 +588,7 @@ test('Find comments on Note 1 except first', async () => {
 })
 
 test('Should update Note 1 title', async () => {
-  const response = await updateNote({ _id:  notesId[0], title: 'Note 1 New Title' }, client);
+  const response = await updateNote({ _id: notesId[0], title: 'Note 1 New Title' }, client);
   expect(response.data).toBeDefined();
   expect(response.data.updateNote.title).toBe('Note 1 New Title');
 });
@@ -556,7 +597,7 @@ test('Should create a new Note', async () => {
   const createdAt = new Date();
   const response = await createNote(client, { title: 'New note', createdAt: createdAt.toJSON(), description: 'New note description', tasks: [{ title: "new task title" }] });
   expect(response.data).toBeDefined();
-  expect(response.data.createNote).toEqual({ _id:  response.data.createNote._id, createdAt, title: 'New note', description: 'New note description' });
+  expect(response.data.createNote).toEqual({ _id: response.data.createNote._id, createdAt, title: 'New note', description: 'New note description' });
 
   const { data } = await getNote(response.data.createNote._id, client);
   expect(data.getNote.tasks).toEqual([{ title: "new task title" }]);
@@ -565,11 +606,11 @@ test('Should create a new Note', async () => {
 test('Delete Note 1', async () => {
   const response = await deleteNote(client, notesId[1]);
   expect(response.data).toBeDefined();
-  expect(response.data.deleteNote).toEqual({ _id:  notesId[1], createdAt, description: 'Note B Description', title: 'Note B' });
+  expect(response.data.deleteNote).toEqual({ _id: notesId[1], createdAt, description: 'Note B Description', title: 'Note B' });
 });
 
 test('get full dataset from custom query without querying the database again', async () => {
-  const { data } = await client.query({ operationName:"getNoteWithFullDataSet", query: GET_NOTE_WITH_CUSTOM_QUERY });
+  const { data } = await client.query({ operationName: "getNoteWithFullDataSet", query: GET_NOTE_WITH_CUSTOM_QUERY });
   customNoteWithFullDataSet.comments[2].metadata = null;
   expect(data.getNoteWithFullDataSet).toEqual(customNoteWithFullDataSet);
 })
@@ -593,7 +634,7 @@ async function createNote(client: ApolloServerTestClient, input: any) {
   return response;
 }
 
-async function deleteNote(client: ApolloServerTestClient, _id:  string | number) {
+async function deleteNote(client: ApolloServerTestClient, _id: string | number) {
   const response = await client.mutate({
     operationName: "deleteNote",
     mutation: documents,
@@ -603,7 +644,7 @@ async function deleteNote(client: ApolloServerTestClient, _id:  string | number)
   return response;
 }
 
-async function getNote(id:  string | number, client: ApolloServerTestClient) {
+async function getNote(id: string | number, client: ApolloServerTestClient) {
   const response = await client.query({
     operationName: "getNote",
     query: documents,

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -562,7 +562,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const findField = getFieldName(modelName, GraphbackOperationType.FIND);
 
     queryObj[findField] = async (_: any, args: FindByArgs, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      return context.graphback.services[modelName].findBy(args, context, info)
+      return context.graphback.services[modelName].findBy(args, context, info, 'items')
     }
   }
 

--- a/packages/graphback-core/src/plugin/getSelectedFieldsFromResolverInfo.ts
+++ b/packages/graphback-core/src/plugin/getSelectedFieldsFromResolverInfo.ts
@@ -8,7 +8,7 @@ import { ModelDefinition } from './ModelDefinition';
  * @param model - the model to find the fields from
  * @param path - the root path to start field resolution from.
  */
-export const getSelectedFieldsFromResolverInfo = (info: GraphQLResolveInfo, model: ModelDefinition, path?: string): string[] => {
+export const getSelectedFieldsFromResolverInfo = (info: GraphQLResolveInfo, model: ModelDefinition, path?: string): string[] => {  
   const resolverFields = Object.keys(fieldsMap(info, { path }));
 
   return getModelFieldsFromResolverFields(resolverFields, model);

--- a/packages/graphback-core/src/runtime/CRUDService.ts
+++ b/packages/graphback-core/src/runtime/CRUDService.ts
@@ -105,12 +105,12 @@ export class CRUDService<Type = any> implements GraphbackCRUDService<Type>  {
     return this.db.findOne(args, selectedFields);
   }
 
-  public async findBy(args?: FindByArgs, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<ResultList<Type>> {
+  public async findBy(args?: FindByArgs, context?: GraphbackContext, info?: GraphQLResolveInfo, path?: string): Promise<ResultList<Type>> {
     let selectedFields: string[];
     let requestedCount: boolean = false;
     if (info) {
-      selectedFields = getSelectedFieldsFromResolverInfo(info, this.model, 'items');
-      requestedCount = getResolverInfoFieldsList(info).some((field: string) => field === "count");
+      selectedFields = getSelectedFieldsFromResolverInfo(info, this.model, path);
+      requestedCount = path === 'items' && getResolverInfoFieldsList(info).some((field: string) => field === "count");
     }
 
     const items: Type[] = await this.db.findBy(args, selectedFields);

--- a/packages/graphback-core/src/runtime/GraphbackCRUDService.ts
+++ b/packages/graphback-core/src/runtime/GraphbackCRUDService.ts
@@ -65,8 +65,9 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
    * @param {GraphbackOrderBy} [args.orderBy] - optionally sort the results by a field
    * @param {GraphbackContext} [context] - context object passed from graphql or rest layer
    * @param {GraphQLResolveInfo} [info] - GraphQL query resolver info
+   * @param {string} [path] - Path to a tree branch which should be mapped during fields extraction
    */
-  findBy(args?: FindByArgs, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<ResultList<Type>>;
+  findBy(args?: FindByArgs, context?: GraphbackContext, info?: GraphQLResolveInfo, path?: string): Promise<ResultList<Type>>;
 
   /**
    * Subscription for all creation events

--- a/packages/graphback-core/src/runtime/GraphbackCRUDService.ts
+++ b/packages/graphback-core/src/runtime/GraphbackCRUDService.ts
@@ -1,4 +1,5 @@
-import { GraphbackPage } from './interfaces';
+import { GraphQLResolveInfo } from 'graphql';
+import { FindByArgs } from './interfaces';
 import { QueryFilter } from './QueryFilter';
 
 export interface ResultList<T = any> {
@@ -29,7 +30,7 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
    * @param data input data
    * @param context context object passed from graphql or rest layer
    */
-  create(data: Type, context: GraphbackContext): Promise<Type>;
+  create(data: Type, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<Type>;
 
   /**
    * Implementation for object updates
@@ -37,7 +38,7 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
    * @param data input data including id
    * @param context context object passed from graphql or rest layer
    */
-  update(data: Type, context: GraphbackContext): Promise<Type>;
+  update(data: Partial<Type>, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<Type>;
 
   /**
    * Implementation for object deletes
@@ -45,7 +46,7 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
    * @param data data used for consistency reasons
    * @param context context object passed from graphql or rest layer
    */
-  delete(data: Type, context: GraphbackContext): Promise<Type>;
+  delete(data: Partial<Type>, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<Type>;
 
   /**
    * Fetch a single record by its unique attribute(s)
@@ -53,17 +54,19 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
    * @param filter - the unique attributes to fetch the record with
    * @param context context object from GraphQL/REST layer
    */
-  findOne(filter: Type, context: GraphbackContext): Promise<Type>;
+  findOne(filter: Partial<Type>, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<Type>;
 
   /**
    * Implementation for reading objects with filtering capabilities
-   *
-   * @param filter filter by specific type
-   * @param context context object passed from graphql or rest layer
-   * @param page pagination options
-   * @param orderBy optionally sort the results by a column
+   * 
+   * @param {FindByArgs} [args] - Query arguments
+   * @param {QueryFilter} [args.filter] - GraphQLCRUD filter to query specific data
+   * @param {GraphbackPage} [args.page] - Gagination options
+   * @param {GraphbackOrderBy} [args.orderBy] - optionally sort the results by a field
+   * @param {GraphbackContext} [context] - context object passed from graphql or rest layer
+   * @param {GraphQLResolveInfo} [info] - GraphQL query resolver info
    */
-  findBy(filter: QueryFilter<Type>, context: GraphbackContext, page?: GraphbackPage, orderBy?: any): Promise<ResultList<Type>>;
+  findBy(args?: FindByArgs, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<ResultList<Type>>;
 
   /**
    * Subscription for all creation events
@@ -71,7 +74,7 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
    * @param filter filter used in subscription
    * @param context additional context
    */
-  subscribeToCreate(filter?: any, context?: GraphbackContext): AsyncIterator<Type> | undefined
+  subscribeToCreate(filter?: QueryFilter, context?: GraphbackContext): AsyncIterator<Type> | undefined
 
   /**
    * Subscription for all update events
@@ -79,7 +82,7 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
    * @param filter filter used in subscription
    * @param context additional context
    */
-  subscribeToUpdate(filter?: any, context?: GraphbackContext): AsyncIterator<Type> | undefined
+  subscribeToUpdate(filter?: QueryFilter, context?: GraphbackContext): AsyncIterator<Type> | undefined
 
   /**
    * Subscription for all deletion events
@@ -87,17 +90,17 @@ export interface GraphbackCRUDService<Type = any, GraphbackContext = any> {
    * @param filter filter used in subscription
    * @param context additional context
    */
-  subscribeToDelete(filter?: any, context?: GraphbackContext): AsyncIterator<Type> | undefined
+  subscribeToDelete(filter?: QueryFilter, context?: GraphbackContext): AsyncIterator<Type> | undefined
 
   /**
-   * Speciallized function that can utilize batching the data basing on
+   * Specialized function that can utilize batching the data basing on
    * DataLoader library
-   *
-   * @param context resolver context object that will be used to apply new loader
-   * @param name name of the object we want to load
-   * @param relationField - name of the field that will be used to match ids
-   * @param id id of the object we want to load
-   * @param fields fields to select from datasource
+   * 
+   * @param {string} relationField - name of the field that will be used to match ids
+   * @param {string|number} id - id of the object we want to load
+   * @param {QueryFilter} [filter] - GraphQLCRUD filter object
+   * @param {GraphbackContext} context - resolver context object that will be used to apply new loader
+   * @param {GraphQLResolveInfo} info - GraphQL resolver info
    */
-  batchLoadData(relationField: string, id: string | number, filter: any, context: any);
+  batchLoadData(relationField: string, id: string | number, filter: QueryFilter, context: GraphbackContext, info?: GraphQLResolveInfo);
 }

--- a/packages/graphback-core/src/runtime/GraphbackDataProvider.ts
+++ b/packages/graphback-core/src/runtime/GraphbackDataProvider.ts
@@ -1,4 +1,4 @@
-import { GraphbackPage, GraphbackOrderBy } from "./interfaces"
+import { GraphbackPage, GraphbackOrderBy, FindByArgs } from "./interfaces"
 import { QueryFilter } from './QueryFilter';
 
 /**
@@ -14,7 +14,7 @@ import { QueryFilter } from './QueryFilter';
  * @see GraphbackCRUDService
  */
 //tslint:disable-next-line: no-any
-export interface GraphbackDataProvider<Type = any, GraphbackContext = any> {
+export interface GraphbackDataProvider<Type = any> {
 
   /**
    * Implementation for object creation
@@ -23,7 +23,7 @@ export interface GraphbackDataProvider<Type = any, GraphbackContext = any> {
    * @param data input data
    * @param context context object passed from graphql or rest layer
    */
-  create(data: Type, context: GraphbackContext): Promise<Type>;
+  create(data: Type, selectedFields?: string[]): Promise<Type>;
 
   /**
    * Implementation for object updates
@@ -32,7 +32,7 @@ export interface GraphbackDataProvider<Type = any, GraphbackContext = any> {
    * @param data input data
    * @param context context object passed from graphql or rest layer
    */
-  update(data: Type, context: GraphbackContext): Promise<Type>;
+  update(data: Partial<Type>, selectedFields?: string[]): Promise<Type>;
 
   /**
    * Implementation for object deletes
@@ -41,7 +41,7 @@ export interface GraphbackDataProvider<Type = any, GraphbackContext = any> {
    * @param data data used for checking consistency
    * @param context context object passed from graphql or rest layer
    */
-  delete(data: Type, context: GraphbackContext): Promise<Type>;
+  delete(data: Partial<Type>, selectedFields?: string[]): Promise<Type>;
 
   /**
    * Implementation for finding a single unique object
@@ -49,7 +49,7 @@ export interface GraphbackDataProvider<Type = any, GraphbackContext = any> {
    * @param args filter by unique attriburtes
    * @param context context object passed from graphql or rest layer
    */
-  findOne(args: Partial<Type>, context: GraphbackContext): Promise<Type>;
+  findOne(args: Partial<Type>, selectedFields?: string[]): Promise<Type>;
   /**
    * Implementation for reading objects with filtering capabilities
    *
@@ -58,14 +58,14 @@ export interface GraphbackDataProvider<Type = any, GraphbackContext = any> {
    * @param page paging context
    * @param orderBy gives the ability to order the results based on a field in ascending or descending order
    */
-  findBy(filter: QueryFilter<Type>, context: GraphbackContext, page?: GraphbackPage, orderBy?: GraphbackOrderBy): Promise<Type[]>;
+  findBy(args?: FindByArgs, selectedFields?: string[]): Promise<Type[]>;
 
   /**
    * Implementation for counting number of objects with filtering capabilities
    *
    * @param filter filter by specific type
    */
-  count(filter: any): Promise<number>;
+  count(filter: QueryFilter): Promise<number>;
 
   /**
    * Read multiple items by their id's (used for lazy data loading purposes)
@@ -75,5 +75,5 @@ export interface GraphbackDataProvider<Type = any, GraphbackContext = any> {
    * @param context fields to select from datasource
    * @param filter filter by specific type
    */
-  batchRead(relationField: string, ids: string[], filter: any, context: GraphbackContext): Promise<Type[][]>
+  batchRead(relationField: string, ids: string[], filter: QueryFilter, selectedFields?: string[]): Promise<Type[][]>
 }

--- a/packages/graphback-core/src/runtime/GraphbackProxyService.ts
+++ b/packages/graphback-core/src/runtime/GraphbackProxyService.ts
@@ -33,8 +33,8 @@ export class GraphbackProxyService<Type = any> implements GraphbackCRUDService<T
     return this.proxiedService.findOne(args, context, info);
   }
 
-  public findBy(args?: FindByArgs, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<ResultList<Type>> {
-    return this.proxiedService.findBy(args, context, info);
+  public findBy(args?: FindByArgs, context?: GraphbackContext, info?: GraphQLResolveInfo, path?: string): Promise<ResultList<Type>> {
+    return this.proxiedService.findBy(args, context, info, path);
   }
 
   public subscribeToCreate(filter?: QueryFilter, context?: GraphbackContext): AsyncIterator<Type> {

--- a/packages/graphback-core/src/runtime/GraphbackProxyService.ts
+++ b/packages/graphback-core/src/runtime/GraphbackProxyService.ts
@@ -1,6 +1,7 @@
+import { GraphQLResolveInfo } from 'graphql';
 import { GraphbackCRUDService, ResultList } from './GraphbackCRUDService';
 import { QueryFilter } from './QueryFilter';
-import { GraphbackOrderBy, GraphbackPage } from '.';
+import { GraphbackContext, FindByArgs } from './interfaces';
 
 /**
  * ProxyService that can be used by any services that wish to extend
@@ -16,39 +17,39 @@ export class GraphbackProxyService<Type = any> implements GraphbackCRUDService<T
     this.proxiedService = service;
   }
 
-  public create(data: Type, context: any): Promise<Type> {
-    return this.proxiedService.create(data, context);
+  public create(data: Type, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<Type> {
+    return this.proxiedService.create(data, context, info);
   }
 
-  public update(data: Type, context: any): Promise<Type> {
-    return this.proxiedService.update(data, context);
+  public update(data: Type, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<Type> {
+    return this.proxiedService.update(data, context, info);
   }
 
-  public delete(data: Type, context: any): Promise<Type> {
-    return this.proxiedService.delete(data, context);
+  public delete(data: Type, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<Type> {
+    return this.proxiedService.delete(data, context, info);
   }
 
-  public findOne(args: any, context: any): Promise<Type> {
-    return this.proxiedService.findOne(args, context);
+  public findOne(args: Partial<Type>, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<Type> {
+    return this.proxiedService.findOne(args, context, info);
   }
 
-  public findBy(filter: QueryFilter<Type>, context: any, page?: GraphbackPage, orderBy?: GraphbackOrderBy): Promise<ResultList<Type>> {
-    return this.proxiedService.findBy(filter, context, page, orderBy);
+  public findBy(args?: FindByArgs, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<ResultList<Type>> {
+    return this.proxiedService.findBy(args, context, info);
   }
 
-  public subscribeToCreate(filter?: any, context?: any): AsyncIterator<Type> {
+  public subscribeToCreate(filter?: QueryFilter, context?: GraphbackContext): AsyncIterator<Type> {
     return this.proxiedService.subscribeToCreate(filter, context)
   }
 
-  public subscribeToUpdate(filter?: any, context?: any): AsyncIterator<Type> {
+  public subscribeToUpdate(filter?: QueryFilter, context?: GraphbackContext): AsyncIterator<Type> {
     return this.proxiedService.subscribeToUpdate(filter, context)
   }
 
-  public subscribeToDelete(filter?: any, context?: any): AsyncIterator<Type> {
+  public subscribeToDelete(filter?: QueryFilter, context?: GraphbackContext): AsyncIterator<Type> {
     return this.proxiedService.subscribeToDelete(filter, context)
   }
 
-  public batchLoadData(relationField: string, id: string | number, filter: any, context: any) {
-    return this.proxiedService.batchLoadData(relationField, id, filter, context)
+  public batchLoadData(relationField: string, id: string | number, filter: QueryFilter, context: GraphbackContext, info?: GraphQLResolveInfo) {
+    return this.proxiedService.batchLoadData(relationField, id, filter, context, info)
   }
 }

--- a/packages/graphback-core/src/runtime/createCRUDService.ts
+++ b/packages/graphback-core/src/runtime/createCRUDService.ts
@@ -18,6 +18,6 @@ export function createCRUDService(config?: CreateCRUDServiceOptions): ServiceCre
       crudOptions: model.crudOptions
     }
 
-    return new CRUDService(model.graphqlType.name, dataProvider, serviceConfig)
+    return new CRUDService(model, dataProvider, serviceConfig)
   }
 }

--- a/packages/graphback-core/src/runtime/interfaces.ts
+++ b/packages/graphback-core/src/runtime/interfaces.ts
@@ -1,5 +1,6 @@
 import { ModelDefinition } from '..';
 import { GraphbackCRUDService } from './GraphbackCRUDService';
+import { QueryFilter } from './QueryFilter';
 import { GraphbackDataProvider } from '.';
 
 /**
@@ -8,23 +9,13 @@ import { GraphbackDataProvider } from '.';
 export interface GraphbackServiceConfigMap {
   [modelName: string]: GraphbackCRUDService
 }
-/**
- * Contains resolver options
- */
-export interface GraphbackResolverOptions {
-  selectedFields: string[],
-  aggregations?: { // A map that indicates the type of aggreation that can be perfomed withing the current context
-    count?: boolean
-  }
-}
 
 /**
  * GraphQL context interface according to Graphback runtime layer format
  */
 export interface GraphbackContext {
   graphback: {
-    services: GraphbackServiceConfigMap,
-    options: GraphbackResolverOptions
+    services: GraphbackServiceConfigMap
   }
 }
 
@@ -44,6 +35,15 @@ export type SortDirection = 'asc' | 'desc'
 export interface GraphbackOrderBy {
   order?: SortDirection
   field: string
+}
+
+/**
+ * Arguments interface for the `findBy` CRUD query
+ */
+export interface FindByArgs {
+  filter?: QueryFilter
+  page?: GraphbackPage
+  orderBy?: GraphbackOrderBy
 }
 
 /**

--- a/packages/graphback-datasync/src/DataSyncPlugin.ts
+++ b/packages/graphback-datasync/src/DataSyncPlugin.ts
@@ -107,7 +107,7 @@ export class DataSyncPlugin extends GraphbackPlugin {
         throw Error("Service is not a DataSyncCRUDService. Please use DataSyncCRUDService and DataSync-compliant DataProvider with DataSync Plugin to get Delta Queries.")
       }
 
-      return dataSyncService.sync(args.lastSync, context, args.filter, args.limit);
+      return dataSyncService.sync(args.lastSync, info, args.filter, args.limit);
     }
   }
 

--- a/packages/graphback-datasync/src/providers/DataSyncProvider.ts
+++ b/packages/graphback-datasync/src/providers/DataSyncProvider.ts
@@ -1,6 +1,6 @@
-import { GraphbackDataProvider, GraphbackContext } from "@graphback/core";
+import { GraphbackDataProvider, GraphbackContext, QueryFilter } from "@graphback/core";
 
 export interface DataSyncProvider<Type = any> extends GraphbackDataProvider<Type> {
 
-  sync(lastSync: Date, context: GraphbackContext, filter?: any, limit?: number): Promise<Type[]>;
+  sync(lastSync: Date, selectedFields?: string[], filter?: QueryFilter, limit?: number): Promise<Type[]>;
 }

--- a/packages/graphback-datasync/src/services/DataSyncCRUDService.ts
+++ b/packages/graphback-datasync/src/services/DataSyncCRUDService.ts
@@ -21,7 +21,10 @@ export class DataSyncCRUDService<T = any> extends CRUDService<T> {
    * For delta queries
    */
   public async sync(lastSync: Date, info?: GraphQLResolveInfo, filter?: any, limit?: number): Promise<SyncList<T>> {
-    const selectedFields = getSelectedFieldsFromResolverInfo(info, this.model)
+    let selectedFields: string[];
+    if (info) {
+      selectedFields = getSelectedFieldsFromResolverInfo(info, this.model)
+    }
     const res = await (this.db as DataSyncProvider).sync(lastSync, selectedFields, filter, limit);
 
     return {

--- a/packages/graphback-datasync/src/services/DataSyncCRUDService.ts
+++ b/packages/graphback-datasync/src/services/DataSyncCRUDService.ts
@@ -1,4 +1,5 @@
-import { CRUDService, CRUDServiceConfig, GraphbackContext } from '@graphback/core';
+import { CRUDService, CRUDServiceConfig, ModelDefinition, getSelectedFieldsFromResolverInfo } from '@graphback/core';
+import { GraphQLResolveInfo } from 'graphql';
 import { DataSyncProvider } from "../providers";
 
 export interface SyncList<T> {
@@ -12,16 +13,16 @@ export interface SyncList<T> {
  */
 export class DataSyncCRUDService<T = any> extends CRUDService<T> {
 
-  public constructor(modelName: string, db: DataSyncProvider, config: CRUDServiceConfig) {
-    super(modelName, db, config);
+  public constructor(model: ModelDefinition, db: DataSyncProvider, config: CRUDServiceConfig) {
+    super(model, db, config);
   }
   /**
    * sync
    * For delta queries
    */
-  public async sync(lastSync: Date, context: GraphbackContext, filter?: any, limit?: number): Promise<SyncList<T>> {
-
-    const res = await (this.db as DataSyncProvider).sync(lastSync, context, filter, limit);
+  public async sync(lastSync: Date, info?: GraphQLResolveInfo, filter?: any, limit?: number): Promise<SyncList<T>> {
+    const selectedFields = getSelectedFieldsFromResolverInfo(info, this.model)
+    const res = await (this.db as DataSyncProvider).sync(lastSync, selectedFields, filter, limit);
 
     return {
       items: res,

--- a/packages/graphback-datasync/src/services/createDataSyncService.ts
+++ b/packages/graphback-datasync/src/services/createDataSyncService.ts
@@ -25,9 +25,9 @@ export function createDataSyncCRUDService(config?: CreateDataSyncCRUDServiceOpti
     }
 
     if (isDataSyncModel(model)) {
-      return new DataSyncCRUDService(model.graphqlType.name, dataProvider as DataSyncProvider, serviceConfig)
+      return new DataSyncCRUDService(model, dataProvider as DataSyncProvider, serviceConfig)
     } else {
-      return new CRUDService(model.graphqlType.name, dataProvider, serviceConfig)
+      return new CRUDService(model, dataProvider, serviceConfig)
     }
   }
 }

--- a/packages/graphback-datasync/tests/DataSyncConflictProviderTest.ts
+++ b/packages/graphback-datasync/tests/DataSyncConflictProviderTest.ts
@@ -1,12 +1,11 @@
 /* eslint-disable max-lines */
 import { NoDataError } from '@graphback/core';
-import { Context, createTestingContext } from './__util__';
 import { ConflictError, DataSyncFieldNames, ServerSideWins, ConflictResolutionStrategy, ConflictMetadata, getDeltaTableName } from '../src';
+import { Context, createTestingContext } from './__util__';
 
 describe('DataSyncConflictMongoDBDataProvider', () => {
   let context: Context;
   afterEach(async () => context.server.stop());
-  const fields = ["_id", "title"];
   const postSchema = `
   """
   @model
@@ -24,23 +23,23 @@ describe('DataSyncConflictMongoDBDataProvider', () => {
   `;
 
   test('conflict does not occur when changes can be merged', async () => {
-    const resolveUpdate = jest.fn((_: ConflictMetadata) => {return {}});
-    const resolveDelete = jest.fn((_: ConflictMetadata) => {return {}});
-    const mockConflictStrategy:ConflictResolutionStrategy = {
+    const resolveUpdate = jest.fn((_: ConflictMetadata) => { return {} });
+    const resolveDelete = jest.fn((_: ConflictMetadata) => { return {} });
+    const mockConflictStrategy: ConflictResolutionStrategy = {
       resolveUpdate,
       resolveDelete
     }
-    context = await createTestingContext(postSchema, { conflictConfig: { models: { Post: { enabled: true, conflictResolution: mockConflictStrategy } }} });
+    context = await createTestingContext(postSchema, { conflictConfig: { models: { Post: { enabled: true, conflictResolution: mockConflictStrategy } } } });
 
     const { Post } = context.providers;
 
-    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" });
 
     const updatedContent = "Post 1 content v2";
-    await Post.update({ _id, content: updatedContent, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}})
+    await Post.update({ _id, content: updatedContent, [DataSyncFieldNames.version]: version })
 
     const updateTitle = "Post 1 v2";
-    await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}});
+    await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version });
 
     expect(resolveUpdate.mock.calls.length).toEqual(0);
     expect(resolveDelete.mock.calls.length).toEqual(0);
@@ -60,7 +59,7 @@ describe('DataSyncConflictMongoDBDataProvider', () => {
       }
 
       scalar GraphbackObjectID
-      `, {conflictConfig: { models: { Note: { enabled: true }}}});
+      `, { conflictConfig: { models: { Note: { enabled: true } } } });
 
 
     const index = await context.findIndex('note', DataSyncFieldNames.ttl);
@@ -96,10 +95,10 @@ describe('DataSyncConflictMongoDBDataProvider', () => {
 
     const { Post } = context.providers;
 
-    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" });
 
     const updatedContent = "Post 1 content v2";
-    await expect(Post.update({ _id, content: updatedContent, [DataSyncFieldNames.version]: 0.5 },{graphback: {services: {}, options: { selectedFields: fields}}})).rejects.toThrowError(ConflictError);
+    await expect(Post.update({ _id, content: updatedContent, [DataSyncFieldNames.version]: 0.5 })).rejects.toThrowError(ConflictError);
   });
 
   test('throws NoDataError when serverData cannot be found', async () => {
@@ -108,7 +107,7 @@ describe('DataSyncConflictMongoDBDataProvider', () => {
     const { Post } = context.providers;
 
     const updatedContent = "Post 1 content v2";
-    await expect(Post.update({ _id: "NotAValidObjectId", content: updatedContent, [DataSyncFieldNames.version]: 1 },{graphback: {services: {}, options: { selectedFields: fields}}})).rejects.toThrowError(NoDataError);
+    await expect(Post.update({ _id: "NotAValidObjectId", content: updatedContent, [DataSyncFieldNames.version]: 1 })).rejects.toThrowError(NoDataError);
   });
 })
 
@@ -133,31 +132,32 @@ describe('Client Side wins Conflict resolution', () => {
   scalar GraphbackObjectID
   `;
 
-  it ('updates successfully when correct version passed', async () => {
+  it('updates successfully when correct version passed', async () => {
     context = await createTestingContext(postSchema, { conflictConfig: { models: { Post: { enabled: true } } } });
 
     const { Post } = context.providers;
 
-    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" });
 
     const updateTitle = "Post 1 v2";
-    const { title, [DataSyncFieldNames.version]: updatedVersion } = await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.version] }}})
+    const { title, [DataSyncFieldNames.version]: updatedVersion } = await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version })
 
     expect(title).toEqual(updateTitle);
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
     expect(updatedVersion).toEqual(version + 1);
   });
 
-  it ('client data wins when conflict occurs', async () => {
+  it('client data wins when conflict occurs', async () => {
     context = await createTestingContext(postSchema, { conflictConfig: { models: { Post: { enabled: true } } } });
 
     const { Post } = context.providers;
 
-    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" });
 
-    await Post.update({ _id, title: "Post 1 v2", [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}})
+    await Post.update({ _id, title: "Post 1 v2", [DataSyncFieldNames.version]: version })
 
     const finalUpdateTitle = "Post 1 v3";
-    const updatedPost = await Post.update({ _id, title: finalUpdateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}});
+    const updatedPost = await Post.update({ _id, title: finalUpdateTitle, [DataSyncFieldNames.version]: version });
 
     expect(updatedPost.title).toEqual(finalUpdateTitle);
   });
@@ -167,45 +167,45 @@ describe('Client Side wins Conflict resolution', () => {
 
     const { Post } = context.providers;
 
-    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" });
 
-    await Post.delete({ _id, [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: fields}}});
+    await Post.delete({ _id, [DataSyncFieldNames.version]: version });
 
     const updatedTitle = "Post 1 v2";
-    const updatedPost = await Post.update({ _id, title: updatedTitle,  [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.deleted]}}})
+    const updatedPost = await Post.update({ _id, title: updatedTitle, [DataSyncFieldNames.version]: version })
 
     expect(updatedPost.title).toEqual(updatedTitle);
     expect(updatedPost[DataSyncFieldNames.deleted]).toEqual(false);
   });
 
-  it ('merges changes when no conflict', async () => {
+  it('merges changes when no conflict', async () => {
     context = await createTestingContext(postSchema, { conflictConfig: { models: { Post: { enabled: true } } } });
 
     const { Post } = context.providers;
 
-    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" });
 
     const updatedContent = "Post 1 content v2";
-    await Post.update({ _id, content: updatedContent, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}})
+    await Post.update({ _id, content: updatedContent, [DataSyncFieldNames.version]: version })
 
     const updateTitle = "Post 1 v2";
-    const updatedPost = await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}});
+    const updatedPost = await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version });
 
     expect(updatedPost.title).toEqual(updateTitle);
     expect(updatedPost.content).toEqual(updatedContent);
   });
 
-  it ('force deletes if conflict occurs', async () => {
+  it('force deletes if conflict occurs', async () => {
     context = await createTestingContext(postSchema, { conflictConfig: { models: { Post: { enabled: true } } } });
 
     const { Post } = context.providers;
 
-    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" });
 
     const updatedTitle = "Post 1 v2";
-    await Post.update({ _id, title: updatedTitle,  [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.deleted]}}});
+    await Post.update({ _id, title: updatedTitle, [DataSyncFieldNames.version]: version });
 
-    const deletedPost = await Post.delete({ _id, [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.deleted]}}});
+    const deletedPost = await Post.delete({ _id, [DataSyncFieldNames.version]: version });
 
     expect(deletedPost[DataSyncFieldNames.deleted]).toEqual(true);
   });
@@ -231,32 +231,33 @@ describe('Server Side wins Conflict resolution', () => {
   scalar GraphbackObjectID
   `;
 
-  it ('updates successfully when correct version passed', async () => {
-    context = await createTestingContext(postSchema, { conflictConfig: { models: { Post: { enabled: true, } }, conflictResolution: ServerSideWins }});
+  it('updates successfully when correct version passed', async () => {
+    context = await createTestingContext(postSchema, { conflictConfig: { models: { Post: { enabled: true, } }, conflictResolution: ServerSideWins } });
 
     const { Post } = context.providers;
 
-    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" });
 
     const updateTitle = "Post 1 v2";
-    const { title, [DataSyncFieldNames.version]: updatedVersion } = await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.version] }}})
+    const { title, [DataSyncFieldNames.version]: updatedVersion } = await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version })
 
     expect(title).toEqual(updateTitle);
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
     expect(updatedVersion).toEqual(version + 1);
   });
 
-  it ('server data wins when conflict occurs', async () => {
+  it('server data wins when conflict occurs', async () => {
     context = await createTestingContext(postSchema, { conflictConfig: { models: { Post: { enabled: true } }, conflictResolution: ServerSideWins } });
 
     const { Post } = context.providers;
 
-    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" });
 
     const updateTitle = "Post 1 v2";
-    await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}})
+    await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version })
 
     const finalUpdateTitle = "Post 1 v3";
-    const updatedPost = await Post.update({ _id, title: finalUpdateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}});
+    const updatedPost = await Post.update({ _id, title: finalUpdateTitle, [DataSyncFieldNames.version]: version });
 
     expect(updatedPost.title).toEqual(updateTitle);
   });
@@ -266,41 +267,41 @@ describe('Server Side wins Conflict resolution', () => {
 
     const { Post } = context.providers;
 
-    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" });
 
-    await Post.delete({ _id, [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: fields}}});
+    await Post.delete({ _id, [DataSyncFieldNames.version]: version });
 
     const updatedTitle = "Post 1 v2";
-    await expect(Post.update({ _id, title: updatedTitle,  [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.deleted]}}})).rejects.toThrowError(ConflictError);
+    await expect(Post.update({ _id, title: updatedTitle, [DataSyncFieldNames.version]: version })).rejects.toThrowError(ConflictError);
   });
 
-  it ('merges changes when no conflict', async () => {
+  it('merges changes when no conflict', async () => {
     context = await createTestingContext(postSchema, { conflictConfig: { models: { Post: { enabled: true } }, conflictResolution: ServerSideWins } });
 
     const { Post } = context.providers;
 
-    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" });
 
     const updatedContent = "Post 1 content v2";
-    await Post.update({ _id, content: updatedContent, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}})
+    await Post.update({ _id, content: updatedContent, [DataSyncFieldNames.version]: version })
 
     const updateTitle = "Post 1 v2";
-    const updatedPost = await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version },{graphback: {services: {}, options: { selectedFields: fields}}});
+    const updatedPost = await Post.update({ _id, title: updateTitle, [DataSyncFieldNames.version]: version });
 
     expect(updatedPost.title).toEqual(updateTitle);
     expect(updatedPost.content).toEqual(updatedContent);
   });
 
-  it ('throw error on deletes if conflict occurs', async () => {
+  it('throw error on deletes if conflict occurs', async () => {
     context = await createTestingContext(postSchema, { conflictConfig: { models: { Post: { enabled: true } }, conflictResolution: ServerSideWins } });
 
     const { Post } = context.providers;
 
-    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" }, {graphback: {services: {}, options: { selectedFields: ["_id", DataSyncFieldNames.version]}}});
+    const { _id, [DataSyncFieldNames.version]: version } = await Post.create({ title: "Post 1", content: "Post 1 content" });
 
     const updatedTitle = "Post 1 v2";
-    await Post.update({ _id, title: updatedTitle,  [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.deleted]}}})
+    await Post.update({ _id, title: updatedTitle, [DataSyncFieldNames.version]: version })
 
-    await expect(Post.delete({ _id, [DataSyncFieldNames.version]: version }, {graphback: {services: {}, options: { selectedFields: fields}}})).rejects.toThrowError(ConflictError);
+    await expect(Post.delete({ _id, [DataSyncFieldNames.version]: version })).rejects.toThrowError(ConflictError);
   });
 });

--- a/packages/graphback-datasync/tests/DataSyncMongoDBTests.ts
+++ b/packages/graphback-datasync/tests/DataSyncMongoDBTests.ts
@@ -29,7 +29,7 @@ describe('Soft deletion test', () => {
 
     const { Post } = context.providers;
 
-    const first = await Post.create({ text: 'TestPost' }, {graphback: {services: {}, options: { selectedFields: [DataSyncFieldNames.deleted]}}});
+    const first = await Post.create({ text: 'TestPost' });
     expect(first[DataSyncFieldNames.deleted]).toEqual(false)
   })
 
@@ -37,14 +37,14 @@ describe('Soft deletion test', () => {
     context = await createTestingContext(postSchema);
 
     const { Post } = context.providers;
-    const createdPost = await Post.create({ text: 'TestPost' }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.lastUpdatedAt]}}});
+    const createdPost = await Post.create({ text: 'TestPost' });
 
     // check count
     let count = await Post.count({});
     expect(count).toEqual(1);
 
     // delete the Post
-    const deletedPost = await Post.delete({ _id: createdPost._id }, {graphback: {services: {}, options: { selectedFields: [DataSyncFieldNames.deleted]}}});
+    const deletedPost = await Post.delete({ _id: createdPost._id });
     expect(deletedPost[DataSyncFieldNames.deleted]).toEqual(true);
 
     // re check count after deletion
@@ -53,21 +53,21 @@ describe('Soft deletion test', () => {
 
     // Tests that we cannot find, update or delete it anymore
     // This test fails if we can still can
-    await expect(Post.findOne({ _id: createdPost._id }, {graphback: {services: {}, options: { selectedFields: fields}}})).rejects.toThrowError(NoDataError);
+    await expect(Post.findOne({ _id: createdPost._id })).rejects.toThrowError(NoDataError);
   })
 
   it('sets ttl field on deletion', async () => {
     context = await createTestingContext(postSchema);
 
     const { Post } = context.providers;
-    const createdPost = await Post.create({ text: 'TestPost' }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.lastUpdatedAt]}}});
+    const createdPost = await Post.create({ text: 'TestPost' });
 
     // check count
     const count = await Post.count({});
     expect(count).toEqual(1);
 
     // delete the Post
-    const deletedPost = await Post.delete({ _id: createdPost._id }, {graphback: {services: {}, options: { selectedFields: [DataSyncFieldNames.deleted, DataSyncFieldNames.ttl]}}});
+    const deletedPost = await Post.delete({ _id: createdPost._id });
     expect(deletedPost[DataSyncFieldNames.deleted]).toEqual(true);
     expect(deletedPost[DataSyncFieldNames.ttl] instanceof Date).toEqual(true);
   })
@@ -88,14 +88,14 @@ describe('Soft deletion test', () => {
     `);
 
     const { Post } = context.providers;
-    const createdPost = await Post.create({ text: 'TestPost' }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.lastUpdatedAt]}}});
+    const createdPost = await Post.create({ text: 'TestPost' });
 
     // check count
     let count = await Post.count({});
     expect(count).toEqual(1);
 
     // delete the Post
-    const deletedPost = await Post.delete({ _id: createdPost._id }, {graphback: {services: {}, options: { selectedFields: []}}});
+    const deletedPost = await Post.delete({ _id: createdPost._id });
     expect(deletedPost[DataSyncFieldNames.deleted]).toEqual(true);
 
     // check count again
@@ -109,42 +109,42 @@ describe('Soft deletion test', () => {
     context = await createTestingContext(postSchema);
 
     const { Post } = context.providers;
-    const createdPost = await Post.create({ text: 'TestPost' }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.lastUpdatedAt]}}});
+    const createdPost = await Post.create({ text: 'TestPost' });
 
     // check count
     let count = await Post.count({});
     expect(count).toEqual(1);
 
     // delete the Post
-    const deletedPost = await Post.delete({ _id: createdPost._id }, {graphback: {services: {}, options: { selectedFields: [DataSyncFieldNames.deleted]}}});
+    const deletedPost = await Post.delete({ _id: createdPost._id });
     expect(deletedPost[DataSyncFieldNames.deleted]).toEqual(true);
 
     // re check count after deletion
     count = await Post.count({});
     expect(count).toEqual(0);
 
-    await expect(Post.update({ _id: createdPost._id, text: 'an update too late' }, {graphback: {services: {}, options: { selectedFields: fields}}})).rejects.toThrowError(NoDataError);
+    await expect(Post.update({ _id: createdPost._id, text: 'an update too late' })).rejects.toThrowError(NoDataError);
   })
 
   it('cannot delete a deleted document', async () => {
     context = await createTestingContext(postSchema);
 
     const { Post } = context.providers;
-    const createdPost = await Post.create({ text: 'TestPost' }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.lastUpdatedAt]}}});
+    const createdPost = await Post.create({ text: 'TestPost' });
 
     // check count
     let count = await Post.count({});
     expect(count).toEqual(1);
 
     // delete the Post
-    const deletedPost = await Post.delete({ _id: createdPost._id }, {graphback: {services: {}, options: { selectedFields: [DataSyncFieldNames.deleted]}}});
+    const deletedPost = await Post.delete({ _id: createdPost._id });
     expect(deletedPost[DataSyncFieldNames.deleted]).toEqual(true);
 
     // re check count after deletion
     count = await Post.count({});
     expect(count).toEqual(0);
 
-    await expect(Post.delete({ _id: createdPost._id }, {graphback: {services: {}, options: { selectedFields: fields}}})).rejects.toThrowError(NoDataError);
+    await expect(Post.delete({ _id: createdPost._id })).rejects.toThrowError(NoDataError);
   })
 
   it('sets _deleted when field absent', async () => {
@@ -153,11 +153,11 @@ describe('Soft deletion test', () => {
     const { db, providers } = context;
     const { Post } = providers;
 
-    const postid = await (await db.collection(defaultTableNameTransform('Post', 'to-db')).insertOne({ text: 'TestPost'})).insertedId
+    const postid = await (await db.collection(defaultTableNameTransform('Post', 'to-db')).insertOne({ text: 'TestPost' })).insertedId
 
     const updateTime = 1593263130987
     advanceTo(updateTime);
-    const deletedPost = await Post.delete({ _id: postid, text: 'SeriousPost' }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.lastUpdatedAt, DataSyncFieldNames.deleted]}}});
+    const deletedPost = await Post.delete({ _id: postid, text: 'SeriousPost' });
     expect(deletedPost[DataSyncFieldNames.lastUpdatedAt]).toEqual(updateTime)
     expect(deletedPost[DataSyncFieldNames.deleted]).toEqual(true);
   })
@@ -227,7 +227,7 @@ describe('Delta Queries', () => {
     advanceTo(startTime);
     // Create some posts
 
-    const createdPost = await Post.create({ text: 'Test Post' }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.lastUpdatedAt]}}});
+    const createdPost = await Post.create({ text: 'Test Post' });
 
     expect(createdPost[DataSyncFieldNames.lastUpdatedAt]).toEqual(startTime);
   });
@@ -241,13 +241,13 @@ describe('Delta Queries', () => {
     advanceTo(startTime);
     // Create a posts
 
-    const createdPost = await Post.create({ text: 'Test Post' }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.lastUpdatedAt]}}});
+    const createdPost = await Post.create({ text: 'Test Post' });
 
     const updateTime = 1593263130987
     advanceTo(updateTime);
 
     // Update the post
-    const updatedPost = await Post.update({ _id: createdPost._id, text: 'Test Post' }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.lastUpdatedAt, DataSyncFieldNames.deleted]}}});
+    const updatedPost = await Post.update({ _id: createdPost._id, text: 'Test Post' });
     expect(updatedPost[DataSyncFieldNames.lastUpdatedAt]).toEqual(updateTime)
   });
 
@@ -257,11 +257,11 @@ describe('Delta Queries', () => {
     const { db, providers } = context;
     const { Post } = providers;
 
-    const postid = await (await db.collection(defaultTableNameTransform('Post', 'to-db')).insertOne({ text: 'TestPost'})).insertedId
+    const postid = await (await db.collection(defaultTableNameTransform('Post', 'to-db')).insertOne({ text: 'TestPost' })).insertedId
 
     const updateTime = 1593263130987
     advanceTo(updateTime);
-    const updatedPost = await Post.update({ _id: postid, text: 'SeriousPost' }, {graphback: {services: {}, options: { selectedFields: [...fields, DataSyncFieldNames.lastUpdatedAt, DataSyncFieldNames.deleted]}}});
+    const updatedPost = await Post.update({ _id: postid, text: 'SeriousPost' });
     expect(updatedPost[DataSyncFieldNames.lastUpdatedAt]).toEqual(updateTime)
   })
 
@@ -274,15 +274,15 @@ describe('Delta Queries', () => {
     advanceTo(startTime);
     // Create some posts
 
-    await Post.create({ text: 'the first post' }, {graphback: {services: {}, options: { selectedFields: fields}}});
+    await Post.create({ text: 'the first post' });
 
     const t1 = 1596124171069
     advanceTo(t1)
 
-    await Post.create({ text: 'the second post' }, {graphback: {services: {}, options: { selectedFields: fields}}});
+    await Post.create({ text: 'the second post' });
 
     // Sync query
-    const deltaPosts = await Post.sync(new Date(t1), {graphback: {services: {}, options: { selectedFields: fields}}});
+    const deltaPosts = await Post.sync(new Date(t1));
 
     expect(deltaPosts.length).toEqual(1);
   });
@@ -294,11 +294,11 @@ describe('Delta Queries', () => {
 
     // Create some posts
     for (const postTitle of ["post", "post2", "trains"]) {
-      await Post.create({ text: postTitle }, {graphback: {services: {}, options: { selectedFields: fields}}});
+      await Post.create({ text: postTitle });
     }
 
     // Sync query
-    const deltaPosts = await Post.sync(new Date(0), {graphback: {services: {}, options: { selectedFields: fields}}}, {
+    const deltaPosts = await Post.sync(new Date(0), undefined, {
       text: {
         startsWith: 'post'
       }
@@ -326,11 +326,11 @@ describe('Delta Queries', () => {
 
     // Create some posts
     for (const postTitle of ["post", "post2", "trains"]) {
-      await Post.create({ text: postTitle }, {graphback: {services: {}, options: { selectedFields: fields}}});
+      await Post.create({ text: postTitle });
     }
 
     // Sync query
-    const deltaPosts = await Post.sync(new Date(0), {graphback: {services: {}, options: { selectedFields: fields}}}, undefined, 1);
+    const deltaPosts = await Post.sync(new Date(0), undefined, undefined, 1);
 
     expect(deltaPosts.length).toEqual(1);
   })

--- a/packages/graphback-datasync/tests/__util__.ts
+++ b/packages/graphback-datasync/tests/__util__.ts
@@ -53,7 +53,7 @@ export async function createTestingContext(schemaStr: string, config?: { seedDat
     const collectionNames = Object.keys(config.seedData);
     for (const collectionName of collectionNames) {
       for (const element of config.seedData[collectionName]) {
-        await providers[collectionName].create(element, {graphback: {services: {}, options: { selectedFields: ["_id"]}}});
+        await providers[collectionName].create(element);
       }
     };
   }

--- a/packages/graphback-keycloak-authz/src/KeycloakCrudService.ts
+++ b/packages/graphback-keycloak-authz/src/KeycloakCrudService.ts
@@ -1,9 +1,8 @@
-import { isAuthorizedByRole, KeycloakContext } from "keycloak-connect-graphql";
-import { GraphbackCRUDService, ResultList, GraphbackOrderBy, GraphbackPage, GraphbackProxyService, GraphbackContext, QueryFilter } from '@graphback/core';
+import { isAuthorizedByRole, KeycloakContext, KeycloakContextBase } from "keycloak-connect-graphql";
+import { GraphbackCRUDService, ResultList, GraphbackProxyService, GraphbackContext, QueryFilter, FindByArgs, getSelectedFieldsFromResolverInfo, ModelDefinition } from '@graphback/core';
+import { GraphQLResolveInfo } from 'graphql';
 import { CrudServiceAuthConfig } from './KeycloakConfig';
-import { getEmptyServiceConfig, UnauthorizedError } from "./utils";
-
-
+import { getEmptyServiceConfig, UnauthorizedError, checkAuthRulesForInput, checkAuthRulesForSelections } from "./utils";
 
 /**
  * options object for the KeycloakCrudService
@@ -21,6 +20,13 @@ export type KeycloakCrudServiceOptions = {
 };
 
 /**
+ * Context interface for Keycloak which extends Graphback context
+ */
+export interface GraphbackKeycloakContext extends GraphbackContext {
+  kauth: KeycloakContextBase | KeycloakContext | any
+}
+
+/**
  * This custom CRUD Service shows another potential way to add auth
  *
  * This is actually quite nice and clean but it does not allow for field level auth.
@@ -29,13 +35,15 @@ export type KeycloakCrudServiceOptions = {
 export class KeycloakCrudService<Type = any> extends GraphbackProxyService<Type> {
 
   private authConfig: CrudServiceAuthConfig;
+  private model: ModelDefinition;
 
-  public constructor({ service, authConfig }: KeycloakCrudServiceOptions) {
+  public constructor(model: ModelDefinition, { service, authConfig }: KeycloakCrudServiceOptions) {
     super(service);
     this.authConfig = authConfig || getEmptyServiceConfig();
+    this.model = model;
   }
 
-  public create(data: Type, context: GraphbackContext | KeycloakContext | any): Promise<Type> {
+  public create(data: Type, context?: GraphbackKeycloakContext, info?: GraphQLResolveInfo): Promise<Type> {
     if (this.authConfig.create && this.authConfig.create.roles && this.authConfig.create.roles.length > 0) {
       const { roles } = this.authConfig.create;
       if (!isAuthorizedByRole(roles, context)) {
@@ -43,24 +51,25 @@ export class KeycloakCrudService<Type = any> extends GraphbackProxyService<Type>
       }
     }
 
-    this.checkAuthRulesForInput(context, Object.keys(data));
+    checkAuthRulesForInput(context, this.authConfig, Object.keys(data));
 
-    return super.create(data, context);
+    return super.create(data, context, info);
   }
 
-  public update(data: Type, context: GraphbackContext | KeycloakContext | any): Promise<Type> {
+  public update(data: Type, context?: GraphbackKeycloakContext, info?: GraphQLResolveInfo): Promise<Type> {
     if (this.authConfig.update && this.authConfig.update.roles && this.authConfig.update.roles.length > 0) {
       const { roles } = this.authConfig.update;
       if (!isAuthorizedByRole(roles, context)) {
         throw new UnauthorizedError()
       }
     }
-    this.checkAuthRulesForInput(context, Object.keys(data));
+    
+    checkAuthRulesForInput(context, this.authConfig, Object.keys(data));
 
-    return super.update(data, context);
+    return super.update(data, context, info);
   }
 
-  public delete(data: Type, context: GraphbackContext | KeycloakContext | any): Promise<Type> {
+  public delete(data: Type, context?: GraphbackKeycloakContext, info?: GraphQLResolveInfo): Promise<Type> {
     if (this.authConfig.delete && this.authConfig.delete.roles && this.authConfig.delete.roles.length > 0) {
       const { roles } = this.authConfig.delete;
       if (!isAuthorizedByRole(roles, context)) {
@@ -68,10 +77,10 @@ export class KeycloakCrudService<Type = any> extends GraphbackProxyService<Type>
       }
     }
 
-    return super.delete(data, context);
+    return super.delete(data, context, info);
   }
 
-  public findOne(args: any, context: GraphbackContext | KeycloakContext | any): Promise<Type> {
+  public findOne(args: any, context: GraphbackKeycloakContext, info?: GraphQLResolveInfo): Promise<Type> {
     if (this.authConfig.read && this.authConfig.read.roles && this.authConfig.read.roles.length > 0) {
       const { roles } = this.authConfig.read;
       if (!isAuthorizedByRole(roles, context)) {
@@ -79,12 +88,17 @@ export class KeycloakCrudService<Type = any> extends GraphbackProxyService<Type>
       }
     }
 
-    this.checkAuthRulesForSelections(context);
+    let selectedFields: string[];
+    if (info) {
+      selectedFields = getSelectedFieldsFromResolverInfo(info, this.model)
+    }
 
-    return super.findOne(args, context);
+    checkAuthRulesForSelections(context, this.authConfig, selectedFields);
+
+    return super.findOne(args, context, info);
   }
 
-  public findBy(filter: QueryFilter<Type>, context: GraphbackContext | KeycloakContext | any | any, page?: GraphbackPage, orderBy?: GraphbackOrderBy): Promise<ResultList<Type>> {
+  public findBy(args: FindByArgs, context?: GraphbackKeycloakContext | any, info?: GraphQLResolveInfo): Promise<ResultList<Type>> {
     if (this.authConfig.read && this.authConfig.read.roles && this.authConfig.read.roles.length > 0) {
       const { roles } = this.authConfig.read;
       if (!isAuthorizedByRole(roles, context)) {
@@ -97,15 +111,20 @@ export class KeycloakCrudService<Type = any> extends GraphbackProxyService<Type>
         throw new Error("Wrong auth filter implementation")
       }
 
-      filter = this.authConfig.filterUsingAuthInfo(filter, context.kauth.accessToken.content)
+      args.filter = this.authConfig.filterUsingAuthInfo(args.filter, context.kauth.accessToken.content)
     }
 
-    this.checkAuthRulesForSelections(context);
+    let selectedFields: string[];
+    if (info) {
+      selectedFields = getSelectedFieldsFromResolverInfo(info, this.model)
+    }
 
-    return super.findBy(filter, context, page, orderBy);
+    checkAuthRulesForSelections(context, this.authConfig, selectedFields);
+
+    return super.findBy(args, context, info);
   }
 
-  public subscribeToCreate(filter?: any, context?: any): AsyncIterator<Type> {
+  public subscribeToCreate(filter?: QueryFilter, context?: GraphbackKeycloakContext): AsyncIterator<Type> {
     if (this.authConfig.subCreate && this.authConfig.subCreate.roles && this.authConfig.subCreate.roles.length > 0) {
       const { roles } = this.authConfig.subCreate;
       if (!isAuthorizedByRole(roles, context)) {
@@ -116,7 +135,7 @@ export class KeycloakCrudService<Type = any> extends GraphbackProxyService<Type>
     return super.subscribeToCreate(filter, context)
   }
 
-  public subscribeToUpdate(filter?: any, context?: any): AsyncIterator<Type> {
+  public subscribeToUpdate(filter?: QueryFilter, context?: GraphbackContext): AsyncIterator<Type> {
     if (this.authConfig.subUpdate && this.authConfig.subUpdate.roles && this.authConfig.subUpdate.roles.length > 0) {
       const { roles } = this.authConfig.subUpdate;
       if (!isAuthorizedByRole(roles, context)) {
@@ -127,7 +146,7 @@ export class KeycloakCrudService<Type = any> extends GraphbackProxyService<Type>
     return super.subscribeToUpdate(filter, context)
   }
 
-  public subscribeToDelete(filter?: any, context?: any): AsyncIterator<Type> {
+  public subscribeToDelete(filter?: QueryFilter, context?: GraphbackContext): AsyncIterator<Type> {
     if (this.authConfig.subDelete && this.authConfig.subDelete.roles && this.authConfig.subDelete.roles.length > 0) {
       const { roles } = this.authConfig.subDelete;
       if (!isAuthorizedByRole(roles, context)) {
@@ -138,7 +157,7 @@ export class KeycloakCrudService<Type = any> extends GraphbackProxyService<Type>
     return super.subscribeToDelete(filter, context)
   }
 
-  public batchLoadData(relationField: string, id: string | number, filter: any, context: GraphbackContext | KeycloakContext | any) {
+  public batchLoadData(relationField: string, id: string | number, filter: QueryFilter, context: GraphbackContext, info?: GraphQLResolveInfo) {
     if (this.authConfig?.relations && this.authConfig?.relations[relationField]?.roles.length > 0) {
       const { roles } = this.authConfig?.relations[relationField];
       if (!isAuthorizedByRole(roles, context)) {
@@ -146,40 +165,7 @@ export class KeycloakCrudService<Type = any> extends GraphbackProxyService<Type>
       }
     }
 
-    return super.batchLoadData(relationField, id, filter, context)
-  }
-
-  /**
-   * Checks if user is allowed to create/update particular field
-   */
-  private checkAuthRulesForInput(context: any, inputKeys: string[]) {
-    if (this.authConfig.updateFields) {
-      for (const inputKey of inputKeys) {
-        if (this.authConfig.updateFields[inputKey]) {
-          const { roles } = this.authConfig.updateFields[inputKey];
-          if (!isAuthorizedByRole(roles, context)) {
-            throw new UnauthorizedError()
-          }
-        }
-      }
-    }
-  }
-
-  /**
-   * Checks if user is allowed to request particular field
-   */
-  private checkAuthRulesForSelections(context: any) {
-    const selectedFields = context.graphback?.options?.selectedFields;
-    if (this.authConfig.returnFields && selectedFields) {
-      for (const selectedField of selectedFields) {
-        if (this.authConfig.returnFields[selectedField]) {
-          const { roles } = this.authConfig.returnFields[selectedField];
-          if (!isAuthorizedByRole(roles, context)) {
-            throw new UnauthorizedError(`Unauthorized to fetch: ${selectedField}`)
-          }
-        }
-      }
-    }
+    return super.batchLoadData(relationField, id, filter, context, info)
   }
 }
 

--- a/packages/graphback-keycloak-authz/src/KeycloakCrudService.ts
+++ b/packages/graphback-keycloak-authz/src/KeycloakCrudService.ts
@@ -98,7 +98,7 @@ export class KeycloakCrudService<Type = any> extends GraphbackProxyService<Type>
     return super.findOne(args, context, info);
   }
 
-  public findBy(args: FindByArgs, context?: GraphbackKeycloakContext | any, info?: GraphQLResolveInfo): Promise<ResultList<Type>> {
+  public findBy(args: FindByArgs, context?: GraphbackKeycloakContext | any, info?: GraphQLResolveInfo, path?: string): Promise<ResultList<Type>> {
     if (this.authConfig.read && this.authConfig.read.roles && this.authConfig.read.roles.length > 0) {
       const { roles } = this.authConfig.read;
       if (!isAuthorizedByRole(roles, context)) {
@@ -116,12 +116,12 @@ export class KeycloakCrudService<Type = any> extends GraphbackProxyService<Type>
 
     let selectedFields: string[];
     if (info) {
-      selectedFields = getSelectedFieldsFromResolverInfo(info, this.model)
+      selectedFields = getSelectedFieldsFromResolverInfo(info, this.model, path)
     }
 
     checkAuthRulesForSelections(context, this.authConfig, selectedFields);
 
-    return super.findBy(args, context, info);
+    return super.findBy(args, context, info, path);
   }
 
   public subscribeToCreate(filter?: QueryFilter, context?: GraphbackKeycloakContext): AsyncIterator<Type> {

--- a/packages/graphback-keycloak-authz/src/createKeycloakCRUDService.ts
+++ b/packages/graphback-keycloak-authz/src/createKeycloakCRUDService.ts
@@ -17,7 +17,7 @@ export function createKeycloakCRUDService(authConfigList: CrudServicesAuthConfig
   return (model: ModelDefinition, dataProvider: GraphbackDataProvider): GraphbackCRUDService => {
     const service = serviceCreator(model, dataProvider);
     const objConfig = authConfigList[model.graphqlType.name];
-    const keycloakService = new KeycloakCrudService({ service, authConfig: objConfig });
+    const keycloakService = new KeycloakCrudService(model, { service, authConfig: objConfig });
 
     return keycloakService;
   }

--- a/packages/graphback-keycloak-authz/src/index.ts
+++ b/packages/graphback-keycloak-authz/src/index.ts
@@ -1,2 +1,3 @@
 export * from './KeycloakCrudService';
 export * from './KeycloakConfig';
+export * from './createKeycloakCRUDService';

--- a/packages/graphback-keycloak-authz/src/utils.ts
+++ b/packages/graphback-keycloak-authz/src/utils.ts
@@ -1,3 +1,5 @@
+import { GraphbackContext } from '@graphback/core';
+import { isAuthorizedByRole } from 'keycloak-connect-graphql';
 import { CrudServiceAuthConfig } from "./KeycloakConfig"
 
 
@@ -10,6 +12,38 @@ export function getEmptyServiceConfig() {
   }
 
   return serviceConfig;
+}
+
+/**
+ * Checks if user is allowed to create/update particular field
+ */
+export function checkAuthRulesForInput(context: GraphbackContext, authConfig: CrudServiceAuthConfig, inputKeys: string[]) {
+  if (authConfig.updateFields) {
+    for (const inputKey of inputKeys) {
+      if (authConfig.updateFields[inputKey]) {
+        const { roles } = authConfig.updateFields[inputKey];
+        if (!isAuthorizedByRole(roles, context)) {
+          throw new UnauthorizedError()
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Checks if user is allowed to request particular field
+ */
+export function checkAuthRulesForSelections(context: GraphbackContext, authConfig: CrudServiceAuthConfig, selectedFields?: string[]) {
+  if (authConfig.returnFields && selectedFields && selectedFields) {
+    for (const selectedField of selectedFields) {
+      if (authConfig.returnFields[selectedField]) {
+        const { roles } = authConfig.returnFields[selectedField];
+        if (!isAuthorizedByRole(roles, context)) {
+          throw new UnauthorizedError(`Unauthorized to fetch: ${selectedField}`)
+        }
+      }
+    }
+  }
 }
 
 /**

--- a/packages/graphback-keycloak-authz/tests/mocks/MockDataProvider.ts
+++ b/packages/graphback-keycloak-authz/tests/mocks/MockDataProvider.ts
@@ -1,32 +1,32 @@
 /* eslint-disable */
-import { GraphbackDataProvider, GraphbackPage, GraphbackOrderBy } from '@graphback/core';
+import { GraphbackDataProvider, GraphbackPage, GraphbackOrderBy, FindByArgs, QueryFilter } from '@graphback/core';
 
-export class MockDataProvider<Type = any, GraphbackContext = any> implements GraphbackDataProvider<any, any> {
-  async create(data: Type, context: GraphbackContext) {
+export class MockDataProvider<Type = any> implements GraphbackDataProvider<Type> {
+  async create(data: Type, selectedFields: string[]) {
     return data
   }
 
-  async update(data: Type, context: GraphbackContext) {
+  async update(data: Type, selectedFields: string[]) {
     return data
   }
 
-  async delete(data: Type, context: GraphbackContext) {
+  async delete(data: Type, selectedFields: string[]) {
     return data
   }
 
-  async findOne(args: Partial<Type>, context: GraphbackContext) {
-    return args
+  async findOne(args: Partial<Type>, selectedFields: string[]) {
+    return args as Type
   }
 
-  async findBy(filter: any, context: GraphbackContext, page?: GraphbackPage, orderBy?: GraphbackOrderBy) {
+  async findBy(args: FindByArgs, selectedFields: string[], page?: GraphbackPage, orderBy?: GraphbackOrderBy) {
     return []
   }
 
-  async count(filter: any) {
+  async count(filter: QueryFilter) {
     return 1
   }
 
-  async batchRead(relationField: string, ids: string[], filter: any, context: GraphbackContext) {
+  async batchRead(relationField: string, ids: string[], filter: QueryFilter, selectedFields: string[]) {
     return []
   }
 }

--- a/packages/graphback-runtime-knex/src/SQLiteKnexDBDataProvider.ts
+++ b/packages/graphback-runtime-knex/src/SQLiteKnexDBDataProvider.ts
@@ -14,13 +14,13 @@ export class SQLiteKnexDBDataProvider<Type = any> extends KnexDBDataProvider<Typ
     super(model, db);
   }
 
-  public async create(data: Type, context: GraphbackContext): Promise<Type> {
+  public async create(data: Type, selectedFields?: string[]): Promise<Type> {
     const { data: createData } = getDatabaseArguments(this.tableMap, data);
 
     //tslint:disable-next-line: await-promise
     const [id] = await this.db(this.tableName).insert(createData);
     //tslint:disable-next-line: await-promise
-    const dbResult = await this.db.select(this.getSelectedFields(context)).from(this.tableName).where(this.tableMap.idField, '=', id)
+    const dbResult = await this.db.select(this.getSelectedFields(selectedFields)).from(this.tableName).where(this.tableMap.idField, '=', id)
     if (dbResult && dbResult[0]) {
       return dbResult[0]
     }

--- a/packages/graphback-runtime-mongodb/src/queryBuilder.ts
+++ b/packages/graphback-runtime-mongodb/src/queryBuilder.ts
@@ -1,5 +1,5 @@
 import * as escapeRegex from "escape-string-regexp";
-import { metadataMap } from "@graphback/core";
+import { metadataMap, QueryFilter } from "@graphback/core";
 
 const { fieldNames } =  metadataMap;
 
@@ -112,7 +112,7 @@ function stringTimestampsToInt(filter: any, key: string): any {
   return filter;
 }
 
-function traverse(filter: any, coerceTSFields: boolean): any {
+function traverse(filter: QueryFilter, coerceTSFields: boolean): any {
 
   Object.keys(filter).forEach((key: string) => {
 
@@ -166,7 +166,7 @@ function traverse(filter: any, coerceTSFields: boolean): any {
   return filter
 }
 
-export function buildQuery(filter: any, coerceTSFields: boolean) {
+export function buildQuery(filter: QueryFilter, coerceTSFields: boolean) {
   let query = {};
   if (filter) { query = traverse(filter, coerceTSFields); }
 

--- a/packages/graphback-runtime-mongodb/tests/__util__.ts
+++ b/packages/graphback-runtime-mongodb/tests/__util__.ts
@@ -50,7 +50,7 @@ export async function createTestingContext(schemaStr: string, config?: { seedDat
     const collectionNames = Object.keys(config.seedData);
     for (const collectionName of collectionNames) {
       for (const element of config.seedData[collectionName]) {
-        await providers[collectionName].create(element, {graphback: {services: {}, options: {selectedFields: [""]}}});
+        await providers[collectionName].create(element);
       }
     };
   }

--- a/packages/graphback-runtime-mongodb/tests/queryBuilderTest.ts
+++ b/packages/graphback-runtime-mongodb/tests/queryBuilderTest.ts
@@ -1,19 +1,20 @@
+/* eslint-disable max-lines */
 import { ObjectID } from 'mongodb';
 import { advanceTo, advanceBy } from "jest-date-mock";
 import { createTestingContext, Context } from "./__util__";
 
 describe('MongoDBDataProvider Advanced Filtering', () => {
 
-    interface Post {
-      _id: ObjectID;
-      text: string;
-      likes: number;
-    }
-    let context: Context;
+  interface Post {
+    _id: ObjectID;
+    text: string;
+    likes: number;
+  }
+  let context: Context;
 
-    const fields = ["id", "text", "likes"];
+  const fields = ["id", "text", "likes"];
 
-    const postSchema = `
+  const postSchema = `
       """
       @model
       """
@@ -26,26 +27,27 @@ describe('MongoDBDataProvider Advanced Filtering', () => {
       scalar GraphbackObjectID
       `;
 
-    const defaultPostSeed = [
-      { text: 'post', likes: 300 },
-      { text: 'post2', likes: 50 },
-      { text: 'post3', likes: 1500 },
-    ]
+  const defaultPostSeed = [
+    { text: 'post', likes: 300 },
+    { text: 'post2', likes: 50 },
+    { text: 'post3', likes: 1500 },
+  ]
 
 
-    //Create a new database before each tests so that
-    //all tests can run parallel
+  //Create a new database before each tests so that
+  //all tests can run parallel
 
-    afterEach(() => context.server.stop());
+  afterEach(() => context.server.stop());
 
-    it('can filter using AND', async () => {
-      context = await createTestingContext(postSchema, {
-        seedData: {
-          Post: defaultPostSeed
-        }
-      });
+  it('can filter using AND', async () => {
+    context = await createTestingContext(postSchema, {
+      seedData: {
+        Post: defaultPostSeed
+      }
+    });
 
-      const posts: Post[] = await context.providers.Post.findBy({
+    const posts: Post[] = await context.providers.Post.findBy({
+      filter: {
         and: [
           {
             text: { eq: 'post' }
@@ -54,24 +56,26 @@ describe('MongoDBDataProvider Advanced Filtering', () => {
             likes: { eq: 300 }
           }
         ]
-      }, {graphback: {services: {}, options: { selectedFields: fields}}});
-
-      expect(posts.length).toBeGreaterThanOrEqual(1);
-      for (const post of posts) {
-        expect(post.text).toEqual('post');
-        expect(post.likes).toEqual(300);
       }
-
     });
 
-    it('can filter using OR', async () => {
-      context = await createTestingContext(postSchema, {
-        seedData: {
-          Post: defaultPostSeed
-        }
-      });
+    expect(posts.length).toBeGreaterThanOrEqual(1);
+    for (const post of posts) {
+      expect(post.text).toEqual('post');
+      expect(post.likes).toEqual(300);
+    }
 
-      const posts: Post[] = await context.providers.Post.findBy({
+  });
+
+  it('can filter using OR', async () => {
+    context = await createTestingContext(postSchema, {
+      seedData: {
+        Post: defaultPostSeed
+      }
+    });
+
+    const posts: Post[] = await context.providers.Post.findBy({
+      filter: {
         or: [
           {
             text: { eq: 'post2' }
@@ -80,21 +84,23 @@ describe('MongoDBDataProvider Advanced Filtering', () => {
             likes: { eq: 300 }
           }
         ]
-      }, {graphback: {services: {}, options: { selectedFields: fields}}});
-      expect(posts.length).toEqual(2);
-      for (const post of posts) {
-        expect((post.text === 'post2') || (post.likes === 300));
+      }
+    });
+    expect(posts.length).toEqual(2);
+    for (const post of posts) {
+      expect((post.text === 'post2') || (post.likes === 300));
+    }
+  });
+
+  it('can filter using NOT', async () => {
+    context = await createTestingContext(postSchema, {
+      seedData: {
+        Post: defaultPostSeed
       }
     });
 
-    it('can filter using NOT', async () => {
-      context = await createTestingContext(postSchema, {
-        seedData: {
-          Post: defaultPostSeed
-        }
-      });
-
-      const posts: Post[] = await context.providers.Post.findBy({
+    const posts: Post[] = await context.providers.Post.findBy({
+      filter: {
         not: [
           {
             text: { eq: 'post2' }
@@ -103,58 +109,64 @@ describe('MongoDBDataProvider Advanced Filtering', () => {
             likes: { eq: 300 }
           }
         ]
-      }, {graphback: {services: {}, options: { selectedFields: fields}}});
-
-      expect(posts.length).toBeGreaterThanOrEqual(1);
-      for (const post of posts) {
-        expect(post.text).not.toEqual('post2');
-        expect(post.likes).not.toEqual(300);
       }
     });
 
-    it('can filter using between operator', async () => {
-      context = await createTestingContext(postSchema, {
-        seedData: {
-          Post: defaultPostSeed
-        }
-      });
+    expect(posts.length).toBeGreaterThanOrEqual(1);
+    for (const post of posts) {
+      expect(post.text).not.toEqual('post2');
+      expect(post.likes).not.toEqual(300);
+    }
+  });
 
-      const posts: Post[] = await context.providers.Post.findBy({
+  it('can filter using between operator', async () => {
+    context = await createTestingContext(postSchema, {
+      seedData: {
+        Post: defaultPostSeed
+      }
+    });
+
+    const posts: Post[] = await context.providers.Post.findBy({
+      filter: {
         likes: { between: [250, 350] }
-      }, {graphback: {services: {}, options: { selectedFields: fields}}});
-
-      expect(posts.length).toBeGreaterThanOrEqual(1);
-      for (const post of posts) {
-        expect(post.likes).toBeLessThanOrEqual(350);
-        expect(post.likes).toBeGreaterThanOrEqual(250);
       }
     });
 
-    it('can filter using nbetween operator', async () => {
-      context = await createTestingContext(postSchema, {
-        seedData: {
-          Post: defaultPostSeed
-        }
-      });
+    expect(posts.length).toBeGreaterThanOrEqual(1);
+    for (const post of posts) {
+      expect(post.likes).toBeLessThanOrEqual(350);
+      expect(post.likes).toBeGreaterThanOrEqual(250);
+    }
+  });
 
-      const posts: Post[] = await context.providers.Post.findBy({
+  it('can filter using nbetween operator', async () => {
+    context = await createTestingContext(postSchema, {
+      seedData: {
+        Post: defaultPostSeed
+      }
+    });
+
+    const posts: Post[] = await context.providers.Post.findBy({
+      filter: {
         likes: { nbetween: [250, 350] }
-      }, {graphback: {services: {}, options: { selectedFields: fields}}});
-
-      expect(posts.length).toBeGreaterThanOrEqual(1);
-      for (const post of posts) {
-        expect((post.likes < 250) || (post.likes > 350));
       }
     });
 
-    it('can use nested filters', async () => {
-      context = await createTestingContext(postSchema, {
-        seedData: {
-          Post: defaultPostSeed
-        }
-      });
+    expect(posts.length).toBeGreaterThanOrEqual(1);
+    for (const post of posts) {
+      expect((post.likes < 250) || (post.likes > 350));
+    }
+  });
 
-      const posts: Post[] = await context.providers.Post.findBy({
+  it('can use nested filters', async () => {
+    context = await createTestingContext(postSchema, {
+      seedData: {
+        Post: defaultPostSeed
+      }
+    });
+
+    const posts: Post[] = await context.providers.Post.findBy({
+      filter: {
         and: [
           {
             or: [
@@ -169,105 +181,114 @@ describe('MongoDBDataProvider Advanced Filtering', () => {
             ]
           }
         ]
-      }, {graphback: {services: {}, options: { selectedFields: fields}}});
-
-
-      expect(posts.length).toBeGreaterThanOrEqual(1);
-      for (const post of posts) {
-        expect(
-          (
-            (post.likes >= 250) && (post.likes <= 350)
-          )
-          ||
-          (
-            (post.likes >= 25) && (post.likes <= 75)
-          )
-        );
-
-        expect(
-          (post.text === 'post')
-          ||
-          (post.text === 'post2')
-        );
       }
     });
 
-    it('can use contains operator', async () => {
-      context = await createTestingContext(postSchema, {
-        seedData: {
-          Post: defaultPostSeed
-        }
-      });
 
-      const posts: Post[] = await context.providers.Post.findBy({
+    expect(posts.length).toBeGreaterThanOrEqual(1);
+    for (const post of posts) {
+      expect(
+        (
+          (post.likes >= 250) && (post.likes <= 350)
+        )
+        ||
+        (
+          (post.likes >= 25) && (post.likes <= 75)
+        )
+      );
+
+      expect(
+        (post.text === 'post')
+        ||
+        (post.text === 'post2')
+      );
+    }
+  });
+
+  it('can use contains operator', async () => {
+    context = await createTestingContext(postSchema, {
+      seedData: {
+        Post: defaultPostSeed
+      }
+    });
+
+    const posts: Post[] = await context.providers.Post.findBy({
+      filter: {
         text: { contains: 'post' }
-      }, {graphback: {services: {}, options: { selectedFields: fields}}});
-
-      expect(posts.length).toBeGreaterThanOrEqual(1);
-      for (const post of posts) {
-        expect(post.text).toEqual(expect.stringContaining('post'))
       }
-
     });
 
-    it('can use startsWith operator', async () => {
-      context = await createTestingContext(postSchema, {
-        seedData: {
-          Post: defaultPostSeed
-        }
-      });
-
-      const posts: Post[] = await context.providers.Post.findBy({
-        text: { startsWith: 'post' }
-      }, {graphback: {services: {}, options: { selectedFields: fields}}});
-
-      expect(posts.length).toBeGreaterThanOrEqual(1);
-      for (const post of posts) {
-        expect(post.text).toEqual(expect.stringMatching(/^post/g))
-      }
-
-    });
-
-    it('can use endsWith operator', async () => {
-      context = await createTestingContext(postSchema, {
-        seedData: {
-          Post: defaultPostSeed
-        }
-      });
-
-      const posts: Post[] = await context.providers.Post.findBy({
-        text: { endsWith: 'post' }
-      }, {graphback: {services: {}, options: { selectedFields: fields}}});
-
-      expect(posts.length).toBeGreaterThanOrEqual(1);
-      for (const post of posts) {
-        expect(post.text).toEqual(expect.stringMatching(/post$/g))
-      }
-
-    });
-
-    test('escaping regex strings', async () => {
-      context = await createTestingContext(postSchema, {
-        seedData: {
-          Post: [
-            ...defaultPostSeed,
-            { text: 'p..t', likes: 4500 }
-          ]
-        }
-      });
-
-      const posts: Post[] = await context.providers.Post.findBy({
-        text: { contains: 'p..t' }
-      }, {graphback: {services: {}, options: { selectedFields: ["text"]}}});
-
-      expect(posts.length).toBeGreaterThanOrEqual(1);
-      for (const post of posts) {
-        expect(post.text).toMatch(/p\.\.t/g)
-      }
-
-    });
+    expect(posts.length).toBeGreaterThanOrEqual(1);
+    for (const post of posts) {
+      expect(post.text).toEqual(expect.stringContaining('post'))
+    }
 
   });
+
+  it('can use startsWith operator', async () => {
+    context = await createTestingContext(postSchema, {
+      seedData: {
+        Post: defaultPostSeed
+      }
+    });
+
+    const posts: Post[] = await context.providers.Post.findBy({
+      filter: {
+        text: { startsWith: 'post' }
+      }
+    });
+
+    expect(posts.length).toBeGreaterThanOrEqual(1);
+    for (const post of posts) {
+      expect(post.text).toEqual(expect.stringMatching(/^post/g))
+    }
+
+  });
+
+  it('can use endsWith operator', async () => {
+    context = await createTestingContext(postSchema, {
+      seedData: {
+        Post: defaultPostSeed
+      }
+    });
+
+    const posts: Post[] = await context.providers.Post.findBy({
+      filter: {
+        text: { endsWith: 'post' }
+      }
+    });
+
+    expect(posts.length).toBeGreaterThanOrEqual(1);
+    for (const post of posts) {
+      expect(post.text).toEqual(expect.stringMatching(/post$/g))
+    }
+
+  });
+
+  test('escaping regex strings', async () => {
+    context = await createTestingContext(postSchema, {
+      seedData: {
+        Post: [
+          ...defaultPostSeed,
+          { text: 'p..t', likes: 4500 }
+        ]
+      }
+    });
+
+    const posts: Post[] = await context.providers.Post.findBy({
+      filter: {
+        text: { contains: 'p..t' }
+      }
+    });
+
+    expect(posts.length).toBeGreaterThanOrEqual(1);
+    for (const post of posts) {
+      expect(post.text).toMatch(/p\.\.t/g)
+    }
+
+  });
+
+});
 
 describe('queryBuilder scalar filtering', () => {
   let context: Context;
@@ -275,7 +296,6 @@ describe('queryBuilder scalar filtering', () => {
   afterEach(() => context.server.stop());
 
   it('can filter @versioned metadata fields', async () => {
-    const fields = ["id", "text", "createdAt", "updatedAt"];
 
     context = await createTestingContext(`
     """
@@ -295,20 +315,25 @@ describe('queryBuilder scalar filtering', () => {
     // Create some posts
     for (const postTitle of ["hi guys", "not yet", "bye guys"]) {
       advanceBy(3000);
-      await context.providers.Post.create({ text: postTitle }, {graphback: {services: {}, options: { selectedFields: ["id"]}}});
+      await context.providers.Post.create({ text: postTitle });
     }
 
     // Get all posts created since startTime
-    const posts = await context.providers.Post.findBy({ createdAt: { gt: startTime } }, {graphback: {services: {}, options: { selectedFields: fields}}});
+    const posts = await context.providers.Post.findBy({
+      filter: {
+        createdAt: { gt: startTime }
+      }
+    });
     expect(posts.length).toEqual(3);
     expect(posts.map((post: any) => post.text)).toEqual(["hi guys", "not yet", "bye guys"]);
 
     // Get all posts created after the first post
-    const newPosts = await context.providers.Post.findBy({ createdAt: { gt: posts[0].createdAt } }, {graphback: {services: {}, options: { selectedFields: fields}}});
+    const newPosts = await context.providers.Post.findBy({ filter: { createdAt: { gt: posts[0].createdAt } } });
     expect(newPosts.length).toEqual(2);
     expect(newPosts.map((post: any) => post.text)).toEqual(["not yet", "bye guys"]);
 
     // Passing invalid timestamp throws
-    expect(context.providers.Post.findBy({ createdAt: { gt: "break" } }, {graphback: {services: {}, options: { selectedFields: ["id", "text"]}}})).rejects.toThrow();
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    expect(context.providers.Post.findBy({ filter: { createdAt: { gt: "break" } } })).rejects.toThrow();
   });
 })

--- a/packages/graphback/src/buildGraphbackAPI.ts
+++ b/packages/graphback/src/buildGraphbackAPI.ts
@@ -128,7 +128,7 @@ export function buildGraphbackAPI(model: string | GraphQLSchema, config: Graphba
   const contextCreator = (context: any) => {
     return {
       ...context,
-      graphback: { services, options: {} }
+      graphback: { services }
     }
   }
 


### PR DESCRIPTION
See **Release notes** below for what has changed in this PR..

This PR improves the user API by decreasing reliance on user modification of the context in resolvers. Now you can create a custom resolver without the context if you wish:

```ts
const customResolvers = {
  Query: {
    getDraftNotes: async (_: any, __: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
      const noteService = context.graphback.services.Note;

      const results = await noteService.findBy({
        filter: {
          title: {
            startsWith: '[WIP]'
          }
        }
      })

      return results.items;
    }
  }
}
```

It is a matter of passing the optional context and info to the CRUD layer, where Graphback will handle field selection, aggregrations etc.

This PR also adds other fixes in the same area (like usng generics instead of any)

### Release notes

#### Changed GraphbackCRUDService `findBy` method signature. This also applies to all services that implement this interface.


```patch
- findBy(filter: QueryFilter<Type>, context: GraphbackContext, page?: GraphbackPage, orderBy?: any): Promise<ResultList<Type>>;
+ findBy(args?: FindByArgs, context?: GraphbackContext, info?: GraphQLResolveInfo): Promise<ResultList<Type>>;
```

**args**

`findBy` now accepts a new interface, `FindByArgs`, which wraps the `filter`, `page` and `orderBy` optional arguments.

```ts
await noteService.findBy({
  filter: {
    id: {
      gt: 100
    }
  },
  page: {
    offset: 0,
    limit: 10
  },
  orderBy: {
    field: 'id'
  }
})
```

**context**

The context parameter is now optional.

**info**

You can now optionally pass the `GraphQLResolveInfo` info object to the CRUD service, to perform extra optimizations like retrieving only the selected fields from the query.

```ts
await noteService.findBy(filter, context, info);
```

#### `context` parameter removed from `subscribeToCreate`, `subscribeToDelete`, `subscribeToUpdate` methods in GraphbackCRUDService.

This method was unused.

#### Removed `context` parameter from all GraphbackDataProvider methods. This also applies to all providers that implement this interface.

All CRUD methods in `GraphbackDataProvider` had a `context` parameter used to get the selected fields. 
These have been replaced with (optional) `selectedFields` - you can pass a string array of the fields you want to select from the database.

```ts
await noteProvider.findBy(filter, ['id', 'name']);
```

#### Changed GraphbackDataProvider `findBy` method signature. This also applies to all providers that implement this interface.

**args**

`findBy` now accepts a new interface, `FindByArgs`, which wraps the `filter`, `page` and `orderBy` optional arguments.

```ts
await noteService.findBy({
  filter: {
    id: {
      gt: 100
    }
  },
  page: {
    offset: 0,
    limit: 10
  },
  orderBy: {
    field: 'id'
  }
})
```

#### Remove resolver options from GraphbackContext

Resolver options was removed from the context because the `count` aggregation and `selectedFields` extraction logic was moved to the CRUDService method.

#### CRUDService, DataSyncCRUDService now accepts a `ModelDefinition` as the first constructor parameter.

To instantiate a CRUDService you must pass the full `ModelDefinition` instead of the model name.

```ts
const myService = new CRUDService(modelDefinition, ...);
```

#### KeycloakCrudService now accepts a `ModelDefinition` as the first constructor parameter.

To instantiate a CRUDService you must pass the full `ModelDefinition` instead of the model name.

```ts
const myService = new KeycloakCrudService(modelDefinition, ...);
```

#### DataSyncProvider `sync` method signature has been changed

```patch
- sync(lastSync: Date, context: GraphbackContext, filter?: any, limit?: number): Promise<Type[]>;
+ sync(lastSync: Date, selectedFields?: string[], filter?: QueryFilter, limit?: number): Promise<Type[]>;
```

The `context` argument has been replaced with (optional) `selectedFields`.

#### `context` parameter is removed from the `create` method in `MongoDBDataProvider` and `DatasyncMongoDBDataProvider` providers.

This parameter did not do anything.

## Follow up

- This enables https://github.com/aerogear/graphback/issues/1627 to be completed.