### PR TITLE
feat(context): move service map to context top-level

### DIFF
--- a/docs/plugins/creating-your-own-plugin.md
+++ b/docs/plugins/creating-your-own-plugin.md
@@ -130,7 +130,7 @@ export class MyGraphbackPlugin extends GraphbackPlugin {
 
       // create a resolver function for every query field created in `transformSchema`
       queryObj[`getArchived${modelName}s`] = async (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-        const crudService = context.graphback.services[modelName];
+        const crudService = context.services[modelName];
 
         // create a filter in the GraphQLCRUD format to retrieve only archived Notes
         const customFilter: QueryFilter = {

--- a/docs/plugins/creating-your-own-plugin.md
+++ b/docs/plugins/creating-your-own-plugin.md
@@ -130,7 +130,7 @@ export class MyGraphbackPlugin extends GraphbackPlugin {
 
       // create a resolver function for every query field created in `transformSchema`
       queryObj[`getArchived${modelName}s`] = async (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-        const crudService = context.services[modelName];
+        const crudService = context.graphback[modelName];
 
         // create a filter in the GraphQLCRUD format to retrieve only archived Notes
         const customFilter: QueryFilter = {

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -153,6 +153,21 @@ await noteService.findBy({
 
 Resolver options (`context.graphback.options`) was removed from the context because the `count` aggregation and `selectedFields` extraction logic was moved to the CRUDService method.
 
+### Removed graphback key from GraphbackContext
+
+The `graphback` property has been removed from `GraphbackContext`.
+
+```patch
+export interface GraphbackContext {
+-  graphback: {
+-    services: GraphbackServiceConfigMap
+-  }
++  services: GraphbackServiceConfigMap
+}
+```
+
+Now you can reach the Graphback services by calling `context.services.Note.findBy(...)`.
+
 #### CRUDService, DataSyncCRUDService now accepts a `ModelDefinition` as the first constructor parameter.
 
 To instantiate a CRUDService you must pass the full `ModelDefinition` instead of the model name.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -155,18 +155,18 @@ Resolver options (`context.graphback.options`) was removed from the context beca
 
 ### Removed graphback key from GraphbackContext
 
-The `graphback` property has been removed from `GraphbackContext`.
+The `graphback.services` property has been removed from `GraphbackContext`, and `graphback` is now the service map property.
 
 ```patch
 export interface GraphbackContext {
 -  graphback: {
--    services: GraphbackServiceConfigMap
+-    graphback: GraphbackServiceConfigMap
 -  }
-+  services: GraphbackServiceConfigMap
++  graphback: GraphbackServiceConfigMap
 }
 ```
 
-Now you can reach the Graphback services by calling `context.services.Note.findBy(...)`.
+Now you can reach the Graphback service map by calling `context.graphback.Note.findBy(...)`.
 
 #### CRUDService, DataSyncCRUDService now accepts a `ModelDefinition` as the first constructor parameter.
 

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -504,11 +504,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const resolverCreateField = getFieldName(modelName, GraphbackOperationType.CREATE);
 
     mutationObj[resolverCreateField] = (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
+      if (!context.services || !context.services[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
 
-      return context.graphback.services[modelName].create(args.input, context, info);
+      return context.services[modelName].create(args.input, context, info);
     }
   }
 
@@ -523,11 +523,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const updateField = getFieldName(modelName, GraphbackOperationType.UPDATE);
 
     mutationObj[updateField] = (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
+      if (!context.services || !context.services[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
 
-      return context.graphback.services[modelName].update(args.input, context, info)
+      return context.services[modelName].update(args.input, context, info)
     }
   }
 
@@ -542,11 +542,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const deleteField = getFieldName(modelName, GraphbackOperationType.DELETE);
 
     mutationObj[deleteField] = (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
+      if (!context.services || !context.services[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
 
-      return context.graphback.services[modelName].delete(args.input, context, info)
+      return context.services[modelName].delete(args.input, context, info)
     }
   }
 
@@ -562,7 +562,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const findField = getFieldName(modelName, GraphbackOperationType.FIND);
 
     queryObj[findField] = async (_: any, args: FindByArgs, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      return context.graphback.services[modelName].findBy(args, context, info, 'items')
+      return context.services[modelName].findBy(args, context, info, 'items')
     }
   }
 
@@ -579,11 +579,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const primaryKeyLabel = model.primaryKey.name;
 
     queryObj[findOneField] = (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
+      if (!context.services || !context.services[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
 
-      return context.graphback.services[modelName].findOne({ [primaryKeyLabel]: args.id }, context, info)
+      return context.services[modelName].findOne({ [primaryKeyLabel]: args.id }, context, info)
     }
   }
 
@@ -599,11 +599,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
 
     subscriptionObj[operation] = {
       subscribe: (_: any, args: any, context: GraphbackContext) => {
-        if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
+        if (!context.services || !context.services[modelName]) {
           throw new Error(`Missing service for ${modelName}`);
         }
 
-        return context.graphback.services[modelName].subscribeToCreate(args.filter, context);
+        return context.services[modelName].subscribeToCreate(args.filter, context);
       }
     }
   }
@@ -620,11 +620,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
 
     subscriptionObj[operation] = {
       subscribe: (_: any, args: any, context: GraphbackContext) => {
-        if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
+        if (!context.services || !context.services[modelName]) {
           throw new Error(`Missing service for ${modelName}`);
         }
 
-        return context.graphback.services[modelName].subscribeToUpdate(args.filter, context);
+        return context.services[modelName].subscribeToUpdate(args.filter, context);
       }
     }
   }
@@ -641,11 +641,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
 
     subscriptionObj[operation] = {
       subscribe: (_: any, args: any, context: GraphbackContext) => {
-        if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
+        if (!context.services || !context.services[modelName]) {
           throw new Error(`Missing service for ${modelName}`);
         }
 
-        return context.graphback.services[modelName].subscribeToDelete(args.filter, context);
+        return context.services[modelName].subscribeToDelete(args.filter, context);
       }
     }
   }
@@ -667,11 +667,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
         return parent[relationOwner];
       }
 
-      if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
+      if (!context.services || !context.services[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
 
-      return context.graphback.services[modelName].batchLoadData(
+      return context.services[modelName].batchLoadData(
         relationship.relationForeignKey,
         parent[model.primaryKey.name],
         args.filter,
@@ -699,7 +699,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
         return parent[relationOwner];
       }
 
-      if (!context.graphback || !context.graphback.services || !context.graphback.services[modelName]) {
+      if (!context.services || !context.services[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
 
@@ -714,7 +714,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
       if (!context[dataLoaderName]) {
         context[dataLoaderName] = new DataLoader<string, any>(async (keys: string[]) => {
 
-          const service = context.graphback.services[modelName];
+          const service = context.services[modelName];
           const results = await service.findBy({ [relationIdField.name]: { in: keys }, }, context, info);
 
           return keys.map((key: string) => {

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -504,11 +504,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const resolverCreateField = getFieldName(modelName, GraphbackOperationType.CREATE);
 
     mutationObj[resolverCreateField] = (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      if (!context.services || !context.services[modelName]) {
+      if (!context.graphback || !context.graphback[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
 
-      return context.services[modelName].create(args.input, context, info);
+      return context.graphback[modelName].create(args.input, context, info);
     }
   }
 
@@ -523,11 +523,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const updateField = getFieldName(modelName, GraphbackOperationType.UPDATE);
 
     mutationObj[updateField] = (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      if (!context.services || !context.services[modelName]) {
+      if (!context.graphback || !context.graphback[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
 
-      return context.services[modelName].update(args.input, context, info)
+      return context.graphback[modelName].update(args.input, context, info)
     }
   }
 
@@ -542,11 +542,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const deleteField = getFieldName(modelName, GraphbackOperationType.DELETE);
 
     mutationObj[deleteField] = (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      if (!context.services || !context.services[modelName]) {
+      if (!context.graphback || !context.graphback[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
 
-      return context.services[modelName].delete(args.input, context, info)
+      return context.graphback[modelName].delete(args.input, context, info)
     }
   }
 
@@ -562,7 +562,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const findField = getFieldName(modelName, GraphbackOperationType.FIND);
 
     queryObj[findField] = async (_: any, args: FindByArgs, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      return context.services[modelName].findBy(args, context, info, 'items')
+      return context.graphback[modelName].findBy(args, context, info, 'items')
     }
   }
 
@@ -579,11 +579,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     const primaryKeyLabel = model.primaryKey.name;
 
     queryObj[findOneField] = (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      if (!context.services || !context.services[modelName]) {
+      if (!context.graphback || !context.graphback[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
 
-      return context.services[modelName].findOne({ [primaryKeyLabel]: args.id }, context, info)
+      return context.graphback[modelName].findOne({ [primaryKeyLabel]: args.id }, context, info)
     }
   }
 
@@ -599,11 +599,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
 
     subscriptionObj[operation] = {
       subscribe: (_: any, args: any, context: GraphbackContext) => {
-        if (!context.services || !context.services[modelName]) {
+        if (!context.graphback || !context.graphback[modelName]) {
           throw new Error(`Missing service for ${modelName}`);
         }
 
-        return context.services[modelName].subscribeToCreate(args.filter, context);
+        return context.graphback[modelName].subscribeToCreate(args.filter, context);
       }
     }
   }
@@ -620,11 +620,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
 
     subscriptionObj[operation] = {
       subscribe: (_: any, args: any, context: GraphbackContext) => {
-        if (!context.services || !context.services[modelName]) {
+        if (!context.graphback || !context.graphback[modelName]) {
           throw new Error(`Missing service for ${modelName}`);
         }
 
-        return context.services[modelName].subscribeToUpdate(args.filter, context);
+        return context.graphback[modelName].subscribeToUpdate(args.filter, context);
       }
     }
   }
@@ -641,11 +641,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
 
     subscriptionObj[operation] = {
       subscribe: (_: any, args: any, context: GraphbackContext) => {
-        if (!context.services || !context.services[modelName]) {
+        if (!context.graphback || !context.graphback[modelName]) {
           throw new Error(`Missing service for ${modelName}`);
         }
 
-        return context.services[modelName].subscribeToDelete(args.filter, context);
+        return context.graphback[modelName].subscribeToDelete(args.filter, context);
       }
     }
   }
@@ -667,11 +667,11 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
         return parent[relationOwner];
       }
 
-      if (!context.services || !context.services[modelName]) {
+      if (!context.graphback || !context.graphback[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
 
-      return context.services[modelName].batchLoadData(
+      return context.graphback[modelName].batchLoadData(
         relationship.relationForeignKey,
         parent[model.primaryKey.name],
         args.filter,
@@ -699,7 +699,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
         return parent[relationOwner];
       }
 
-      if (!context.services || !context.services[modelName]) {
+      if (!context.graphback || !context.graphback[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
 
@@ -714,7 +714,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
       if (!context[dataLoaderName]) {
         context[dataLoaderName] = new DataLoader<string, any>(async (keys: string[]) => {
 
-          const service = context.services[modelName];
+          const service = context.graphback[modelName];
           const results = await service.findBy({ [relationIdField.name]: { in: keys }, }, context, info);
 
           return keys.map((key: string) => {

--- a/packages/graphback-core/src/runtime/interfaces.ts
+++ b/packages/graphback-core/src/runtime/interfaces.ts
@@ -14,7 +14,7 @@ export interface GraphbackServiceConfigMap {
  * GraphQL context interface according to Graphback runtime layer format
  */
 export interface GraphbackContext {
-  services: GraphbackServiceConfigMap
+  graphback: GraphbackServiceConfigMap
 }
 
 /**

--- a/packages/graphback-core/src/runtime/interfaces.ts
+++ b/packages/graphback-core/src/runtime/interfaces.ts
@@ -14,9 +14,7 @@ export interface GraphbackServiceConfigMap {
  * GraphQL context interface according to Graphback runtime layer format
  */
 export interface GraphbackContext {
-  graphback: {
-    services: GraphbackServiceConfigMap
-  }
+  services: GraphbackServiceConfigMap
 }
 
 /**

--- a/packages/graphback-datasync/src/DataSyncPlugin.ts
+++ b/packages/graphback-datasync/src/DataSyncPlugin.ts
@@ -46,7 +46,7 @@ export class DataSyncPlugin extends GraphbackPlugin {
       // Diff queries
       if (isDataSyncModel(model)) {
 
-        dataSyncModelCount+= 1;
+        dataSyncModelCount += 1;
         modelConflictConfigSet.delete(model.graphqlType.name);
 
         this.addDataSyncFieldsToModel(schemaComposer, model);
@@ -108,7 +108,10 @@ export class DataSyncPlugin extends GraphbackPlugin {
     const deltaQuery = getDeltaQuery(modelName)
 
     queryObj[deltaQuery] = async (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      const dataSyncService = isDataSyncService(context.graphback.services[modelName]);
+      if (!context.services || !context.services[modelName]) {
+        throw new Error(`Missing service for ${modelName}`);
+      }
+      const dataSyncService = isDataSyncService(context.services[modelName]);
       if (dataSyncService === undefined) {
         throw Error("Service is not a DataSyncCRUDService. Please use DataSyncCRUDService and DataSync-compliant DataProvider with DataSync Plugin to get Delta Queries.")
       }

--- a/packages/graphback-datasync/src/DataSyncPlugin.ts
+++ b/packages/graphback-datasync/src/DataSyncPlugin.ts
@@ -108,10 +108,10 @@ export class DataSyncPlugin extends GraphbackPlugin {
     const deltaQuery = getDeltaQuery(modelName)
 
     queryObj[deltaQuery] = async (_: any, args: any, context: GraphbackContext, info: GraphQLResolveInfo) => {
-      if (!context.services || !context.services[modelName]) {
+      if (!context.graphback || !context.graphback[modelName]) {
         throw new Error(`Missing service for ${modelName}`);
       }
-      const dataSyncService = isDataSyncService(context.services[modelName]);
+      const dataSyncService = isDataSyncService(context.graphback[modelName]);
       if (dataSyncService === undefined) {
         throw Error("Service is not a DataSyncCRUDService. Please use DataSyncCRUDService and DataSync-compliant DataProvider with DataSync Plugin to get Delta Queries.")
       }

--- a/packages/graphback-keycloak-authz/tests/KeycloakCrudService.test.ts
+++ b/packages/graphback-keycloak-authz/tests/KeycloakCrudService.test.ts
@@ -64,7 +64,7 @@ test('unauthorized tokens will result in unauthorized errors', async () => {
     }
   } as Keycloak.Token
 
-  const unauthorizedContext = { kauth: new KeycloakContextBase(unauthorizedToken), services: {} }
+  const unauthorizedContext = { kauth: new KeycloakContextBase(unauthorizedToken), graphback: {} }
 
   const val = { test: 'value' }
 
@@ -133,7 +133,7 @@ test('authorized tokens will not throw an error and will get a result', async ()
   } as Keycloak.Token
 
 
-  const authorizedContext = { kauth: new KeycloakContextBase(authorizedToken), services: {} }
+  const authorizedContext = { kauth: new KeycloakContextBase(authorizedToken), graphback: {} }
 
   const dbCreateSpy = jest.spyOn(db, "create")
   const dbUpdateSpy = jest.spyOn(db, "update")
@@ -188,7 +188,7 @@ test('passing no authConfig will result in all operations being allowed', async 
     service: new CRUDService(modelDefinition, db, { crudOptions: {}, pubSub })
   })
 
-  const context = { kauth: {}, services: {} }
+  const context = { kauth: {}, graphback: {} }
   const val = { test: 'value' }
 
   await expect(service.create(val, context)).resolves.toEqual(val)
@@ -241,7 +241,7 @@ test('multiple roles can be applied to each operation', async () => {
     }
   } as Keycloak.Token
 
-  const context = { kauth: new KeycloakContextBase(Token), services: {} }
+  const context = { kauth: new KeycloakContextBase(Token), graphback: {} }
 
   const val = { test: 'value' }
 
@@ -294,7 +294,7 @@ test('Subscriptions', async () => {
     }
   } as Keycloak.Token
 
-  const context = { kauth: new KeycloakContextBase(Token), services: {} }
+  const context = { kauth: new KeycloakContextBase(Token), graphback: {} }
 
   const val = { test: 'value' }
 
@@ -353,7 +353,7 @@ test('Batching', async () => {
     }
   } as Keycloak.Token
 
-  const context = { kauth: new KeycloakContextBase(Token), services: {} }
+  const context = { kauth: new KeycloakContextBase(Token), graphback: {} }
 
   expect(() => service.batchLoadData('task', "test", {}, context)).toThrowError('User is not authorized.')
 });
@@ -398,7 +398,7 @@ test('Input filter', async () => {
     }
   } as Keycloak.Token
 
-  const context = { kauth: new KeycloakContextBase(Token), services: {} }
+  const context = { kauth: new KeycloakContextBase(Token), graphback: {} }
 
   expect(() => service.update({ secret: "Tasks only for admins" }, context)).toThrowError('User is not authorized.')
   expect(() => service.create({ secret: "Tasks updates only for admins" }, context)).toThrowError('User is not authorized.')

--- a/packages/graphback-keycloak-authz/tests/KeycloakCrudService.test.ts
+++ b/packages/graphback-keycloak-authz/tests/KeycloakCrudService.test.ts
@@ -64,7 +64,7 @@ test('unauthorized tokens will result in unauthorized errors', async () => {
     }
   } as Keycloak.Token
 
-  const unauthorizedContext = { kauth: new KeycloakContextBase(unauthorizedToken), graphback: { services: {} } }
+  const unauthorizedContext = { kauth: new KeycloakContextBase(unauthorizedToken), services: {} }
 
   const val = { test: 'value' }
 
@@ -133,7 +133,7 @@ test('authorized tokens will not throw an error and will get a result', async ()
   } as Keycloak.Token
 
 
-  const authorizedContext = { kauth: new KeycloakContextBase(authorizedToken), graphback: { services: {} } }
+  const authorizedContext = { kauth: new KeycloakContextBase(authorizedToken), services: {} }
 
   const dbCreateSpy = jest.spyOn(db, "create")
   const dbUpdateSpy = jest.spyOn(db, "update")
@@ -188,7 +188,7 @@ test('passing no authConfig will result in all operations being allowed', async 
     service: new CRUDService(modelDefinition, db, { crudOptions: {}, pubSub })
   })
 
-  const context = { kauth: {}, graphback: { services: {} } }
+  const context = { kauth: {}, services: {} }
   const val = { test: 'value' }
 
   await expect(service.create(val, context)).resolves.toEqual(val)
@@ -241,7 +241,7 @@ test('multiple roles can be applied to each operation', async () => {
     }
   } as Keycloak.Token
 
-  const context = { kauth: new KeycloakContextBase(Token), graphback: { services: {} } }
+  const context = { kauth: new KeycloakContextBase(Token), services: {} }
 
   const val = { test: 'value' }
 
@@ -294,7 +294,7 @@ test('Subscriptions', async () => {
     }
   } as Keycloak.Token
 
-  const context = { kauth: new KeycloakContextBase(Token), graphback: { services: {} } }
+  const context = { kauth: new KeycloakContextBase(Token), services: {} }
 
   const val = { test: 'value' }
 
@@ -353,7 +353,7 @@ test('Batching', async () => {
     }
   } as Keycloak.Token
 
-  const context = { kauth: new KeycloakContextBase(Token), graphback: { services: {} } }
+  const context = { kauth: new KeycloakContextBase(Token), services: {} }
 
   expect(() => service.batchLoadData('task', "test", {}, context)).toThrowError('User is not authorized.')
 });
@@ -398,7 +398,7 @@ test('Input filter', async () => {
     }
   } as Keycloak.Token
 
-  const context = { kauth: new KeycloakContextBase(Token), graphback: { services: {} } }
+  const context = { kauth: new KeycloakContextBase(Token), services: {} }
 
   expect(() => service.update({ secret: "Tasks only for admins" }, context)).toThrowError('User is not authorized.')
   expect(() => service.create({ secret: "Tasks updates only for admins" }, context)).toThrowError('User is not authorized.')

--- a/packages/graphback/src/buildGraphbackAPI.ts
+++ b/packages/graphback/src/buildGraphbackAPI.ts
@@ -128,7 +128,7 @@ export function buildGraphbackAPI(model: string | GraphQLSchema, config: Graphba
   const contextCreator = (context: any) => {
     return {
       ...context,
-      graphback: { services }
+      services
     }
   }
 

--- a/packages/graphback/src/buildGraphbackAPI.ts
+++ b/packages/graphback/src/buildGraphbackAPI.ts
@@ -128,7 +128,7 @@ export function buildGraphbackAPI(model: string | GraphQLSchema, config: Graphba
   const contextCreator = (context: any) => {
     return {
       ...context,
-      services
+      graphback: services
     }
   }
 


### PR DESCRIPTION
The `graphback` property has been removed from `GraphbackContext`.

```patch
export interface GraphbackContext {
-  graphback: {
-    services: GraphbackServiceConfigMap
-  }
+  graphback: GraphbackServiceConfigMap
}
```

Now you can reach the Graphback services like so: 

```patch
- context.graphback.services.Note.findBy(...);
+ context.graphback.Note.findBy(...);
```

This is another enabler PR for #1637 