### PR TITLE
style: remove unused imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
   "plugins": [
     "@typescript-eslint",
     "@typescript-eslint/tslint",
+    "unused-imports",
     "import",
     "no-null"
   ],
@@ -197,6 +198,7 @@
     "no-unsafe-finally": "error",
     "no-unused-expressions": "error",
     "no-unused-labels": "error",
+    "unused-imports/no-unused-imports": "warn",
     "no-var": "error",
     "no-void": "off",
     "object-shorthand": "off",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint-plugin-no-null": "1.0.2",
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
+    "eslint-plugin-unused-imports": "0.1.3",
     "husky": "4.3.0",
     "lerna": "3.22.1",
     "npm-run-all": "4.1.5",

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -4,9 +4,9 @@ import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import * as DataLoader from "dataloader";
 import { parseMetadata } from "graphql-metadata";
 import { SchemaComposer, NamedTypeComposer } from 'graphql-compose';
-import { IResolvers, IObjectTypeResolver, IFieldResolver } from '@graphql-tools/utils';
+import { IResolvers, IObjectTypeResolver } from '@graphql-tools/utils';
 import { GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLInt, GraphQLFloat, isScalarType, isSpecifiedScalarType, GraphQLResolveInfo, isObjectType, GraphQLInputObjectType, GraphQLScalarType } from 'graphql';
-import { getFieldName, metadataMap, printSchemaWithDirectives, getSubscriptionName, GraphbackCoreMetadata, GraphbackOperationType, GraphbackPlugin, ModelDefinition, addRelationshipFields, extendRelationshipFields, extendOneToManyFieldArguments, getInputTypeName, FieldRelationshipMetadata, GraphbackContext, getSelectedFieldsFromResolverInfo, isModelType, getPrimaryKey, graphbackScalarsTypes, getResolverInfoFieldsList, GraphbackTimestamp, FILTER_SUPPORTED_SCALARS, FindByArgs } from '@graphback/core';
+import { getFieldName, metadataMap, printSchemaWithDirectives, getSubscriptionName, GraphbackCoreMetadata, GraphbackOperationType, GraphbackPlugin, ModelDefinition, addRelationshipFields, extendRelationshipFields, extendOneToManyFieldArguments, getInputTypeName, FieldRelationshipMetadata, GraphbackContext, getSelectedFieldsFromResolverInfo, isModelType, getPrimaryKey, graphbackScalarsTypes,  GraphbackTimestamp, FILTER_SUPPORTED_SCALARS, FindByArgs } from '@graphback/core';
 import { gqlSchemaFormatter, jsSchemaFormatter, tsSchemaFormatter } from './writer/schemaFormatters';
 import { buildFilterInputType, createModelListResultType, StringScalarInputType, BooleanScalarInputType, SortDirectionEnum, buildCreateMutationInputType, buildFindOneFieldMap, buildMutationInputType, OrderByInputType, buildSubscriptionFilterType, IDScalarInputType, PageRequest, createInputTypeForScalar, createVersionedFields, createVersionedInputFields, addCreateObjectInputType, addUpdateObjectInputType, getInputName } from './definitions/schemaDefinitions';
 

--- a/packages/graphback-core/src/runtime/GraphbackDataProvider.ts
+++ b/packages/graphback-core/src/runtime/GraphbackDataProvider.ts
@@ -1,4 +1,4 @@
-import { GraphbackPage, GraphbackOrderBy, FindByArgs } from "./interfaces"
+import {   FindByArgs } from "./interfaces"
 import { QueryFilter } from './QueryFilter';
 
 /**

--- a/packages/graphback-datasync/src/providers/DataSyncProvider.ts
+++ b/packages/graphback-datasync/src/providers/DataSyncProvider.ts
@@ -1,4 +1,4 @@
-import { GraphbackDataProvider, GraphbackContext, QueryFilter } from "@graphback/core";
+import { GraphbackDataProvider,  QueryFilter } from "@graphback/core";
 
 export interface DataSyncProvider<Type = any> extends GraphbackDataProvider<Type> {
 

--- a/packages/graphback-datasync/src/providers/DatasyncMongoDBDataProvider.ts
+++ b/packages/graphback-datasync/src/providers/DatasyncMongoDBDataProvider.ts
@@ -1,4 +1,4 @@
-import { getDatabaseArguments, NoDataError, TransformType, FieldTransform, GraphbackOrderBy, GraphbackPage, QueryFilter, ModelDefinition, FindByArgs } from '@graphback/core';
+import { getDatabaseArguments, NoDataError, TransformType, FieldTransform,   QueryFilter, ModelDefinition, FindByArgs } from '@graphback/core';
 import { ObjectId } from 'mongodb';
 import { MongoDBDataProvider, applyIndexes } from '@graphback/runtime-mongo';
 import { DataSyncFieldNames, getDataSyncAnnotationData } from "../util";

--- a/packages/graphback-keycloak-authz/src/KeycloakConfig.ts
+++ b/packages/graphback-keycloak-authz/src/KeycloakConfig.ts
@@ -1,4 +1,4 @@
-import { KeycloakOptions } from "keycloak-connect"
+
 /**
  * Operations supported by RBAC config
  */

