### PR TITLE
fix: Remove performance from workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
     "templates/ts-apollo-mongodb-datasync-backend",
     "templates/ts-apollo-postgres-backend",
     "templates/ts-react-apollo-client",
-    "integration",
-    "performance"
+    "integration"
   ],
   "husky": {
     "hooks": {


### PR DESCRIPTION
Something that is used occasionally should not be part of the CI/CD build or local dev install.
It also list packages in the root making impression that we use them somewhere