### PR TITLE
docs(graphback-cli): add generate command documentation

### DIFF
--- a/docs/cli/graphback-cli.md
+++ b/docs/cli/graphback-cli.md
@@ -3,3 +3,80 @@ id: graphback-cli
 title: Graphback CLI
 sidebar_label: Graphback CLI
 ---
+
+Graphback helps you to kickstart your experience with any existing GraphQL implementation by generating backend and client side CRUD layer using your [GraphQL data model](../model/datamodel.md). The CLI exposes a single `generate` command.  
+
+## Installation
+
+You can add `Graphback CLI` on your existing GraphQL project using either of the following commands. 
+
+With npm:
+
+```bash
+npm install --save-dev graphback-cli
+```
+
+Or with yarn: 
+
+```bash
+yarn add --dev graphback-cli
+```
+
+## Usage
+
+### Prerequisite
+
+You project must contain the configuration file that follows the format described by the [graphql-config](https://graphql-config.com/introduction).
+
+Taking a `.graphqlrc.yml` configuration file for example, your configuration should have the following minimum required entry:
+
+```yaml
+## Please review configuration and adjust it for your own project
+schema: ./src/schema/schema.graphql
+extensions:
+  graphback:
+    model: ./model/**/*.graphql
+    ## You can add as many Graphback plugins as you wish
+    ## Here we are only adding the Schema and Client plugin
+    plugins:
+      graphback-schema:
+        format: graphql
+        outputPath: ./src/schema/schema.graphql
+      graphback-client:
+        format: 'graphql'
+        outputFile: ./src/graphql/graphback.graphql   
+```
+
+:::note
+If you used [graphql-cli](https://github.com/Urigo/graphql-cli) to initialize
+ the project, this file will be automatic setup for you. Otherwise, you can still use the `init` command from the CLI to initialize this configuration setup.
+:::
+
+
+### Using the command
+
+To use Graphback generate command. In your `package.json` file, edit the `scripts` parts and add the following line:
+
+```json
+"generate": "graphback generate"
+```
+
+And finally, use npm or yarn to run it:
+
+With yarn:
+
+```bash
+yarn generate
+```
+
+With bash:
+
+```bash
+npm run generate
+```
+
+`generate` command will execute generation process that will generate GraphQL server based on your data model.
+
+:::note
+Graphback CLI is now part of the [graphql-cli](https://github.com/Urigo/graphql-cli) command line tool. Please consider installing it for wider set of features
+::: 

--- a/packages/graphback-cli/README.md
+++ b/packages/graphback-cli/README.md
@@ -18,6 +18,6 @@ by generating backend and client side CRUD layer using your GraphQL data model.
 
 ## CLI commands reference
 
-See: https://graphback.dev/docs/commands
+See: https://graphback.dev/docs/cli/graphback-cli
 
 > NOTE: Graphback CLI is now part of the graphql-cli command line tool. Please consider installing https://github.com/Urigo/graphql-cli for wider set of features

--- a/website/versioned_docs/version-0.14.x/cli/graphback-cli.md
+++ b/website/versioned_docs/version-0.14.x/cli/graphback-cli.md
@@ -3,3 +3,82 @@ id: graphback-cli
 title: Graphback CLI
 sidebar_label: Graphback CLI
 ---
+
+Graphback helps you to kickstart your experience with any existing GraphQL implementation by generating backend and client side CRUD layer using your [GraphQL data model](../model/datamodel.md). The CLI exposes a single `generate` command.  
+
+## Installation
+
+You can add `Graphback CLI` on your existing GraphQL project using either of the following commands. 
+
+With npm:
+
+```bash
+npm install --save-dev graphback-cli
+```
+
+Or with yarn: 
+
+```bash
+yarn add --dev graphback-cli
+```
+
+## Usage
+
+### Pre-requisite
+
+You project must contain the configuration file that follows the format described by the [graphql-config](https://graphql-config.com/introduction).
+
+Taking a `.graphqlrc.yml` configuration file for example, your configuration should have the following minimum required entry:
+
+```yaml
+## Please review configuration and adjust it for your own project
+schema: ./src/schema/schema.graphql
+extensions:
+  graphback:
+    model: ./model/**/*.graphql
+    ## You can add as many Graphback plugins as you wish
+    ## Here we are only adding the Schema and Client plugin
+    plugins:
+      graphback-schema:
+        format: graphql
+        outputPath: ./src/schema/schema.graphql
+      graphback-client:
+        format: 'graphql'
+        outputFile: ./src/graphql/graphback.graphql   
+```
+
+:::note
+If you used [graphql-cli](https://github.com/Urigo/graphql-cli) to initialize
+ the project, this file will be automatic setup for you. Otherwise, you can still use the `init` command from the CLI to initialize
+ this configuration setup.
+:::
+
+
+### Using the command
+
+To use Graphback generate command. In your `package.json` file, edit the `scripts` parts and add the following line:
+
+```json
+"generate": "graphback generate"
+```
+
+And finally, use npm or yarn to run it:
+
+With yarn:
+
+```bash
+yarn generate
+```
+
+With bash:
+
+```bash
+npm run generate
+```
+
+`generate` command will execute generation process that will generate GraphQL server based on your data model.
+
+:::note
+Graphback CLI is now part of the [graphql-cli](https://github.com/Urigo/graphql-cli) command line tool. Please consider installing it for wider set of features
+::: 
+

--- a/website/versioned_docs/version-0.15.x/cli/graphback-cli.md
+++ b/website/versioned_docs/version-0.15.x/cli/graphback-cli.md
@@ -3,3 +3,81 @@ id: graphback-cli
 title: Graphback CLI
 sidebar_label: Graphback CLI
 ---
+
+Graphback helps you to kickstart your experience with any existing GraphQL implementation by generating backend and client side CRUD layer using your [GraphQL data model](../model/datamodel.md). The CLI exposes a single `generate` command.  
+
+## Installation
+
+You can add `Graphback CLI` on your existing GraphQL project using either of the following commands. 
+
+With npm:
+
+```bash
+npm install --save-dev graphback-cli
+```
+
+Or with yarn: 
+
+```bash
+yarn add --dev graphback-cli
+```
+
+## Usage
+
+### Pre-requisite
+
+You project must contain the configuration file that follows the format described by the [graphql-config](https://graphql-config.com/introduction).
+
+Taking a `.graphqlrc.yml` configuration file for example, your configuration should have the following minimum required entry:
+
+```yaml
+## Please review configuration and adjust it for your own project
+schema: ./src/schema/schema.graphql
+extensions:
+  graphback:
+    model: ./model/**/*.graphql
+    ## You can add as many Graphback plugins as you wish
+    ## Here we are only adding the Schema and Client plugin
+    plugins:
+      graphback-schema:
+        format: graphql
+        outputPath: ./src/schema/schema.graphql
+      graphback-client:
+        format: 'graphql'
+        outputFile: ./src/graphql/graphback.graphql   
+```
+
+:::note
+If you used [graphql-cli](https://github.com/Urigo/graphql-cli) to initialize
+ the project, this file will be automatic setup for you. Otherwise, you can still use the `init` command from the CLI to initialize
+ this configuration setup.
+:::
+
+
+### Using the command
+
+To use Graphback generate command. In your `package.json` file, edit the `scripts` parts and add the following line:
+
+```json
+"generate": "graphback generate"
+```
+
+And finally, use npm or yarn to run it:
+
+With yarn:
+
+```bash
+yarn generate
+```
+
+With bash:
+
+```bash
+npm run generate
+```
+
+`generate` command will execute generation process that will generate GraphQL server based on your data model.
+
+:::note
+Graphback CLI is now part of the [graphql-cli](https://github.com/Urigo/graphql-cli) command line tool. Please consider installing it for wider set of features
+::: 

--- a/website/versioned_docs/version-0.16.x/cli/graphback-cli.md
+++ b/website/versioned_docs/version-0.16.x/cli/graphback-cli.md
@@ -3,3 +3,81 @@ id: graphback-cli
 title: Graphback CLI
 sidebar_label: Graphback CLI
 ---
+
+Graphback helps you to kickstart your experience with any existing GraphQL implementation by generating backend and client side CRUD layer using your [GraphQL data model](../model/datamodel.md). The CLI exposes a single `generate` command.  
+
+## Installation
+
+You can add `Graphback CLI` on your existing GraphQL project using either of the following commands. 
+
+With npm:
+
+```bash
+npm install --save-dev graphback-cli
+```
+
+Or with yarn: 
+
+```bash
+yarn add --dev graphback-cli
+```
+
+## Usage
+
+### Pre-requisite
+
+You project must contain the configuration file that follows the format described by the [graphql-config](https://graphql-config.com/introduction).
+
+Taking a `.graphqlrc.yml` configuration file for example, your configuration should have the following minimum required entry:
+
+```yaml
+## Please review configuration and adjust it for your own project
+schema: ./src/schema/schema.graphql
+extensions:
+  graphback:
+    model: ./model/**/*.graphql
+    ## You can add as many Graphback plugins as you wish
+    ## Here we are only adding the Schema and Client plugin
+    plugins:
+      graphback-schema:
+        format: graphql
+        outputPath: ./src/schema/schema.graphql
+      graphback-client:
+        format: 'graphql'
+        outputFile: ./src/graphql/graphback.graphql   
+```
+
+:::note
+If you used [graphql-cli](https://github.com/Urigo/graphql-cli) to initialize
+ the project, this file will be automatic setup for you. Otherwise, you can still use the `init` command from the CLI to initialize
+ this configuration setup.
+:::
+
+
+### Using the command
+
+To use Graphback generate command. In your `package.json` file, edit the `scripts` parts and add the following line:
+
+```json
+"generate": "graphback generate"
+```
+
+And finally, use npm or yarn to run it:
+
+With yarn:
+
+```bash
+yarn generate
+```
+
+With bash:
+
+```bash
+npm run generate
+```
+
+`generate` command will execute generation process that will generate GraphQL server based on your data model.
+
+:::note
+Graphback CLI is now part of the [graphql-cli](https://github.com/Urigo/graphql-cli) command line tool. Please consider installing it for wider set of features
+::: 


### PR DESCRIPTION
Fixes https://github.com/aerogear/graphback/issues/1954

PS: The issue was a good first issue and tagged for Hacktoberfest but I thought we could bring this early on since https://graphback.dev/docs/cli/graphback-cli looks weird. 

