### PR TITLE
fix(graphql-migrations): migration failed for auto increments column

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -26,7 +26,8 @@
     "rimraf": "3.0.2",
     "ts-node": "9.0.0",
     "tsutils": "3.17.1",
-    "typescript": "4.0.2"
+    "typescript": "4.0.2",
+    "graphql": "15.3.0"
   },
   "license": "Apache-2.0"
 }

--- a/integration/tests/graphql-migrations-postgres.ts
+++ b/integration/tests/graphql-migrations-postgres.ts
@@ -1,0 +1,47 @@
+import * as Knex from "knex";
+
+import { buildSchema } from 'graphql';
+import { migrateDB } from "../../packages/graphql-migrations/src";
+import { Operation } from "../../packages/graphql-migrations/src/diff/Operation";
+
+
+const dbConfig: Knex.Config = {
+  client: "pg",
+  connection: {
+    user: "postgresql",
+    password: "postgres",
+    database: "users",
+    host: "localhost",
+    port: parseInt(process.env.POSTGRES_PORT, 10) || 5432
+  }
+}
+
+const db = Knex(dbConfig);
+
+beforeEach(async () => {
+  await db.raw(`DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+GRANT ALL ON SCHEMA public TO postgresql;
+GRANT ALL ON SCHEMA public TO public;`);
+})
+
+afterAll(() => db.destroy());
+
+test('consecutive migrations', async () => {
+  const model = buildSchema(`
+  """@model"""
+  type User {
+    """@id"""
+    _id: ID
+    name: String
+  }
+`)
+
+  let ops = await migrateDB(dbConfig, model)
+  expect(ops.results).toHaveLength(3);
+  const opsResults = ops.results.map((op: Operation) => op.type);
+  expect(opsResults).toEqual(['table.create', 'table.primary.set', 'column.create'])
+
+  ops = await migrateDB(dbConfig, model)
+  expect(ops.results).toHaveLength(0);
+})

--- a/packages/graphql-migrations/src/diff/computeDiff.ts
+++ b/packages/graphql-migrations/src/diff/computeDiff.ts
@@ -136,7 +136,7 @@ class Differ {
 
       // Compare columns
       for (const { fromCol, toCol } of sameColumnQueue) {
-        if (toCol.name === 'id') {
+        if (toCol.autoIncrementable || fromCol.autoIncrementable) {
           const fromPrimaryKeyType = getKnexColumnType(fromCol.type);
           const toPrimaryKeyType = getKnexColumnType(toCol.type);
 

--- a/packages/graphql-migrations/src/util/isAutoIncrementableColumn.ts
+++ b/packages/graphql-migrations/src/util/isAutoIncrementableColumn.ts
@@ -1,0 +1,21 @@
+import Knex from 'knex';
+
+/**
+ * Detect if the column is incrementable based on column information
+ * 
+ * @param {string} client - database client 
+ * @param {Knex.ColumnInfo} columnInfo - metadata for column
+ */
+export function isAutoIncrementableColumn (client: string, columnInfo: Knex.ColumnInfo): boolean {
+  switch (client) {
+    case 'pg':
+      return columnInfo.defaultValue?.toString().startsWith('nextval(');
+    case 'sqlite3':
+      // sqlite3 primary keys not supported
+      return false;
+    default:
+      console.warn(`${client} increments column detection not supported`)
+
+      return false;
+  }
+}


### PR DESCRIPTION
Fixes #2047 

Could not add a unit test for this because it is only a Postgres issue - we do need to think about integration tests for this scenario but due to it being a blocker we should get it merged and release first.