### PR TITLE
fix(schema): don't create empty resolver objects

### DIFF
--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import * as DataLoader from "dataloader";
 import { parseMetadata } from "graphql-metadata";
 import { SchemaComposer, NamedTypeComposer } from 'graphql-compose';
-import { IResolvers, IObjectTypeResolver } from '@graphql-tools/utils';
+import { IResolvers, IObjectTypeResolver, IFieldResolver } from '@graphql-tools/utils';
 import { GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLInt, GraphQLFloat, isScalarType, isSpecifiedScalarType, GraphQLResolveInfo, isObjectType, GraphQLInputObjectType, GraphQLScalarType } from 'graphql';
 import { getFieldName, metadataMap, printSchemaWithDirectives, getSubscriptionName, GraphbackCoreMetadata, GraphbackOperationType, GraphbackPlugin, ModelDefinition, addRelationshipFields, extendRelationshipFields, extendOneToManyFieldArguments, getInputTypeName, FieldRelationshipMetadata, GraphbackContext, getSelectedFieldsFromResolverInfo, isModelType, getPrimaryKey, graphbackScalarsTypes, getResolverInfoFieldsList, GraphbackTimestamp, FILTER_SUPPORTED_SCALARS, FindByArgs } from '@graphback/core';
 import { gqlSchemaFormatter, jsSchemaFormatter, tsSchemaFormatter } from './writer/schemaFormatters';
@@ -79,11 +79,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
       return undefined
     }
 
-    const resolvers: IResolvers = {
-      Query: {},
-      Mutation: {},
-      Subscription: {}
-    };
+    const resolvers: IResolvers = {};
 
     // Graphback scalar resolvers
     const schema = metadata.getSchema();
@@ -102,9 +98,9 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
       }, {});
 
     for (const model of models) {
-      this.addQueryResolvers(model, resolvers.Query as IObjectTypeResolver)
-      this.addMutationResolvers(model, resolvers.Mutation as IObjectTypeResolver)
-      this.addSubscriptionResolvers(model, resolvers.Subscription as IObjectTypeResolver)
+      this.addQueryResolvers(model, resolvers)
+      this.addMutationResolvers(model, resolvers)
+      this.addSubscriptionResolvers(model, resolvers)
       this.addRelationshipResolvers(model, resolvers, modelNameToModelDefinition)
     }
 
@@ -421,14 +417,18 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
    * Create Query resolver fields
    *
    * @param {ModelDefinition} model - The model definition with CRUD config and GraphQL typr
-   * @param {IFieldResolver} queryObj - Query resolver object
+   * @param {IResolvers} resolvers - root resolver object
    */
