### PR TITLE
fix: remove indent from generated query

### DIFF
--- a/packages/graphback-codegen-client/src/templates/gqlTemplates.ts
+++ b/packages/graphback-codegen-client/src/templates/gqlTemplates.ts
@@ -28,7 +28,8 @@ export const findOneQuery = (t: ModelDefinition) => {
     ${fieldName}(id: $id) {
       ...${t.graphqlType.name}ExpandedFields
     }
-  }`
+}
+`
 }
 
 export const findQuery = (t: GraphQLObjectType) => {
@@ -44,7 +45,8 @@ export const findQuery = (t: GraphQLObjectType) => {
       limit
       count
     }
-  }`
+}
+`
 }
 
 
@@ -90,7 +92,8 @@ export const subscription = (t: GraphQLObjectType, fieldName: string, inputTypeF
   ${fieldName}(filter: $filter) {
       ...${t.name}Fields
   }
-} `
+} 
+`
 }
 
 export const createFragments = (types: ModelDefinition[]) => {

--- a/packages/graphback-codegen-client/src/templates/gqlTemplates.ts
+++ b/packages/graphback-codegen-client/src/templates/gqlTemplates.ts
@@ -9,7 +9,7 @@ export const fragment = (t: GraphQLObjectType) => {
 
   return `fragment ${t.name}Fields on ${t.name} {
 ${returnFieldsString}
-} `
+}`
 }
 
 export const expandedFragment = (t: GraphQLObjectType) => {
@@ -18,7 +18,7 @@ export const expandedFragment = (t: GraphQLObjectType) => {
 
   return `fragment ${t.name}ExpandedFields on ${t.name} {
 ${returnFieldsString}
-} `
+}`
 }
 
 export const findOneQuery = (t: ModelDefinition) => {
@@ -28,8 +28,7 @@ export const findOneQuery = (t: ModelDefinition) => {
     ${fieldName}(id: $id) {
       ...${t.graphqlType.name}ExpandedFields
     }
-}
-`
+}`
 }
 
 export const findQuery = (t: GraphQLObjectType) => {
@@ -45,8 +44,7 @@ export const findQuery = (t: GraphQLObjectType) => {
       limit
       count
     }
-}
-`
+}`
 }
 
 
@@ -58,8 +56,7 @@ export const createMutation = (t: GraphQLObjectType) => {
   ${ fieldName}(input: $input) {
       ...${ t.name}Fields
   }
-}
-`
+}`
 }
 
 export const updateMutation = (t: GraphQLObjectType) => {
@@ -70,8 +67,7 @@ export const updateMutation = (t: GraphQLObjectType) => {
   ${fieldName}(input: $input) {
       ...${ t.name}Fields
   }
-}
-`
+}`
 }
 
 export const deleteMutation = (t: GraphQLObjectType) => {
@@ -82,8 +78,7 @@ export const deleteMutation = (t: GraphQLObjectType) => {
   ${fieldName}(input: $input) {
       ...${t.name}Fields
   }
-}
-`
+}`
 }
 
 export const subscription = (t: GraphQLObjectType, fieldName: string, inputTypeField: string) => {
@@ -92,8 +87,7 @@ export const subscription = (t: GraphQLObjectType, fieldName: string, inputTypeF
   ${fieldName}(filter: $filter) {
       ...${t.name}Fields
   }
-} 
-`
+}`
 }
 
 export const createFragments = (types: ModelDefinition[]) => {

--- a/packages/graphback-codegen-client/tests/__snapshots__/GraphQLClientCreatorTest.ts.snap
+++ b/packages/graphback-codegen-client/tests/__snapshots__/GraphQLClientCreatorTest.ts.snap
@@ -199,7 +199,8 @@ Object {
       limit
       count
     }
-  }",
+}
+",
       "name": "findNotes",
     },
     Object {
@@ -207,7 +208,8 @@ Object {
     getNote(id: $id) {
       ...NoteExpandedFields
     }
-  }",
+}
+",
       "name": "getNote",
     },
     Object {
@@ -220,7 +222,8 @@ Object {
       limit
       count
     }
-  }",
+}
+",
       "name": "findComments",
     },
     Object {
@@ -228,7 +231,8 @@ Object {
     getComment(id: $id) {
       ...CommentExpandedFields
     }
-  }",
+}
+",
       "name": "getComment",
     },
     Object {
@@ -241,7 +245,8 @@ Object {
       limit
       count
     }
-  }",
+}
+",
       "name": "findModelWithGraphbackObjectIDPrimaryKeys",
     },
     Object {
@@ -249,7 +254,8 @@ Object {
     getModelWithGraphbackObjectIDPrimaryKey(id: $id) {
       ...ModelWithGraphbackObjectIDPrimaryKeyExpandedFields
     }
-  }",
+}
+",
       "name": "getModelWithGraphbackObjectIDPrimaryKey",
     },
     Object {
@@ -262,7 +268,8 @@ Object {
       limit
       count
     }
-  }",
+}
+",
       "name": "findModelWithAnnotatedPrimaryKeys",
     },
     Object {
@@ -270,7 +277,8 @@ Object {
     getModelWithAnnotatedPrimaryKey(id: $id) {
       ...ModelWithAnnotatedPrimaryKeyExpandedFields
     }
-  }",
+}
+",
       "name": "getModelWithAnnotatedPrimaryKey",
     },
   ],
