### PR TITLE
feat: add ability to perform package override in config

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -10,6 +10,10 @@ Please follow individual releases for more information.
 
 # 1.0.0
 
+### Features
+
+* Added ability to override package name in plugin config ([#2077](https://github.com/aerogear/graphback/pull/2077), fixed by [4cfd68c](https://github.com/aerogear/graphback/pull/2077/commits/4cfd68c8b3aeec44df610525686eedd7f1920ecb))
+
 ### Bug Fixes
 
 * Logical `or` filter selector was not mapped correctly in `graphback-runtime-mongo` ([#2034](https://github.com/aerogear/graphback/pull/2034), fixed by [1ebe7e9](https://github.com/aerogear/graphback/pull/2034/commits/1ebe7e9bc8d3a61f0b3ef65b588881d16b7ae63f))

--- a/packages/graphback/src/loadPlugins.ts
+++ b/packages/graphback/src/loadPlugins.ts
@@ -1,23 +1,41 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { GraphbackPlugin } from "@graphback/core";
 
-export function loadPlugins(pluginConfig: any): GraphbackPlugin[] {
-  if (!pluginConfig) {
+interface PluginDefaultProps {
+  packageName?: string
+}
+
+interface PluginConfigMap {
+  [pluginName: string]: PluginConfig
+} 
+
+interface PluginConfig extends PluginDefaultProps {
+  [key: string]: any
+}
+
+export function loadPlugins(pluginConfigMap: PluginConfigMap): GraphbackPlugin[] {
+  if (!pluginConfigMap) {
     return [];
   }
 
   const pluginInstances = [];
-  for (const pluginLabel of Object.keys(pluginConfig)) {
+  for (const pluginLabel of Object.keys(pluginConfigMap)) {
     let pluginName = pluginLabel;
     if (pluginLabel.startsWith('graphback-')) {
       // Internal graphback plugins needs rename
       pluginName = pluginLabel.replace('graphback-', '@graphback/codegen-');
     }
+    const packageName = pluginConfigMap[pluginLabel].packageName;
+    // override package name
+    if(packageName){
+      pluginName = packageName;
+    }
+    
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const plugin = require(pluginName);
       if (plugin.Plugin) {
-        const config = pluginConfig[pluginLabel];
+        const config = pluginConfigMap[pluginLabel];
         pluginInstances.push(new plugin.Plugin(config));
       }
       else {


### PR DESCRIPTION
I have noticed that https://github.com/aerogear/graphback/blob/package-override/docs/plugins/creating-your-own-plugin.md no longer has information about config as well.