### PR TITLE
fix(graphql-serve): print-schema command was not working

### DIFF
--- a/packages/graphql-serve/src/commands/printSchema.ts
+++ b/packages/graphql-serve/src/commands/printSchema.ts
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import chalk from 'chalk';
+import * as chalk from 'chalk';
 import { printSchemaHandler } from '../components';
 
 type Params = { model?: string };


### PR DESCRIPTION
The command was broken cause of the wrong import statement.

This caused an `undefined` error.

To verify:

Build the current master and launch the print schema command:

```bash
cd packages/graphql-serve/dist/
node index.js print-schema templates/ts-apollo-mongodb-datasync-backend/model/datamodel.graphql
```

Apply the patch, build and re-launch the command.