@@ -280,7 +288,8 @@ Object {
   newNote(filter: $filter) {
       ...NoteFields
   }
-} ",
+} 
+",
       "name": "newNote",
     },
     Object {
@@ -288,7 +297,8 @@ Object {
   updatedNote(filter: $filter) {
       ...NoteFields
   }
-} ",
+} 
+",
       "name": "updatedNote",
     },
     Object {
@@ -296,7 +306,8 @@ Object {
   deletedNote(filter: $filter) {
       ...NoteFields
   }
-} ",
+} 
+",
       "name": "deletedNote",
     },
     Object {
@@ -304,7 +315,8 @@ Object {
   newComment(filter: $filter) {
       ...CommentFields
   }
-} ",
+} 
+",
       "name": "newComment",
     },
     Object {
@@ -312,7 +324,8 @@ Object {
   updatedComment(filter: $filter) {
       ...CommentFields
   }
-} ",
+} 
+",
       "name": "updatedComment",
     },
     Object {
@@ -320,7 +333,8 @@ Object {
   deletedComment(filter: $filter) {
       ...CommentFields
   }
-} ",
+} 
+",
       "name": "deletedComment",
     },
     Object {
@@ -328,7 +342,8 @@ Object {
   newModelWithGraphbackObjectIDPrimaryKey(filter: $filter) {
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
-} ",
+} 
+",
       "name": "newModelWithGraphbackObjectIDPrimaryKey",
     },
     Object {
@@ -336,7 +351,8 @@ Object {
   updatedModelWithGraphbackObjectIDPrimaryKey(filter: $filter) {
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
-} ",
+} 
+",
       "name": "updatedModelWithGraphbackObjectIDPrimaryKey",
     },
     Object {
@@ -344,7 +360,8 @@ Object {
   deletedModelWithGraphbackObjectIDPrimaryKey(filter: $filter) {
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
-} ",
+} 
+",
       "name": "deletedModelWithGraphbackObjectIDPrimaryKey",
     },
     Object {
@@ -352,7 +369,8 @@ Object {
   newModelWithAnnotatedPrimaryKey(filter: $filter) {
       ...ModelWithAnnotatedPrimaryKeyFields
   }
-} ",
+} 
+",
       "name": "newModelWithAnnotatedPrimaryKey",
     },
     Object {
@@ -360,7 +378,8 @@ Object {
   updatedModelWithAnnotatedPrimaryKey(filter: $filter) {
       ...ModelWithAnnotatedPrimaryKeyFields
   }
-} ",
+} 
+",
       "name": "updatedModelWithAnnotatedPrimaryKey",
     },
     Object {
@@ -368,7 +387,8 @@ Object {
   deletedModelWithAnnotatedPrimaryKey(filter: $filter) {
       ...ModelWithAnnotatedPrimaryKeyFields
   }
-} ",
+} 
+",
       "name": "deletedModelWithAnnotatedPrimaryKey",
     },
   ],
