### PR TITLE
Fixes in CRUDService and Knex Query Mapper

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -20,7 +20,9 @@ Please follow individual releases for more information.
 * Logical `or` filter selector was not mapped correctly in `graphback-runtime-knex` ([#2034](https://github.com/aerogear/graphback/pull/2034), fixed by [6d43f28](https://github.com/aerogear/graphback/commit/6d43f288865a2c8c0d441e486a156301ca6cc42a))
 * Logical `or` predicate was not applied correctly in `createInMemoryPredicateFilter` ([#2034](https://github.com/aerogear/graphback/pull/2034), fixed by [01f9912](https://github.com/aerogear/graphback/commit/01f99121a9462e5a277657359094ab131e6f809c))
 * GraphQL Migrations did not read auto-incrementing info from database column ([#2017](https://github.com/aerogear/graphback/pull/2071), fixed by [83a80cd](https://github.com/aerogear/graphback/commit/83a80cdbb1104da7b36acdfa54b37a871c3ff1a0))
-* Prevent creation of empty `Subscription`, `Query`, `Mutation` resolver objects ([#2073](https://github.com/aerogear/graphback/pull/2073), fixed by [97e826](https://github.com/aerogear/graphback/commit/97e82677257b54783916c3062ed6f0e74f25c038))
+* Prevent creation of empty `Subscription`, `Query`, `Mutation` resolver objects ([#2073](https://github.com/aerogear/graphback/pull/2073), fixed by [97e8267](https://github.com/aerogear/graphback/commit/97e82677257b54783916c3062ed6f0e74f25c038))
+* Fix `TypeError: Cannot read property 'page' of undefined` error in CRUDService ([#2095](https://github.com/aerogear/graphback/pull/2095) fixed by [5143fb6](https://github.com/aerogear/graphback/commit/5143fb6c6a76d20f44b3e79ab25c6922408dd54a))
+* It was not possible to map a `WHERE X IS/IS NOT NULL` query in the Knex query mapper ([#2095](https://github.com/aerogear/graphback/pull/2095) fixed by [d10e918](https://github.com/aerogear/graphback/commit/d10e918714a85c8c6f6ebb4260e9aff0b6b99ffa))
 
 ### Breaking Changes
 

--- a/packages/graphback-core/src/runtime/CRUDService.ts
+++ b/packages/graphback-core/src/runtime/CRUDService.ts
@@ -129,7 +129,7 @@ export class CRUDService<Type = any> implements GraphbackCRUDService<Type>  {
     // set page values for returned object
     const resultPageInfo = {
       offset: 0,
-      ...args.page
+      ...args?.page
     }
 
     let count: number;

--- a/packages/graphback-runtime-knex/src/knexQueryMapper.ts
+++ b/packages/graphback-runtime-knex/src/knexQueryMapper.ts
@@ -1,7 +1,7 @@
 import Knex from 'knex';
 import { QueryFilter, QueryFilterOperator } from '@graphback/core';
 
-const knexOperators = ['=', '<>', '<=', '<', '>', '>=', 'like', 'between', 'in'] as const;
+const knexOperators = ['=', '<>', '<=', '<', '>', '>=', 'like', 'between', 'in', 'is', 'is not'] as const;
 const knexMethods = ['where', 'orWhere', 'orWhereNot', 'whereNot'] as const;
 
 type KnexQueryOperator = typeof knexOperators[number];
@@ -29,8 +29,10 @@ export interface CRUDKnexQueryMapper {
 
 const mapQueryFilterOperatorToKnexWhereCondition = (operator: QueryFilterOperator, value: any): KnexWhereConditionMap => {
   const operatorToWhereConditionMap: { [key in QueryFilterOperator]: KnexWhereConditionMap } = {
-    eq: ['=', value],
-    ne: ['<>', value],
+    // eslint-disable-next-line no-null/no-null
+    eq: [value === null ? 'is' : '=', value],
+    // eslint-disable-next-line no-null/no-null
+    ne: [value === null ? 'is not' : '<>', value],
     lt: ['<', value],
     le: ['<=', value],
     ge: ['>=', value],

--- a/packages/graphback-runtime-knex/tests/knexQueryMapperTest.ts
+++ b/packages/graphback-runtime-knex/tests/knexQueryMapperTest.ts
@@ -31,6 +31,28 @@ describe('knexQueryMapper', () => {
     expect(queryBuilder.buildQuery(filter).toQuery()).toEqual("select * where (`name` = 'Enda')")
   });
 
+  test('where name is null', () => {
+    const filter: QueryFilter = {
+      name: {
+        // eslint-disable-next-line no-null/no-null
+        eq: null
+      }
+    }
+
+    expect(queryBuilder.buildQuery(filter).toQuery()).toEqual("select * where (`name` is null)")
+  })
+
+  test('where name is not null', () => {
+    const filter: QueryFilter = {
+      name: {
+        // eslint-disable-next-line no-null/no-null
+        ne: null
+      }
+    }
+
+    expect(queryBuilder.buildQuery(filter).toQuery()).toEqual("select * where (`name` is not null)")
+  })
+
   test('where name <> ?', () => {
     const filter: QueryFilter = {
       name: {

--- a/packages/graphback-runtime-knex/tests/service/DefaultCRUDServiceTest.ts
+++ b/packages/graphback-runtime-knex/tests/service/DefaultCRUDServiceTest.ts
@@ -154,6 +154,14 @@ test('find Todo by text', async () => {
   expect(todoResults.items[0].id).toEqual(2);
 });
 
+test('findBy with no arguments should work', async () => {
+  const { services } = await setup({ seedData: { todo: [{ text: 'my first todo' }, { text: 'the second todo' }] } })
+
+  const todoResults = await services.Todo.findBy();
+
+  expect(todoResults.items).toHaveLength(2);
+})
+
 test('delete User by custom ID field', async () => {
   const { services } = await setup({
     schemaSDL: `


### PR DESCRIPTION
- 5143fb6c6a76d20f44b3e79ab25c6922408dd54a - `TypeError: Cannot read property 'page' of undefined` error is thrown when no `findBy#args` argument is null or undefined.

- d10e918 fixes an error where it was not possible to perform a `where x is/not null` query in the Knex data provider. This is already possible in the Mongo Data Provider.

All fixes accompanied by a unit test