### PR TITLE
fix: adding relationships to datasync plugin

### DIFF
--- a/packages/graphback-datasync/src/DataSyncPlugin.ts
+++ b/packages/graphback-datasync/src/DataSyncPlugin.ts
@@ -1,7 +1,7 @@
 import { SchemaComposer } from 'graphql-compose';
 import { IResolvers, IFieldResolver } from '@graphql-tools/utils';
-import { GraphQLNonNull, GraphQLSchema, buildSchema, GraphQLResolveInfo, GraphQLInt, GraphQLBoolean, GraphQLList, GraphQLObjectType, GraphQLField } from 'graphql';
-import { GraphbackCoreMetadata, GraphbackPlugin, ModelDefinition, getInputTypeName, GraphbackOperationType, parseRelationshipAnnotation, GraphbackContext, GraphbackTimestamp, transformForeignKeyName } from '@graphback/core';
+import { GraphQLNonNull, GraphQLSchema, buildSchema, GraphQLResolveInfo, GraphQLInt, GraphQLBoolean, GraphQLList } from 'graphql';
+import { GraphbackCoreMetadata, GraphbackPlugin, ModelDefinition, getInputTypeName, GraphbackOperationType,  GraphbackContext, GraphbackTimestamp } from '@graphback/core';
 import { getDeltaType, getDeltaListType, getDeltaQuery } from "./deltaMappingHelper";
 import { isDataSyncService, isDataSyncModel, DataSyncFieldNames, GlobalConflictConfig, getModelConfigFromGlobal } from "./util";
 
@@ -205,55 +205,5 @@ export class DataSyncPlugin extends GraphbackPlugin {
       filter: findFilterITC.getType(),
       limit: GraphQLInt
     });
-  }
-
-  private getDeltaTypeFieldNames(modelTC: GraphQLObjectType): string[] {
-
-    const entries = Object.entries(modelTC.getFields()).map(([fieldName, field]: [string, GraphQLField<any, any>]) => {
-      const relationship = parseRelationshipAnnotation(field.description);
-      if (relationship) {
-        console.log("RELATIONSHIP", relationship)
-        if (relationship.kind === "oneToOne") {
-          return relationship.key || transformForeignKeyName(field.name);
-        }
-        if (relationship.kind === "manyToOne") {
-          return relationship.key || transformForeignKeyName(field.name);
-        }
-      }
-
-      return fieldName;
-    }).filter((entry: any) => {
-      // console.log("filter", entry)
-
-      return !!entry
-    });
-    // console.log(entries);
-
-    return entries;
-  }
-
-  private addDBKeyFields(modelTC: GraphQLObjectType): string[] {
-
-    const entries = Object.entries(modelTC.getFields()).map(([fieldName, field]: [string, GraphQLField<any, any>]) => {
-      const relationship = parseRelationshipAnnotation(field.description);
-      if (relationship) {
-        console.log("RELATIONSHIP", relationship)
-        if (relationship.kind === "oneToOne") {
-          return relationship.key || transformForeignKeyName(field.name);
-        }
-        if (relationship.kind === "manyToOne") {
-          return relationship.key || transformForeignKeyName(field.name);
-        }
-      }
-
-      return fieldName;
-    }).filter((entry: any) => {
-      // console.log("filter", entry)
-
-      return !!entry
-    });
-    // console.log(entries);
-
-    return entries;
   }
 }

--- a/packages/graphback-datasync/src/DataSyncPlugin.ts
+++ b/packages/graphback-datasync/src/DataSyncPlugin.ts
@@ -179,16 +179,12 @@ export class DataSyncPlugin extends GraphbackPlugin {
       DeltaOTC.addFields({ [field.name]: field.type.toString() })
     }
 
