### PR TITLE
fix(keycloak-authz): make relationship field auth configurable at GraphQL field level

### DIFF
--- a/docs/authentication/keycloak.md
+++ b/docs/authentication/keycloak.md
@@ -57,24 +57,23 @@ With this configuration the following rules are in place.
 
 ## Relationships Autorization
 
-Developers can also add authorization rules on sepecific relationships for data fetching purposes.
+Developers can also add authorization rules on specific one-to-many relationships for data fetching purposes.
 Relationship rules will be added on top of the existing rules that are defined for the individual objects.
+
+To apply a relationship field rule to the one-to-many field `Task.users`, you must configure it on the `User.task` configuration object, the inverse field which `Task.users` maps to.
 
 ```ts
 const authConfig = {
-  Task: {
+  User: {
     relations: {
-        taskUsers: { roles: ['admin'] }
-        allTasksComments: { roles: ['commenter'] }
+      task: { roles: ['admin'] }
     },
-
-  },
+  }
 ```
 
-With this configuration the following rules are in place.
+With this configuration the following authorization rule is set:
 
-- Tasks `taskUsers` field has `admin` role applied. Fetching User object will require `admin` role for any user field fetched
-- Tasks `allTasksComments` field has `commenter` role applied. Fetching `Comment` object will require `commenter` role for any user field fetched
+- `User.relations.task.roles` applies the `admin` role on `Task.users`. Users must have the `admin` role in order to query `Task.users`.
 
 :::info
 Due to limitations of the Graphback `relations` authorization works only on `OneToMany` relationships.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -23,6 +23,8 @@ Please follow individual releases for more information.
 * Prevent creation of empty `Subscription`, `Query`, `Mutation` resolver objects ([#2073](https://github.com/aerogear/graphback/pull/2073), fixed by [97e8267](https://github.com/aerogear/graphback/commit/97e82677257b54783916c3062ed6f0e74f25c038))
 * Fix `TypeError: Cannot read property 'page' of undefined` error in CRUDService ([#2095](https://github.com/aerogear/graphback/pull/2095) fixed by [5143fb6](https://github.com/aerogear/graphback/commit/5143fb6c6a76d20f44b3e79ab25c6922408dd54a))
 * It was not possible to map a `WHERE X IS/IS NOT NULL` query in the Knex query mapper ([#2095](https://github.com/aerogear/graphback/pull/2095) fixed by [d10e918](https://github.com/aerogear/graphback/commit/d10e918714a85c8c6f6ebb4260e9aff0b6b99ffa))
+* Prevent creation of empty `Subscription`, `Query`, `Mutation` resolver objects ([#2073](https://github.com/aerogear/graphback/pull/2073), fixed by [97e826](https://github.com/aerogear/graphback/commit/97e82677257b54783916c3062ed6f0e74f25c038))
+* Configure relationship auth rule with field instead of database key ([#2101](https://github.com/aerogear/graphback/pull/2073), fixed by [525bc9a](https://github.com/aerogear/graphback/commit/525bc9a641fa7cb1818a0727a675564e6fa12dda))
 
 ### Breaking Changes
 

--- a/packages/graphback-keycloak-authz/tests/KeycloakCrudService.test.ts
+++ b/packages/graphback-keycloak-authz/tests/KeycloakCrudService.test.ts
@@ -313,7 +313,7 @@ test('Batching', async () => {
       description: String
 
       """ @oneToMany(field: 'task') """
-      comment: Comment
+      comments: [Comment]
     }
 
     """@model"""


### PR DESCRIPTION
Relationship fields needed to be configured with the database field name. This made it confusing to set auth rules since often the user does not know what the database column name is (it usually maps to `{fieldName}Id`, but this knowledge is not apparent from the schema and is hard to track.

This fixes that so it can be configured with the model field name instead.

This PR also updates the docs, which showed configuration happening from the 1:M side, whereas it should be from the M:1 side.

Before and after:

```patch
Comment: {
  relations: {
-    noteId: {
+    note: {
       roles: ['admin']
    }
  }
}
```