-  protected addQueryResolvers(model: ModelDefinition, queryObj: IObjectTypeResolver) {
-    if (model.crudOptions.findOne) {
-      this.addFindOneQueryResolver(model, queryObj)
-    }
-    if (model.crudOptions.find) {
-      this.addFindQueryResolver(model, queryObj)
+  protected addQueryResolvers(model: ModelDefinition, resolvers: IResolvers) {
+    if (model.crudOptions.findOne || model.crudOptions.find) {
+      resolvers.Query = {} as IObjectTypeResolver
+
+      if (model.crudOptions.findOne) {
+        this.addFindOneQueryResolver(model, resolvers.Query)
+      }
+      if (model.crudOptions.find) {
+        this.addFindQueryResolver(model, resolvers.Query)
+      }
     }
   }
 
@@ -436,17 +436,21 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
    * Create Mutation resolver fields
    *
    * @param {ModelDefinition} model - The model definition with CRUD config and GraphQL typr
-   * @param {IFieldResolver} mutationObj - Mutation resolver object
+   * @param {IResolvers} resolvers - root resolver object
    */
-  protected addMutationResolvers(model: ModelDefinition, mutationObj: IObjectTypeResolver) {
-    if (model.crudOptions.create) {
-      this.addCreateMutationResolver(model, mutationObj)
-    }
-    if (model.crudOptions.update) {
-      this.addUpdateMutationResolver(model, mutationObj)
-    }
-    if (model.crudOptions.delete) {
-      this.addDeleteMutationResolver(model, mutationObj)
+  protected addMutationResolvers(model: ModelDefinition, resolvers: IResolvers) {
+    if (model.crudOptions.create || model.crudOptions.update || model.crudOptions.delete) {
+      resolvers.Mutation = {} as IObjectTypeResolver
+
+      if (model.crudOptions.create) {
+        this.addCreateMutationResolver(model, resolvers.Mutation)
+      }
+      if (model.crudOptions.update) {
+        this.addUpdateMutationResolver(model, resolvers.Mutation)
+      }
+      if (model.crudOptions.delete) {
+        this.addDeleteMutationResolver(model, resolvers.Mutation)
+      }
     }
   }
 
@@ -454,20 +458,29 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
    * Create Subscription resolver fields
    *
    * @param {ModelDefinition} model - The model definition with CRUD config and GraphQL typr
-   * @param {IFieldResolver} subscriptionObj - Subscription resolver object
+   * @param {IResolvers} resolvers - root resolver object
    */
-  protected addSubscriptionResolvers(model: ModelDefinition, subscriptionObj: IObjectTypeResolver) {
+  protected addSubscriptionResolvers(model: ModelDefinition, resolvers: IResolvers) {
     const modelType = model.graphqlType;
 
-    if (model.crudOptions.create && model.crudOptions.subCreate) {
-      this.addCreateSubscriptionResolver(modelType, subscriptionObj)
+    const createSubEnabled = model.crudOptions.create && model.crudOptions.subCreate;
+    const updateSubEnabled = model.crudOptions.update && model.crudOptions.subUpdate;
+    const deleteSubEnabled = model.crudOptions.delete && model.crudOptions.subDelete;
+
+    if (createSubEnabled || updateSubEnabled || deleteSubEnabled) {
+      resolvers.Subscription = {} as IObjectTypeResolver;
+
+      if (createSubEnabled) {
+        this.addCreateSubscriptionResolver(modelType, resolvers.Subscription)
+      }
+      if (updateSubEnabled) {
+        this.addUpdateSubscriptionResolver(modelType, resolvers.Subscription)
+      }
+      if (deleteSubEnabled) {
+        this.addDeleteSubscriptionResolver(modelType, resolvers.Subscription)
+      }
     }
-    if (model.crudOptions.update && model.crudOptions.subUpdate) {
-      this.addUpdateSubscriptionResolver(modelType, subscriptionObj)
-    }
-    if (model.crudOptions.delete && model.crudOptions.subDelete) {
-      this.addDeleteSubscriptionResolver(modelType, subscriptionObj)
-    }
+
   }
 
   /**

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -421,7 +421,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
    */
   protected addQueryResolvers(model: ModelDefinition, resolvers: IResolvers) {
     if (model.crudOptions.findOne || model.crudOptions.find) {
-      resolvers.Query = {} as IObjectTypeResolver
+      resolvers.Query = (resolvers.Query || {}) as IObjectTypeResolver;
 
       if (model.crudOptions.findOne) {
         this.addFindOneQueryResolver(model, resolvers.Query)
@@ -440,7 +440,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
    */
   protected addMutationResolvers(model: ModelDefinition, resolvers: IResolvers) {
     if (model.crudOptions.create || model.crudOptions.update || model.crudOptions.delete) {
-      resolvers.Mutation = {} as IObjectTypeResolver
+      resolvers.Mutation = (resolvers.Mutation || {}) as IObjectTypeResolver
 
       if (model.crudOptions.create) {
         this.addCreateMutationResolver(model, resolvers.Mutation)
@@ -463,20 +463,16 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
   protected addSubscriptionResolvers(model: ModelDefinition, resolvers: IResolvers) {
     const modelType = model.graphqlType;
 
-    const createSubEnabled = model.crudOptions.create && model.crudOptions.subCreate;
-    const updateSubEnabled = model.crudOptions.update && model.crudOptions.subUpdate;
-    const deleteSubEnabled = model.crudOptions.delete && model.crudOptions.subDelete;
+    if (model.crudOptions.subCreate || model.crudOptions.subUpdate || model.crudOptions.subDelete) {
+      resolvers.Subscription = (resolvers.Subscription || {}) as IObjectTypeResolver
 
-    if (createSubEnabled || updateSubEnabled || deleteSubEnabled) {
-      resolvers.Subscription = {} as IObjectTypeResolver;
-
-      if (createSubEnabled) {
+      if (model.crudOptions.subCreate) {
         this.addCreateSubscriptionResolver(modelType, resolvers.Subscription)
       }
-      if (updateSubEnabled) {
+      if (model.crudOptions.subUpdate) {
         this.addUpdateSubscriptionResolver(modelType, resolvers.Subscription)
       }
-      if (deleteSubEnabled) {
+      if (model.crudOptions.subDelete) {
         this.addDeleteSubscriptionResolver(modelType, resolvers.Subscription)
       }
     }

--- a/packages/graphback/tests/buildGraphbackAPITest.ts
+++ b/packages/graphback/tests/buildGraphbackAPITest.ts
@@ -155,6 +155,83 @@ describe('buildGraphbackAPI', () => {
     expect(Object.keys(Subscription)).toEqual(['newNote', 'deletedNote'])
   })
 
+  test('Do not create subscription resolver object', () => {
+    const model = `
+    """
+    @model
+    """
+    type Note {
+      id: ID!
+      title: String!
+      description: String
+    }
+    `
+
+    const { db } = setup()
+
+    const { resolvers } = buildGraphbackAPI(model, {
+      dataProviderCreator: createKnexDbProvider(db),
+      crud: {
+        subUpdate: false,
+        subCreate: false,
+        subDelete: false
+      }
+    });
+
+    expect(resolvers.Subscription).toBeUndefined();
+  });
+
+  test('Do not create mutation resolver object', () => {
+    const model = `
+    """
+    @model
+    """
+    type Note {
+      id: ID!
+      title: String!
+      description: String
+    }
+    `
+
+    const { db } = setup()
+
+    const { resolvers } = buildGraphbackAPI(model, {
+      dataProviderCreator: createKnexDbProvider(db),
+      crud: {
+        update: false,
+        delete: false,
+        create: false
+      }
+    });
+
+    expect(resolvers.Mutation).toBeUndefined();
+    expect(resolvers.Subscription).toBeUndefined();
+  });
+  test('Do not create query resolver object', () => {
+    const model = `
+    """
+    @model
+    """
+    type Note {
+      id: ID!
+      title: String!
+      description: String
+    }
+    `
+
+    const { db } = setup()
+
+    const { resolvers } = buildGraphbackAPI(model, {
+      dataProviderCreator: createKnexDbProvider(db),
+      crud: {
+        find: false,
+        findOne: false
+      }
+    });
+
+    expect(resolvers.Query).toBeUndefined();
+  });
+
   test('Custom plugins are executed', () => {
 
     const model = `

--- a/packages/graphback/tests/buildGraphbackAPITest.ts
+++ b/packages/graphback/tests/buildGraphbackAPITest.ts
@@ -205,8 +205,9 @@ describe('buildGraphbackAPI', () => {
     });
 
     expect(resolvers.Mutation).toBeUndefined();
-    expect(resolvers.Subscription).toBeUndefined();
+    expect(Object.keys(resolvers.Subscription)).toEqual(['newNote', 'updatedNote', 'deletedNote']);
   });
+  
   test('Do not create query resolver object', () => {
     const model = `
     """


### PR DESCRIPTION
Fixes #2070 

## Verification

1. Disable all subscriptions, either globally through `buildGraphbackAPI` or per model in the `@model` annotation.
Start the server - it should work. Debug the `resolvers` object created by Graphback, there should be no Subscription resolver object.