-    modelTC.addFields({
+    DeltaOTC.addFields({
       [DataSyncFieldNames.lastUpdatedAt]: {
         type: TimestampSTC.getType(),
         description: "@index(name: 'Datasync_lastUpdatedAt')"
       }
     });
-
-    DeltaOTC.addFields({
-      [DataSyncFieldNames.deleted]: GraphQLBoolean
-    })
 
     DeltaOTC.addFields({
       [DataSyncFieldNames.deleted]: GraphQLBoolean

--- a/packages/graphback-datasync/src/DataSyncPlugin.ts
+++ b/packages/graphback-datasync/src/DataSyncPlugin.ts
@@ -1,7 +1,7 @@
 import { SchemaComposer } from 'graphql-compose';
 import { IResolvers, IFieldResolver } from '@graphql-tools/utils';
 import { GraphQLNonNull, GraphQLSchema, buildSchema, GraphQLResolveInfo, GraphQLInt, GraphQLBoolean, GraphQLList } from 'graphql';
-import { GraphbackCoreMetadata, GraphbackPlugin, ModelDefinition, getInputTypeName, GraphbackOperationType,  GraphbackContext, GraphbackTimestamp } from '@graphback/core';
+import { GraphbackCoreMetadata, GraphbackPlugin, ModelDefinition, getInputTypeName, GraphbackOperationType, GraphbackContext, GraphbackTimestamp } from '@graphback/core';
 import { getDeltaType, getDeltaListType, getDeltaQuery } from "./deltaMappingHelper";
 import { isDataSyncService, isDataSyncModel, DataSyncFieldNames, GlobalConflictConfig, getModelConfigFromGlobal } from "./util";
 
@@ -178,6 +178,17 @@ export class DataSyncPlugin extends GraphbackPlugin {
     for (const field of allFields) {
       DeltaOTC.addFields({ [field.name]: field.type.toString() })
     }
+
+    modelTC.addFields({
+      [DataSyncFieldNames.lastUpdatedAt]: {
+        type: TimestampSTC.getType(),
+        description: "@index(name: 'Datasync_lastUpdatedAt')"
+      }
+    });
+
+    DeltaOTC.addFields({
+      [DataSyncFieldNames.deleted]: GraphQLBoolean
+    })
 
     DeltaOTC.addFields({
       [DataSyncFieldNames.deleted]: GraphQLBoolean

--- a/packages/graphback-datasync/tests/__snapshots__/DataSyncPlugin.test.ts.snap
+++ b/packages/graphback-datasync/tests/__snapshots__/DataSyncPlugin.test.ts.snap
@@ -19,11 +19,9 @@ type Comment {
 
 type CommentDelta {
   id: ID!
-  title: String!
-  description: String!
-
-  \\"\\"\\"@index(name: 'Datasync_lastUpdatedAt')\\"\\"\\"
-  _lastUpdatedAt: GraphbackTimestamp
+  title: String
+  description: String
+  noteId: ID
   _deleted: Boolean
 }
 
@@ -70,6 +68,7 @@ input CreateNoteInput {
   id: ID
   title: String!
   description: String!
+  mainCommentId: ID!
 }
 
 \\"\\"\\"
@@ -98,6 +97,7 @@ input MutateNoteInput {
   id: ID!
   title: String
   description: String
+  mainCommentId: ID
 }
 
 type Mutation {
@@ -119,6 +119,9 @@ type Note {
   title: String!
   description: String!
 
+  \\"\\"\\"@oneToOne(field: 'mainComment', key: 'mainCommentId')\\"\\"\\"
+  mainComment: Comment!
+
   \\"\\"\\"@oneToMany(field: 'noteComment', key: 'noteId')\\"\\"\\"
   comments(filter: CommentFilter): [Comment]!
 
@@ -128,11 +131,9 @@ type Note {
 
 type NoteDelta {
   id: ID!
-  title: String!
-  description: String!
-
-  \\"\\"\\"@index(name: 'Datasync_lastUpdatedAt')\\"\\"\\"
-  _lastUpdatedAt: GraphbackTimestamp
+  title: String
+  description: String
+  mainCommentId: ID
   _deleted: Boolean
 }
 
@@ -146,6 +147,7 @@ input NoteFilter {
   id: IDInput
   title: StringInput
   description: StringInput
+  mainCommentId: IDInput
   and: [NoteFilter!]
   or: [NoteFilter!]
   not: NoteFilter
@@ -179,6 +181,7 @@ input PageRequest {
 
 type Query {
   getLikedNotes(id: ID!, names: [String]!): Note!
+  getLikedComments(id: ID!, names: [String]!): Comment!
   getNote(id: ID!): Note
   findNotes(filter: NoteFilter, page: PageRequest, orderBy: OrderByInput): NoteResultList!
   getComment(id: ID!): Comment
@@ -235,12 +238,9 @@ type Comment {
 
 type CommentDelta {
   id: ID!
-  title: String!
-  description: String!
-
-  \\"\\"\\"@index(name: 'Datasync_lastUpdatedAt')\\"\\"\\"
-  _lastUpdatedAt: GraphbackTimestamp
-  _version: Int
+  title: String
+  description: String
+  _version: Int!
   _deleted: Boolean
 }
 
@@ -369,11 +369,8 @@ type Comment {
 
 type CommentDelta {
   id: ID!
-  title: String!
-  description: String!
-
-  \\"\\"\\"@index(name: 'Datasync_lastUpdatedAt')\\"\\"\\"
-  _lastUpdatedAt: GraphbackTimestamp
+  title: String
+  description: String
   _deleted: Boolean
 }
 

--- a/packages/graphback-datasync/tests/__snapshots__/DataSyncPlugin.test.ts.snap
+++ b/packages/graphback-datasync/tests/__snapshots__/DataSyncPlugin.test.ts.snap
@@ -22,6 +22,9 @@ type CommentDelta {
   title: String
   description: String
   noteId: ID
+
+  \\"\\"\\"@index(name: 'Datasync_lastUpdatedAt')\\"\\"\\"
+  _lastUpdatedAt: GraphbackTimestamp
   _deleted: Boolean
 }
 
@@ -134,6 +137,9 @@ type NoteDelta {
   title: String
   description: String
   mainCommentId: ID
+
+  \\"\\"\\"@index(name: 'Datasync_lastUpdatedAt')\\"\\"\\"
+  _lastUpdatedAt: GraphbackTimestamp
   _deleted: Boolean
 }
 
@@ -241,6 +247,9 @@ type CommentDelta {
   title: String
   description: String
   _version: Int!
+
+  \\"\\"\\"@index(name: 'Datasync_lastUpdatedAt')\\"\\"\\"
+  _lastUpdatedAt: GraphbackTimestamp
   _deleted: Boolean
 }
 
@@ -371,6 +380,9 @@ type CommentDelta {
   id: ID!
   title: String
   description: String
+
+  \\"\\"\\"@index(name: 'Datasync_lastUpdatedAt')\\"\\"\\"
+  _lastUpdatedAt: GraphbackTimestamp
   _deleted: Boolean
 }
 

--- a/packages/graphback-datasync/tests/mock.graphql
+++ b/packages/graphback-datasync/tests/mock.graphql
@@ -6,6 +6,12 @@ type Note {
   id: ID!
   title: String!
   description: String!
+
+  """
+  @oneToOne(field: 'mainComment', key: 'mainCommentId')
+  """
+  mainComment: Comment!
+
   """
   @oneToMany(field: 'noteComment', key: 'noteId')
   """
@@ -20,14 +26,13 @@ type Comment {
   id: ID!
   title: String!
   description: String!
-  """
-  @manyToOne(field: 'comments', key: 'noteId')
-  """
+  """@manyToOne(field: 'comments', key: 'noteId')"""
   noteComment: Note!
 }
 
 type Query {
   getLikedNotes(id: ID!, names: [String]!): Note!
+  getLikedComments(id: ID!, names: [String]!): Comment!
 }
 
 type Mutation {


### PR DESCRIPTION
It is not possible to simply answer relationships status for single model - relationships are build per entire schema which will make it hard to use this info in data sync that typically works with subset of types.

Creating to see how we can get that done for the demo and fix datasync.
See #2163 