### PR TITLE
docs: add DataSync plugin usage guide

### DIFF
--- a/docs/datasync/delta-queries.md
+++ b/docs/datasync/delta-queries.md
@@ -97,7 +97,7 @@ In the [`src/index.ts`](https://github.com/aerogear/graphback/blob/templates-rel
 import { createDataSyncAPI } from '@graphback/datasync'
 
 
-const { typeDefs, resolvers, contextCreator } = createDataSyncAPI(modelDefs, { db });;
+const { typeDefs, resolvers, contextCreator } = createDataSyncAPI(modelDefs, { db });
 ```
 The data sources provided by `createDataSyncAPI` ensure that:
 - The documents are always soft deleted

--- a/docs/datasync/intro.md
+++ b/docs/datasync/intro.md
@@ -32,9 +32,61 @@ npm install @graphback/datasync
 
 ## Usage
 
-In order to use data synchronization features, there are two steps to be followed:
+Add annotations to your data models:
 
-- Add metadata to schema
-- Use `createDataSyncAPI` to create the API using Graphback
+```graphql
+"""
+@model
+// highlight-next-line
+@datasync
+"""
+type User {
+  id: _GraphbackObjectID
+  name: String
+}
+```
+
+The preferred and simpest way to add data sync functionality is to use the `createDataSyncAPI` function which wraps `buildGraphbackAPI`:
+
+```ts
+import { createDataSyncAPI } from '@graphback/datasync'
+
+const { typeDefs, resolvers, contextCreator } = createDataSyncAPI(modelDefs, { db });
+```
+
+Alternatively, you can use the default [`buildGraphbackAPI`](../getting-started/adding-graphback-to-your-project.md#configure-graphback) and add the `DataSyncPlugin` plugin directly:
+
+```ts
+import { buildGraphbackAPI } from 'graphback';
+import { DataSyncPlugin } from '@graphback/datasync'
+
+const { typeDefs, resolvers, contextCreator } = buildGraphbackAPI(schema, {
+  ...,
+  plugins: [
+    new DataSyncPlugin({
+      enabled: true
+    })
+  ]
+});
+```
+
+Or if you are invoking the plugin with `graphback generate`:
+
+```yaml title=".graphqlrc"
+schema: './src/schema.graphql'
+documents: './client/src/graphql/**/*.graphql'
+extensions:
+  graphback:
+    # path to data mode file(s)
+    model: './model/datamodel.graphql'
+    plugins:
+      ...
+      graphback-datasync:
+        packageName: '@graphback/datasync' # required to dynamically load
+        conflictConfig: 
+          models:
+            Note:
+              enabled: true
+```
 
 For a more in-depth guide to setting up data synchronization features, check [this](delta-queries.md) page.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -26,6 +26,7 @@ Please follow individual releases for more information.
 * Prevent creation of empty `Subscription`, `Query`, `Mutation` resolver objects ([#2073](https://github.com/aerogear/graphback/pull/2073), fixed by [97e826](https://github.com/aerogear/graphback/commit/97e82677257b54783916c3062ed6f0e74f25c038))
 * Configure relationship auth rule with field instead of database key ([#2101](https://github.com/aerogear/graphback/pull/2073), fixed by [525bc9a](https://github.com/aerogear/graphback/commit/525bc9a641fa7cb1818a0727a675564e6fa12dda))
 * Fix `Could not find a declaration file for module 'bson'` error ([#2104](https://github.com/aerogear/graphback/pull/2104), fixed by [4f9ce7c](https://github.com/aerogear/graphback/commit/4f9ce7c2d6c494b33f447e1b4d6a47fbd880f353))
+* Add missing interface ([#2019](https://github.com/aerogear/graphback/pull/2109), fixed by [f46e920](https://github.com/aerogear/graphback/commit/f46e9200def565b0b0e34ccc13f7efa50f346550))
 
 ### Breaking Changes
 

--- a/packages/graphback-datasync/src/helpers/createDataSync.ts
+++ b/packages/graphback-datasync/src/helpers/createDataSync.ts
@@ -8,7 +8,25 @@ import { createDataSyncConflictProviderCreator } from '../providers';
 
 type DataSyncGraphbackAPIConfig = Omit<GraphbackAPIConfig, "dataProviderCreator">
 
-export function createDataSyncAPI(model: string | GraphQLSchema, createDataSyncConfig: { db: Db,  conflictConfig?: GlobalConflictConfig, graphbackAPIConfig?: DataSyncGraphbackAPIConfig }): GraphbackAPI {
+/**
+ * Config to create a Graphback DataSync API
+ */
+export interface DataSyncAPIConfig {
+  /**
+   * MongoDB driver
+   */
+  db: Db, 
+  /**
+   * Conflict configmap for the data models
+   */
+  conflictConfig?: GlobalConflictConfig
+  /**
+   * GraphbackAPI config
+   */
+  graphbackAPIConfig?: DataSyncGraphbackAPIConfig
+}
+
+export function createDataSyncAPI(model: string | GraphQLSchema, createDataSyncConfig: DataSyncAPIConfig): GraphbackAPI {
   const { db, conflictConfig, graphbackAPIConfig } = createDataSyncConfig;
 
   return buildGraphbackAPI(model, {

--- a/templates/ts-apollo-mongodb-datasync-backend/src/index.ts
+++ b/templates/ts-apollo-mongodb-datasync-backend/src/index.ts
@@ -7,9 +7,9 @@ import { createDataSyncAPI } from '@graphback/datasync';
 import cors from 'cors';
 // eslint-disable-next-line @typescript-eslint/tslint/config
 import express from 'express';
+import { loadConfigSync } from 'graphql-config';
 import { connectDB } from './db';
 import { noteResolvers } from './resolvers/noteResolvers';
-import { loadConfigSync } from 'graphql-config';
 
 async function start() {
   const app = express();

--- a/templates/ts-apollo-mongodb-datasync-backend/src/index.ts
+++ b/templates/ts-apollo-mongodb-datasync-backend/src/index.ts
@@ -32,7 +32,13 @@ async function start() {
 
   const { typeDefs, resolvers, contextCreator } = createDataSyncAPI(modelDefs, {
     db,
-    conflictConfig: { models: { Comment: { enabled: true } } }
+    conflictConfig: {
+      models: {
+        Comment: {
+          enabled: true
+        }
+      }
+    }
   });
 
   const apolloServer = new ApolloServer({


### PR DESCRIPTION
This PR updates the docs with information on how to use the DataSync plugin without `createDataSyncAPI`.

It also adds an interface for the `createDataSyncAPI` config.