### PR TITLE
Fix script path to compiled `index.js` in templates and move `@types/bson` from devDependencies in `@graphback/core`

### DIFF
--- a/packages/graphback-core/package.json
+++ b/packages/graphback-core/package.json
@@ -28,7 +28,6 @@
     "node": ">=10.15.3"
   },
   "devDependencies": {
-    "@types/bson": "4.0.2",
     "@types/jest": "26.0.14",
     "@types/node": "12.12.62",
     "@types/pino": "6.3.0",
@@ -47,6 +46,7 @@
   "dependencies": {
     "@graphql-tools/merge": "6.2.3",
     "@graphql-tools/utils": "6.2.3",
+    "@types/bson": "4.0.2",
     "bson": "4.1.0",
     "dataloader": "2.0.0",
     "glob": "7.1.6",

--- a/templates/ts-apollo-mongodb-backend/package.json
+++ b/templates/ts-apollo-mongodb-backend/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "description": "Graphback runtime template with Apollo Server and MongoDb",
   "private": true,
-  "main": "dist/src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
     "develop": "ts-node src/index.ts",
-    "start": "node dist/src/index.js",
+    "start": "node dist/index.js",
     "watch": "tsc -w",
     "generate": "graphback generate && graphql codegen"
   },

--- a/templates/ts-apollo-mongodb-datasync-backend/package.json
+++ b/templates/ts-apollo-mongodb-datasync-backend/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "description": "Graphback with Data Synchronization runtime template with Apollo Server and MongoDb",
   "private": true,
-  "main": "dist/src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
     "develop": "ts-node src/index.ts",
-    "start": "node dist/src/index.js",
+    "start": "node dist/index.js",
     "watch": "tsc -w",
     "generate": "graphback generate && graphql codegen"
   },

--- a/templates/ts-apollo-postgres-backend/package.json
+++ b/templates/ts-apollo-postgres-backend/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "description": "Graphback runtime template with Apollo Server and PostgreSQL",
   "private": true,
-  "main": "dist/src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
     "develop": "ts-node src/index.ts",
-    "start": "node dist/src/index.js",
+    "start": "node dist/index.js",
     "watch": "tsc -w",
     "generate": "graphback generate && graphql codegen"
   },


### PR DESCRIPTION
- [`81f9612` (#2104)](https://github.com/aerogear/graphback/pull/2104/commits/81f96128e3daa27a2345070ab961b0df01c1d102) fixes an issue in the templates where path to `dist/index.js` was wrong in the `start` script.

- [`e9f6460` (#2104)](https://github.com/aerogear/graphback/pull/2104/commits/e9f6460035f676e03445a99a4d36500984a9e083) fixes https://github.com/aerogear/graphback/issues/2103.