### PR TITLE
remove empty resolver creation in plugin

### DIFF
--- a/packages/graphql-serve/src/commands/printSchema.ts
+++ b/packages/graphql-serve/src/commands/printSchema.ts
@@ -22,5 +22,6 @@ export function handler(args: Params): void {
   const schemaSDL = printSchemaHandler(args);
 
   console.log("Generated schema:\n");
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   console.log(chalk.cyan(schemaSDL));
 }


### PR DESCRIPTION
Fixes https://github.com/aerogear/graphback/issues/2117

The DataSyncPlugin was creating empty root Query, Mutation and Subscription resolver objects.