### PR TITLE
fix: do not require manyToOne to be defined on the relationship field

### DIFF
--- a/packages/graphback-core/src/crud/mappingHelpers.ts
+++ b/packages/graphback-core/src/crud/mappingHelpers.ts
@@ -163,7 +163,7 @@ export function getInputFieldTypeName(modelName: string, field: GraphQLField<any
 
     const relationshipAnnotation = parseRelationshipAnnotation(field.description);
 
-    if (!relationshipAnnotation) {
+    if (!relationshipAnnotation && relationshipAnnotation.kind !== 'manyToOne') {
       throw new Error(`Missing relationship definition on: "${modelName}.${field.name}". Visit https://graphback.dev/docs/model/datamodel#relationships to see how you can define relationship in your business model.`);
     }
 


### PR DESCRIPTION
With the current shape of relationships, graphback is really confusing with validation failing with errors that should not happen.

1) ManyToOne is not documented yet it is **required** and **validated** to be present

2) Using ManyToOne in model is causing validation issues (despite usage being valid)

3) Using only OneToMany will not work with model - client-side generation plugin is not seeing changes and breaks when generating client side queries. (that can be a separate issue but is also a sign of problem) 

3) Validation for relationships is clearly broken (Specifying the same `key` value on both sides still ends up with the validation error.

4) Model itself is a little bit confusing as we are **forced** to remove fields that should stay.


### Solution

I have tested this only for mongo by I think we should have short and long term discussions on this. 
For short I think we need to disable validation and require manyToOne annotation for the fields that are already covered with OneToMany. This is the fix in this PR.


### Long term plan

I think we need some small refactor on relationships to be able to get them aligned. 
We can use target schema in the client side plugin as well - that will also fix the problem I see with not being able to generate queries when field is missing, but other problems with persist.
