### PR TITLE
fix: add jest to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,18 +20,19 @@
     "eslint-plugin-react-hooks": "4.1.2",
     "eslint-plugin-unused-imports": "0.1.3",
     "husky": "4.3.0",
+    "jest": "26.4.2",
     "lerna": "3.22.1",
     "npm-run-all": "4.1.5",
     "nyc": "15.1.0",
     "replace": "1.2.0",
+    "ts-jest": "26.4.1",
     "ts-node": "9.0.0",
     "tslint": "6.1.3",
     "tslint-config-prettier": "1.18.0",
     "tslint-microsoft-contrib": "6.2.0",
     "typedoc": "0.19.2",
     "typedoc-plugin-markdown": "2.4.2",
-    "typescript": "4.0.3",
-    "jest": "26.4.2"
+    "typescript": "4.0.3"
   },
   "scripts": {
     "bench": "cd performance && yarn start",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "tslint-microsoft-contrib": "6.2.0",
     "typedoc": "0.19.2",
     "typedoc-plugin-markdown": "2.4.2",
-    "typescript": "4.0.3"
+    "typescript": "4.0.3",
+    "jest": "26.4.2"
   },
   "scripts": {
     "bench": "cd performance && yarn start",


### PR DESCRIPTION
Fix to Issue #2150

Dev dependency on jest was missing so users are unable to run tests on fresh clones without installing jest manually.