### PR TITLE
Enable TypeScript declaration maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "alwaysStrict": false,
     "sourceMap": true,
     "declaration": true,
+    "declarationMap": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
@@ -25,5 +26,5 @@
     "node_modules",
     "dist",
     "types"
-  ]	  
+  ]
 }


### PR DESCRIPTION
This generates a corresponding `.d.ts.map` file for each declaration file. It means that when someone uses "go to definition" on anything imported from a graphback package they will end up at the original definition in `src/foo.ts` rather than in a type definition file `types/foo.d.ts`