### PR TITLE
fix(graphql-serve): import full chalk module

### DIFF
--- a/packages/graphql-serve/src/commands/printSchema.ts
+++ b/packages/graphql-serve/src/commands/printSchema.ts
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import { cyan } from 'chalk';
+import chalk from 'chalk';
 import { printSchemaHandler } from '../components';
 
 type Params = { model?: string };
@@ -22,5 +22,5 @@ export function handler(args: Params): void {
   const schemaSDL = printSchemaHandler(args);
 
   console.log("Generated schema:\n");
-  console.log(cyan(schemaSDL));
+  console.log(chalk.cyan(schemaSDL));
 }


### PR DESCRIPTION
This fixes #1999 - the full chalk module needed to be imported.