### PR TITLE
fix(codegen-schema): create subscription fields when mutations are disabled

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -27,6 +27,7 @@ Please follow individual releases for more information.
 * Configure relationship auth rule with field instead of database key ([#2101](https://github.com/aerogear/graphback/pull/2073), fixed by [525bc9a](https://github.com/aerogear/graphback/commit/525bc9a641fa7cb1818a0727a675564e6fa12dda))
 * Fix `Could not find a declaration file for module 'bson'` error ([#2104](https://github.com/aerogear/graphback/pull/2104), fixed by [4f9ce7c](https://github.com/aerogear/graphback/commit/4f9ce7c2d6c494b33f447e1b4d6a47fbd880f353))
 * Add missing interface ([#2019](https://github.com/aerogear/graphback/pull/2109), fixed by [f46e920](https://github.com/aerogear/graphback/commit/f46e9200def565b0b0e34ccc13f7efa50f346550))
+* Generate schema subscription fields when mutations are disabled ([#2114](https://github.com/aerogear/graphback/2114), fixed by [212eb7a](https://github.com/aerogear/graphback/commit/212eb7a3e718eb102c226c237ce2448a2aa26898))
 
 ### Breaking Changes
 

--- a/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
+++ b/packages/graphback-codegen-schema/src/SchemaCRUDPlugin.ts
@@ -161,7 +161,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
     buildSubscriptionFilterType(schemaComposer, modelType);
 
     const subscriptionFields = {}
-    if (model.crudOptions.subCreate && model.crudOptions.create) {
+    if (model.crudOptions.subCreate) {
       const operation = getSubscriptionName(name, GraphbackOperationType.CREATE)
 
       const filterInputName = getInputTypeName(name, GraphbackOperationType.SUBSCRIPTION_CREATE)
@@ -176,7 +176,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
         }
       };
     }
-    if (model.crudOptions.subUpdate && model.crudOptions.update) {
+    if (model.crudOptions.subUpdate) {
       const operation = getSubscriptionName(name, GraphbackOperationType.UPDATE)
 
       const filterInputName = getInputTypeName(name, GraphbackOperationType.SUBSCRIPTION_UPDATE)
@@ -191,7 +191,7 @@ export class SchemaCRUDPlugin extends GraphbackPlugin {
         }
       };
     }
-    if (model.crudOptions.subDelete && model.crudOptions.delete) {
+    if (model.crudOptions.subDelete) {
       const operation = getSubscriptionName(name, GraphbackOperationType.DELETE)
 
       const filterInputName = getInputTypeName(name, GraphbackOperationType.SUBSCRIPTION_DELETE)

--- a/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
+++ b/packages/graphback-codegen-schema/tests/__snapshots__/GraphQLSchemaCreatorTest.ts.snap
@@ -1,5 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Create subscription fields when mutations are disabled 1`] = `
+"type Query {
+  getNote(id: ID!): Note
+  findNotes(filter: NoteFilter, page: PageRequest, orderBy: OrderByInput): NoteResultList!
+}
+
+\\"\\"\\"@model\\"\\"\\"
+type Note {
+  id: ID!
+  title: String
+}
+
+type NoteResultList {
+  items: [Note]!
+  offset: Int
+  limit: Int
+  count: Int
+}
+
+input NoteFilter {
+  id: IDInput
+  title: StringInput
+  and: [NoteFilter!]
+  or: [NoteFilter!]
+  not: NoteFilter
+}
+
+input IDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  in: [ID!]
+}
+
+input StringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  in: [String!]
+  contains: String
+  startsWith: String
+  endsWith: String
+}
+
+input PageRequest {
+  limit: Int
+  offset: Int
+}
+
+input OrderByInput {
+  field: String!
+  order: SortDirectionEnum = ASC
+}
+
+enum SortDirectionEnum {
+  DESC
+  ASC
+}
+
+type Subscription {
+  newNote(filter: NoteSubscriptionFilter): Note!
+  updatedNote(filter: NoteSubscriptionFilter): Note!
+  deletedNote(filter: NoteSubscriptionFilter): Note!
+}
+
+input NoteSubscriptionFilter {
+  and: [NoteSubscriptionFilter!]
+  or: [NoteSubscriptionFilter!]
+  not: NoteSubscriptionFilter
+  id: IDInput
+  title: StringInput
+}
+"
+`;
+
 exports[`Creates CRUD resolvers for models 1`] = `
 Object {
   "Comment": Object {


### PR DESCRIPTION
Fixes #2113 

The `SchemCRUDPlugin` was still checking both `sub{Create,Update,Delete}` and `{create,update,delete}` were true before creating subscription fields