### PR TITLE
[ISSUE-1195]: Updated Docker PostgreSQL templates to use stable postgres docker image of version 11.9

### DIFF
--- a/templates/ts-apollo-postgres-backend/docker-compose.yml
+++ b/templates/ts-apollo-postgres-backend/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:9.6
+    image: postgres:11.9
     ports:
       - "55432:5432"
     environment:


### PR DESCRIPTION
Issue link : [ISSUE-1195](https://github.com/tighten/takeout/issues/1195)

### Description 
The following contains information on how I tested if database migrations work with v11 of PostgreSQL docker

1.  Created a Graphback application/project and chose postgres template
![image](https://user-images.githubusercontent.com/67866345/94991976-437d6980-05a4-11eb-95b3-73156a29f7ef.png)
2.  Modified postgres template's docker-compose.yml to use postgres image of version 11.9
     - 11.9 is the stable 11.x version of postgres image
     - Click [here](https://hub.docker.com/_/postgres) for Dockerhub reference
![image](https://user-images.githubusercontent.com/67866345/94992040-de764380-05a4-11eb-9d6e-f045b2134d33.png)
3. Booted up the postgres docker container 
![image](https://user-images.githubusercontent.com/67866345/94992083-12e9ff80-05a5-11eb-862c-eadf60baa766.png)
4. Connected with the postgres docker container and checked if the default users database is set up as configured in docker-compose.yml.
     - **Note : As you can see in the image, the users database has no relations/tables**
![image](https://user-images.githubusercontent.com/67866345/94992114-55abd780-05a5-11eb-9699-08159c601d47.png)
5. Started the application server
![image](https://user-images.githubusercontent.com/67866345/94992150-9a377300-05a5-11eb-8dac-efeb4a1fe586.png)
6. Checked if migrations are performed to postgres users database, after starting the application server
![image](https://user-images.githubusercontent.com/67866345/94992193-e2ef2c00-05a5-11eb-9d21-1088457b2379.png)