@@ -667,7 +687,8 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       limit
       count
     }
-  }
+}
+
 
   \${NoteExpandedFragment}
 \`
@@ -680,7 +701,8 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
     getNote(id: $id) {
       ...NoteExpandedFields
     }
-  }
+}
+
 
   \${NoteExpandedFragment}
 \`
@@ -698,7 +720,8 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       limit
       count
     }
-  }
+}
+
 
   \${CommentExpandedFragment}
 \`
@@ -711,7 +734,8 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
     getComment(id: $id) {
       ...CommentExpandedFields
     }
-  }
+}
+
 
   \${CommentExpandedFragment}
 \`
@@ -729,7 +753,8 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       limit
       count
     }
-  }
+}
+
 
   \${ModelWithGraphbackObjectIDPrimaryKeyExpandedFragment}
 \`
@@ -742,7 +767,8 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
     getModelWithGraphbackObjectIDPrimaryKey(id: $id) {
       ...ModelWithGraphbackObjectIDPrimaryKeyExpandedFields
     }
-  }
+}
+
 
   \${ModelWithGraphbackObjectIDPrimaryKeyExpandedFragment}
 \`
@@ -760,7 +786,8 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       limit
       count
     }
-  }
+}
+
 
   \${ModelWithAnnotatedPrimaryKeyExpandedFragment}
 \`
@@ -773,7 +800,8 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
     getModelWithAnnotatedPrimaryKey(id: $id) {
       ...ModelWithAnnotatedPrimaryKeyExpandedFields
     }
-  }
+}
+
 
   \${ModelWithAnnotatedPrimaryKeyExpandedFragment}
 \`
@@ -790,6 +818,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   }
 } 
 
+
   \${NoteFragment}
 \`
 ",
@@ -802,6 +831,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...NoteFields
   }
 } 
+
 
   \${NoteFragment}
 \`
@@ -816,6 +846,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   }
 } 
 
+
   \${NoteFragment}
 \`
 ",
@@ -828,6 +859,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...CommentFields
   }
 } 
+
 
   \${CommentFragment}
 \`
@@ -842,6 +874,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   }
 } 
 
+
   \${CommentFragment}
 \`
 ",
@@ -854,6 +887,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...CommentFields
   }
 } 
+
 
   \${CommentFragment}
 \`
@@ -868,6 +902,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   }
 } 
 
+
   \${ModelWithGraphbackObjectIDPrimaryKeyFragment}
 \`
 ",
@@ -880,6 +915,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
 } 
+
 
   \${ModelWithGraphbackObjectIDPrimaryKeyFragment}
 \`
@@ -894,6 +930,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   }
 } 
 
+
   \${ModelWithGraphbackObjectIDPrimaryKeyFragment}
 \`
 ",
@@ -906,6 +943,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...ModelWithAnnotatedPrimaryKeyFields
   }
 } 
+
 
   \${ModelWithAnnotatedPrimaryKeyFragment}
 \`
@@ -920,6 +958,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   }
 } 
 
+
   \${ModelWithAnnotatedPrimaryKeyFragment}
 \`
 ",
@@ -932,6 +971,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...ModelWithAnnotatedPrimaryKeyFields
   }
 } 
+
 
   \${ModelWithAnnotatedPrimaryKeyFragment}
 \`

--- a/packages/graphback-codegen-client/tests/__snapshots__/GraphQLClientCreatorTest.ts.snap
+++ b/packages/graphback-codegen-client/tests/__snapshots__/GraphQLClientCreatorTest.ts.snap
@@ -9,7 +9,7 @@ Object {
    title
    description
 
-} ",
+}",
       "name": "Note",
     },
     Object {
@@ -22,7 +22,7 @@ Object {
       title
       description
    }
-} ",
+}",
       "name": "NoteExpanded",
     },
     Object {
@@ -31,7 +31,7 @@ Object {
    title
    description
 
-} ",
+}",
       "name": "Comment",
     },
     Object {
@@ -44,7 +44,7 @@ Object {
       title
       description
    }
-} ",
+}",
       "name": "CommentExpanded",
     },
     Object {
@@ -52,7 +52,7 @@ Object {
    _id
    metadata
 
-} ",
+}",
       "name": "ModelWithGraphbackObjectIDPrimaryKey",
     },
     Object {
@@ -60,21 +60,21 @@ Object {
    _id
    metadata
 
-} ",
+}",
       "name": "ModelWithGraphbackObjectIDPrimaryKeyExpanded",
     },
     Object {
       "implementation": "fragment ModelWithAnnotatedPrimaryKeyFields on ModelWithAnnotatedPrimaryKey {
    email
 
-} ",
+}",
       "name": "ModelWithAnnotatedPrimaryKey",
     },
     Object {
       "implementation": "fragment ModelWithAnnotatedPrimaryKeyExpandedFields on ModelWithAnnotatedPrimaryKey {
    email
 
-} ",
+}",
       "name": "ModelWithAnnotatedPrimaryKeyExpanded",
     },
   ],
@@ -84,8 +84,7 @@ Object {
   createNote(input: $input) {
       ...NoteFields
   }
-}
-",
+}",
       "name": "createNote",
     },
     Object {
@@ -93,8 +92,7 @@ Object {
   updateNote(input: $input) {
       ...NoteFields
   }
-}
-",
+}",
       "name": "updateNote",
     },
     Object {
@@ -102,8 +100,7 @@ Object {
   deleteNote(input: $input) {
       ...NoteFields
   }
-}
-",
+}",
       "name": "deleteNote",
     },
     Object {
@@ -111,8 +108,7 @@ Object {
   createComment(input: $input) {
       ...CommentFields
   }
-}
-",
+}",
       "name": "createComment",
     },
     Object {
@@ -120,8 +116,7 @@ Object {
   updateComment(input: $input) {
       ...CommentFields
   }
-}
-",
+}",
       "name": "updateComment",
     },
     Object {
@@ -129,8 +124,7 @@ Object {
   deleteComment(input: $input) {
       ...CommentFields
   }
-}
-",
+}",
       "name": "deleteComment",
     },
     Object {
@@ -138,8 +132,7 @@ Object {
   createModelWithGraphbackObjectIDPrimaryKey(input: $input) {
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
-}
-",
+}",
       "name": "createModelWithGraphbackObjectIDPrimaryKey",
     },
     Object {
@@ -147,8 +140,7 @@ Object {
   updateModelWithGraphbackObjectIDPrimaryKey(input: $input) {
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
-}
-",
+}",
       "name": "updateModelWithGraphbackObjectIDPrimaryKey",
     },
     Object {
@@ -156,8 +148,7 @@ Object {
   deleteModelWithGraphbackObjectIDPrimaryKey(input: $input) {
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
-}
-",
+}",
       "name": "deleteModelWithGraphbackObjectIDPrimaryKey",
     },
     Object {
@@ -165,8 +156,7 @@ Object {
   createModelWithAnnotatedPrimaryKey(input: $input) {
       ...ModelWithAnnotatedPrimaryKeyFields
   }
-}
-",
+}",
       "name": "createModelWithAnnotatedPrimaryKey",
     },
     Object {
@@ -174,8 +164,7 @@ Object {
   updateModelWithAnnotatedPrimaryKey(input: $input) {
       ...ModelWithAnnotatedPrimaryKeyFields
   }
-}
-",
+}",
       "name": "updateModelWithAnnotatedPrimaryKey",
     },
     Object {
@@ -183,8 +172,7 @@ Object {
   deleteModelWithAnnotatedPrimaryKey(input: $input) {
       ...ModelWithAnnotatedPrimaryKeyFields
   }
-}
-",
+}",
       "name": "deleteModelWithAnnotatedPrimaryKey",
     },
   ],
@@ -199,8 +187,7 @@ Object {
       limit
       count
     }
-}
-",
+}",
       "name": "findNotes",
     },
     Object {
@@ -208,8 +195,7 @@ Object {
     getNote(id: $id) {
       ...NoteExpandedFields
     }
-}
-",
+}",
       "name": "getNote",
     },
     Object {
@@ -222,8 +208,7 @@ Object {
       limit
       count
     }
-}
-",
+}",
       "name": "findComments",
     },
     Object {
@@ -231,8 +216,7 @@ Object {
     getComment(id: $id) {
       ...CommentExpandedFields
     }
-}
-",
+}",
       "name": "getComment",
     },
     Object {
@@ -245,8 +229,7 @@ Object {
       limit
       count
     }
-}
-",
+}",
       "name": "findModelWithGraphbackObjectIDPrimaryKeys",
     },
     Object {
@@ -254,8 +237,7 @@ Object {
     getModelWithGraphbackObjectIDPrimaryKey(id: $id) {
       ...ModelWithGraphbackObjectIDPrimaryKeyExpandedFields
     }
-}
-",
+}",
       "name": "getModelWithGraphbackObjectIDPrimaryKey",
     },
     Object {
@@ -268,8 +250,7 @@ Object {
       limit
       count
     }
-}
-",
+}",
       "name": "findModelWithAnnotatedPrimaryKeys",
     },
     Object {
@@ -277,8 +258,7 @@ Object {
     getModelWithAnnotatedPrimaryKey(id: $id) {
       ...ModelWithAnnotatedPrimaryKeyExpandedFields
     }
-}
-",
+}",
       "name": "getModelWithAnnotatedPrimaryKey",
     },
   ],
@@ -288,8 +268,7 @@ Object {
   newNote(filter: $filter) {
       ...NoteFields
   }
-} 
-",
+}",
       "name": "newNote",
     },
     Object {
@@ -297,8 +276,7 @@ Object {
   updatedNote(filter: $filter) {
       ...NoteFields
   }
-} 
-",
+}",
       "name": "updatedNote",
     },
     Object {
@@ -306,8 +284,7 @@ Object {
   deletedNote(filter: $filter) {
       ...NoteFields
   }
-} 
-",
+}",
       "name": "deletedNote",
     },
     Object {
@@ -315,8 +292,7 @@ Object {
   newComment(filter: $filter) {
       ...CommentFields
   }
-} 
-",
+}",
       "name": "newComment",
     },
     Object {
@@ -324,8 +300,7 @@ Object {
   updatedComment(filter: $filter) {
       ...CommentFields
   }
-} 
-",
+}",
       "name": "updatedComment",
     },
     Object {
@@ -333,8 +308,7 @@ Object {
   deletedComment(filter: $filter) {
       ...CommentFields
   }
-} 
-",
+}",
       "name": "deletedComment",
     },
     Object {
@@ -342,8 +316,7 @@ Object {
   newModelWithGraphbackObjectIDPrimaryKey(filter: $filter) {
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
-} 
-",
+}",
       "name": "newModelWithGraphbackObjectIDPrimaryKey",
     },
     Object {
@@ -351,8 +324,7 @@ Object {
   updatedModelWithGraphbackObjectIDPrimaryKey(filter: $filter) {
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
-} 
-",
+}",
       "name": "updatedModelWithGraphbackObjectIDPrimaryKey",
     },
     Object {
@@ -360,8 +332,7 @@ Object {
   deletedModelWithGraphbackObjectIDPrimaryKey(filter: $filter) {
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
-} 
-",
+}",
       "name": "deletedModelWithGraphbackObjectIDPrimaryKey",
     },
     Object {
@@ -369,8 +340,7 @@ Object {
   newModelWithAnnotatedPrimaryKey(filter: $filter) {
       ...ModelWithAnnotatedPrimaryKeyFields
   }
-} 
-",
+}",
       "name": "newModelWithAnnotatedPrimaryKey",
     },
     Object {
@@ -378,8 +348,7 @@ Object {
   updatedModelWithAnnotatedPrimaryKey(filter: $filter) {
       ...ModelWithAnnotatedPrimaryKeyFields
   }
-} 
-",
+}",
       "name": "updatedModelWithAnnotatedPrimaryKey",
     },
     Object {
@@ -387,8 +356,7 @@ Object {
   deletedModelWithAnnotatedPrimaryKey(filter: $filter) {
       ...ModelWithAnnotatedPrimaryKeyFields
   }
-} 
-",
+}",
       "name": "deletedModelWithAnnotatedPrimaryKey",
     },
   ],
@@ -407,7 +375,7 @@ export const NoteFragment = gql\`
    title
    description
 
-} 
+}
 \`
 ",
       "name": "Note",
@@ -423,7 +391,7 @@ export const NoteFragment = gql\`
       title
       description
    }
-} 
+}
 \`
 ",
       "name": "NoteExpanded",
@@ -437,7 +405,7 @@ export const CommentFragment = gql\`
    title
    description
 
-} 
+}
 \`
 ",
       "name": "Comment",
@@ -453,7 +421,7 @@ export const CommentFragment = gql\`
       title
       description
    }
-} 
+}
 \`
 ",
       "name": "CommentExpanded",
@@ -466,7 +434,7 @@ export const ModelWithGraphbackObjectIDPrimaryKeyFragment = gql\`
    _id
    metadata
 
-} 
+}
 \`
 ",
       "name": "ModelWithGraphbackObjectIDPrimaryKey",
@@ -477,7 +445,7 @@ export const ModelWithGraphbackObjectIDPrimaryKeyFragment = gql\`
    _id
    metadata
 
-} 
+}
 \`
 ",
       "name": "ModelWithGraphbackObjectIDPrimaryKeyExpanded",
@@ -489,7 +457,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   fragment ModelWithAnnotatedPrimaryKeyFields on ModelWithAnnotatedPrimaryKey {
    email
 
-} 
+}
 \`
 ",
       "name": "ModelWithAnnotatedPrimaryKey",
@@ -499,7 +467,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   fragment ModelWithAnnotatedPrimaryKeyExpandedFields on ModelWithAnnotatedPrimaryKey {
    email
 
-} 
+}
 \`
 ",
       "name": "ModelWithAnnotatedPrimaryKeyExpanded",
@@ -514,7 +482,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   }
 }
 
-
   \${NoteFragment}
 \`
 ",
@@ -527,7 +494,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...NoteFields
   }
 }
-
 
   \${NoteFragment}
 \`
@@ -542,7 +508,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   }
 }
 
-
   \${NoteFragment}
 \`
 ",
@@ -555,7 +520,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...CommentFields
   }
 }
-
 
   \${CommentFragment}
 \`
@@ -570,7 +534,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   }
 }
 
-
   \${CommentFragment}
 \`
 ",
@@ -583,7 +546,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...CommentFields
   }
 }
-
 
   \${CommentFragment}
 \`
@@ -598,7 +560,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   }
 }
 
-
   \${ModelWithGraphbackObjectIDPrimaryKeyFragment}
 \`
 ",
@@ -611,7 +572,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
 }
-
 
   \${ModelWithGraphbackObjectIDPrimaryKeyFragment}
 \`
@@ -626,7 +586,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   }
 }
 
-
   \${ModelWithGraphbackObjectIDPrimaryKeyFragment}
 \`
 ",
@@ -639,7 +598,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...ModelWithAnnotatedPrimaryKeyFields
   }
 }
-
 
   \${ModelWithAnnotatedPrimaryKeyFragment}
 \`
@@ -654,7 +612,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   }
 }
 
-
   \${ModelWithAnnotatedPrimaryKeyFragment}
 \`
 ",
@@ -667,7 +624,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...ModelWithAnnotatedPrimaryKeyFields
   }
 }
-
 
   \${ModelWithAnnotatedPrimaryKeyFragment}
 \`
@@ -689,7 +645,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
     }
 }
 
-
   \${NoteExpandedFragment}
 \`
 ",
@@ -702,7 +657,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...NoteExpandedFields
     }
 }
-
 
   \${NoteExpandedFragment}
 \`
@@ -722,7 +676,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
     }
 }
 
-
   \${CommentExpandedFragment}
 \`
 ",
@@ -735,7 +688,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...CommentExpandedFields
     }
 }
-
 
   \${CommentExpandedFragment}
 \`
@@ -755,7 +707,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
     }
 }
 
-
   \${ModelWithGraphbackObjectIDPrimaryKeyExpandedFragment}
 \`
 ",
@@ -768,7 +719,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...ModelWithGraphbackObjectIDPrimaryKeyExpandedFields
     }
 }
-
 
   \${ModelWithGraphbackObjectIDPrimaryKeyExpandedFragment}
 \`
@@ -788,7 +738,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
     }
 }
 
-
   \${ModelWithAnnotatedPrimaryKeyExpandedFragment}
 \`
 ",
@@ -801,7 +750,6 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
       ...ModelWithAnnotatedPrimaryKeyExpandedFields
     }
 }
-
 
   \${ModelWithAnnotatedPrimaryKeyExpandedFragment}
 \`
@@ -816,8 +764,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   newNote(filter: $filter) {
       ...NoteFields
   }
-} 
-
+}
 
   \${NoteFragment}
 \`
@@ -830,8 +777,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   updatedNote(filter: $filter) {
       ...NoteFields
   }
-} 
-
+}
 
   \${NoteFragment}
 \`
@@ -844,8 +790,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   deletedNote(filter: $filter) {
       ...NoteFields
   }
-} 
-
+}
 
   \${NoteFragment}
 \`
@@ -858,8 +803,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   newComment(filter: $filter) {
       ...CommentFields
   }
-} 
-
+}
 
   \${CommentFragment}
 \`
@@ -872,8 +816,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   updatedComment(filter: $filter) {
       ...CommentFields
   }
-} 
-
+}
 
   \${CommentFragment}
 \`
@@ -886,8 +829,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   deletedComment(filter: $filter) {
       ...CommentFields
   }
-} 
-
+}
 
   \${CommentFragment}
 \`
@@ -900,8 +842,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   newModelWithGraphbackObjectIDPrimaryKey(filter: $filter) {
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
-} 
-
+}
 
   \${ModelWithGraphbackObjectIDPrimaryKeyFragment}
 \`
@@ -914,8 +855,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   updatedModelWithGraphbackObjectIDPrimaryKey(filter: $filter) {
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
-} 
-
+}
 
   \${ModelWithGraphbackObjectIDPrimaryKeyFragment}
 \`
@@ -928,8 +868,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   deletedModelWithGraphbackObjectIDPrimaryKey(filter: $filter) {
       ...ModelWithGraphbackObjectIDPrimaryKeyFields
   }
-} 
-
+}
 
   \${ModelWithGraphbackObjectIDPrimaryKeyFragment}
 \`
@@ -942,8 +881,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   newModelWithAnnotatedPrimaryKey(filter: $filter) {
       ...ModelWithAnnotatedPrimaryKeyFields
   }
-} 
-
+}
 
   \${ModelWithAnnotatedPrimaryKeyFragment}
 \`
@@ -956,8 +894,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   updatedModelWithAnnotatedPrimaryKey(filter: $filter) {
       ...ModelWithAnnotatedPrimaryKeyFields
   }
-} 
-
+}
 
   \${ModelWithAnnotatedPrimaryKeyFragment}
 \`
@@ -970,8 +907,7 @@ export const ModelWithAnnotatedPrimaryKeyFragment = gql\`
   deletedModelWithAnnotatedPrimaryKey(filter: $filter) {
       ...ModelWithAnnotatedPrimaryKeyFields
   }
-} 
-
+}
 
   \${ModelWithAnnotatedPrimaryKeyFragment}
 \`


### PR DESCRIPTION
I think I have found a fix for issue #1965. The indentation issue would have also come when using subscriptions so I've tried to fix that too. 

I could not test my changes. I followed the written instructions but had the following problem:
1. First I changed the path of extensions.graphback.model in the .graphqlrc file,
![ss1](https://user-images.githubusercontent.com/56963264/94267369-1bb15480-ff59-11ea-8f63-eba221a88a3f.png)
2. Then I ran the command in the templates folder and received this error,
![ss2](https://user-images.githubusercontent.com/56963264/94267423-308de800-ff59-11ea-9853-138998680f56.png)

While I wasn't able to test it I think the changes I've made should fix the issue.