### PR TITLE
docs: add custom resolvers page

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -16,6 +16,9 @@
       "crud/mutations",
       "crud/subscriptions"
     ],
+    "Resolvers": [
+      "resolvers/custom-resolvers"
+    ],
     "Databases": [
       "databases/overview",
       "databases/mongodb",


### PR DESCRIPTION
This PR adds documentation for how you can use the Graphback services in your own custom resolvers.