### PR TITLE
fix(datasync): add conflict error message

### DIFF
--- a/packages/graphback-datasync/src/util.ts
+++ b/packages/graphback-datasync/src/util.ts
@@ -72,7 +72,7 @@ export function getModelConfigFromGlobal(modelName: string, globalConfig: Global
 export class ConflictError extends Error {
   public conflictInfo: ConflictMetadata;
   public constructor(stateMap: ConflictMetadata) {
-    super();
+    super('A conflict has occurred');
     this.conflictInfo = stateMap;
   }
 }


### PR DESCRIPTION
The `ConflictError` message always gives an error message of `""`