### PR TITLE
ci: add timeout in minutes

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   buildWebsite:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     # Allow failure when website build fails. This won't block merging but the status will still be red allowing for investigations
     continue-on-error: true
     steps:

--- a/.github/workflows/graphback-ci.yml
+++ b/.github/workflows/graphback-ci.yml
@@ -43,6 +43,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     services:
       mongodb:
         image: mongo:4.2.9


### PR DESCRIPTION
Make the timeout to 60 minutes to fail fast instead of the default 360 which is kinda long.