### PR TITLE
fix: correct main path of graphql-serve

### DIFF
--- a/packages/graphql-serve/package.json
+++ b/packages/graphql-serve/package.json
@@ -1,8 +1,8 @@
 {
   "name": "graphql-serve",
   "version": "0.16.0",
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "license": "Apache 2.0",
   "typescript": {
     "definition": "types/index.d.ts"


### PR DESCRIPTION
Without this I was running through

```log
 error TS2307: Cannot find module 'graphql-serve' or its corresponding type declarations.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
