### PR TITLE
feat(create-graphback): add a filter option to filter limit displayed templates

### DIFF
--- a/packages/create-graphback/src/index.ts
+++ b/packages/create-graphback/src/index.ts
@@ -4,7 +4,12 @@ import * as yargs from 'yargs';
 
 import { init } from './init/components';
 
-type Params = { name?: string, templateName?: string, templateUrl: string };
+type Params = {
+  name?: string;
+  templateName?: string;
+  templateUrl?: string;
+  filter?: string;
+};
 
 const command = '$0 <name>';
 
@@ -14,33 +19,46 @@ export const desc = 'Create Graphback project from available templates';
 export const builder = (args: yargs.Argv) => {
   args.positional('name', {
     describe: 'Project name',
-    type: 'string',
-  })
+    type: 'string'
+  });
   args.option('templateName', {
     describe: 'Name of the predefined template',
     type: 'string'
-  })
+  });
   args.option('templateUrl', {
-    describe: 'GitHub URL of the template. For example (https://github.com/wtrocki/graphql-serve-example#master)',
+    describe:
+      'GitHub URL of the template. For example (https://github.com/wtrocki/graphql-serve-example#master)',
     type: 'string'
-  })
-}
+  });
+  args.option('filter', {
+    describe:
+      'A filter option used to limit the number of displayed templates that only matches it. For example "postgres" will only display templates that have a Postgres backed',
+    type: 'string'
+  });
+};
 
-export async function handler({ name, templateName, templateUrl }: Params) {
-  await init(name, templateName, templateUrl);
+export async function handler({
+  name,
+  templateName,
+  templateUrl,
+  filter
+}: Params) {
+  await init(name, templateName, templateUrl, filter);
 }
 
 if (require.main === module) {
   // eslint-disable-next-line no-unused-expressions
   yargs
     .command(command, desc, builder, handler)
-    .example('$0 my-awesome-project', 'creates the "my-awesome-project" in the current working directory')
+    .example(
+      '$0 my-awesome-project',
+      'creates the "my-awesome-project" in the current working directory'
+    )
     .demandCommand(1)
     .strict()
     .recommendCommands()
     .help()
     .alias('h', 'help')
     .version()
-    .alias('v', 'version')
-    .argv;
+    .alias('v', 'version').argv;
 }

--- a/packages/create-graphback/src/init/components.ts
+++ b/packages/create-graphback/src/init/components.ts
@@ -32,7 +32,7 @@ async function chooseTemplate(filter: string = ''): Promise<Template> {
     regex.test(`${chalk.green(template.name)} ${template.description}`)
   );
   if (!displayedTemplates.length) {
-    logInfo(`Graphback init could not find templates matching the given filter: "${filter}".
+    logInfo(`create-graphback could not find templates matching the given filter: "${filter}".
 You can either change the given filter or not pass the option to display the full list.`);
     process.exit(0);
   }


### PR DESCRIPTION
Fixes https://github.com/aerogear/graphback/issues/1981

To verify:

1. checkout the PR locally
2. Build the project
3. Use the following command to launch the init script:
  ```
  node packages/create-graphback/dist/index.js test --filter mongo
  ```
  This will only display mongo related templates.

Filtering is optional, a full list will be displayed if this option is
not supplied.