### PR TITLE
chore(templates): exclude directories from build

### DIFF
--- a/templates/ts-apollo-mongodb-backend/tsconfig.json
+++ b/templates/ts-apollo-mongodb-backend/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "exclude": [
+    "client",
+    "types"
+  ],
   "compilerOptions": {
     "outDir": "dist",
     "declarationDir": "types",

--- a/templates/ts-apollo-mongodb-datasync-backend/tsconfig.json
+++ b/templates/ts-apollo-mongodb-datasync-backend/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "exclude": [
+    "client",
+    "types"
+  ],
   "compilerOptions": {
     "outDir": "dist",
     "declarationDir": "types",

--- a/templates/ts-apollo-postgres-backend/tsconfig.json
+++ b/templates/ts-apollo-postgres-backend/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "exclude": [
+    "client",
+    "types"
+  ],
   "compilerOptions": {
     "outDir": "dist",
     "declarationDir": "types",


### PR DESCRIPTION
Running `yarn build` failed on fullstack templates as the `tsconfig.json` is not configured to compile React and does not have the required dependencies.

Since the client template comes with react-scripts, we can let them be built individually.