--- a/packages/graphback-keycloak-authz/src/createKeycloakCRUDService.ts
+++ b/packages/graphback-keycloak-authz/src/createKeycloakCRUDService.ts
@@ -1,6 +1,6 @@
 import { ModelDefinition, GraphbackDataProvider, GraphbackCRUDService, ServiceCreator } from '@graphback/core';
 import { KeycloakCrudService } from './KeycloakCrudService';
-import { CrudServiceAuthConfig, CrudServicesAuthConfig } from './KeycloakConfig';
+import {  CrudServicesAuthConfig } from './KeycloakConfig';
 
 /**
  * Creates a new KeycloakCrudService by wrapping original service.

--- a/packages/graphback-runtime-knex/src/SQLiteKnexDBDataProvider.ts
+++ b/packages/graphback-runtime-knex/src/SQLiteKnexDBDataProvider.ts
@@ -1,4 +1,4 @@
-import { getDatabaseArguments, GraphbackContext, NoDataError, ModelDefinition } from '@graphback/core';
+import { getDatabaseArguments, NoDataError, ModelDefinition } from '@graphback/core';
 import * as Knex from 'knex';
 import { KnexDBDataProvider } from './KnexDBDataProvider';
 

--- a/packages/graphql-migrations/src/util/getCheckConstraints.ts
+++ b/packages/graphql-migrations/src/util/getCheckConstraints.ts
@@ -47,6 +47,7 @@ const queries: any = {
   }),
 }
 
+// eslint-disable-next-line import/no-default-export
 export default async function(
   knex: Knex,
   tableName: string,

--- a/packages/graphql-migrations/src/util/getColumnComments.ts
+++ b/packages/graphql-migrations/src/util/getColumnComments.ts
@@ -15,6 +15,7 @@ const queries: any = {
   }),
 }
 
+// eslint-disable-next-line import/no-default-export
 export default async function(
   knex: Knex,
   tableName: string,

--- a/packages/graphql-migrations/src/util/getForeignKeys.ts
+++ b/packages/graphql-migrations/src/util/getForeignKeys.ts
@@ -20,6 +20,7 @@ where tc.constraint_type = 'FOREIGN KEY' and tc.table_name = ? and tc.table_sche
   }),
 }
 
+// eslint-disable-next-line import/no-default-export
 export default async function(
   knex: Knex,
   tableName: string,

--- a/packages/graphql-migrations/src/util/getObjectTypeFromList.ts
+++ b/packages/graphql-migrations/src/util/getObjectTypeFromList.ts
@@ -1,5 +1,6 @@
 import { GraphQLField, isListType, isNonNullType, isObjectType } from 'graphql';
 
+// eslint-disable-next-line import/no-default-export
 export default function(field: GraphQLField<any, any, { [key: string]: any; }>) {
   //comments: [Comment]
   if (isListType(field.type) && isObjectType(field.type.ofType)) {

--- a/packages/graphql-migrations/src/util/getPrimaryKey.ts
+++ b/packages/graphql-migrations/src/util/getPrimaryKey.ts
@@ -15,6 +15,7 @@ const queries: any = {
   }),
 }
 
+// eslint-disable-next-line import/no-default-export
 export default async function(
   knex: Knex,
   tableName: string,

--- a/packages/graphql-migrations/src/util/getTypeAlias.ts
+++ b/packages/graphql-migrations/src/util/getTypeAlias.ts
@@ -18,6 +18,7 @@ const ALIAS: any = {
   'bytea': { type: 'binary', args: [] },
 }
 
+// eslint-disable-next-line import/no-default-export
 export default function(dataType: string, maxLength: any): { type: string, args: any[] } {
   let alias = ALIAS[dataType.toLowerCase()]
   if (!alias) {

--- a/packages/graphql-migrations/src/util/getUniques.ts
+++ b/packages/graphql-migrations/src/util/getUniques.ts
@@ -29,6 +29,7 @@ const queries: any = {
   }),
 }
 
+// eslint-disable-next-line import/no-default-export
 export default async function(
   knex: Knex,
   tableName: string,

--- a/packages/graphql-migrations/src/util/listTables.ts
+++ b/packages/graphql-migrations/src/util/listTables.ts
@@ -40,6 +40,7 @@ const queries: any = {
   }),
 }
 
+// eslint-disable-next-line import/no-default-export
 export default async function(knex: Knex, schemaName: string) {
   const query = queries[knex.client.config.client]
   if (!query) {


### PR DESCRIPTION
- [d4975afb0db25f9bddddee92ba0be4540133320b] removes all unused imports, and adds an ESLint rule to warn if it happens again, this will make it easier to identify and remove unused imports in the future.

- [4a00e907a62d3fc36dcb6fdbe5de2c123f09e386] disable `prefer-named-exports` rule for certain cases. Now there are no lint warnings in the repo, since there were always these few hanging around we often ignored them and might miss other new ones.