### PR TITLE
fix(templates): replaced _id with id in client and postgres template

### DIFF
--- a/packages/create-graphback/src/init/starterTemplates.ts
+++ b/packages/create-graphback/src/init/starterTemplates.ts
@@ -30,6 +30,11 @@ export let allTemplates: Template[] = [
   {
     name: 'apollo-fullstack-react-mongo-ts',
     description: 'Apollo GraphQL Server connecting to Mongo database and React client using TypeScript',
+    /**
+     * Keeping this template disabled based on discussion here:
+     * https://github.com/aerogear/graphback/issues/2249
+     */
+    disabled: true,
     repos: [
       {
         uri: 'https://github.com/aerogear/graphback',

--- a/packages/create-graphback/src/init/starterTemplates.ts
+++ b/packages/create-graphback/src/init/starterTemplates.ts
@@ -28,26 +28,6 @@ export let allTemplates: Template[] = [
       }]
   },
   {
-    name: 'apollo-fullstack-react-mongo-ts',
-    description: 'Apollo GraphQL Server connecting to Mongo database and React client using TypeScript',
-    /**
-     * Keeping this template disabled based on discussion here:
-     * https://github.com/aerogear/graphback/issues/2249
-     */
-    disabled: true,
-    repos: [
-      {
-        uri: 'https://github.com/aerogear/graphback',
-        branch: 'templates-1.0.0',
-        path: '/templates/ts-react-apollo-client',
-        mountpath: "client"
-      }, {
-        uri: 'https://github.com/aerogear/graphback',
-        branch: 'templates-1.0.0',
-        path: '/templates/ts-apollo-mongodb-backend',
-      }]
-  },
-  {
     name: 'fastify-fullstack-react-mongo-ts',
     description: 'GraphQL Server based on Fastify connecting to MongoDB database and React client using TypeScript',
     /**

--- a/templates/ts-apollo-postgres-backend/model/datamodel.graphql
+++ b/templates/ts-apollo-postgres-backend/model/datamodel.graphql
@@ -1,7 +1,7 @@
 """ @model """
 type Note {
   """ @id """
-  _id: ID!
+  id: ID!
   title: String!
   description: String
   """
@@ -13,7 +13,7 @@ type Note {
 """ @model """
 type Comment {
   """ @id """
-  _id: ID!
+  id: ID!
   text: String
   description: String
 }

--- a/templates/ts-apollo-postgres-backend/src/generated-types.ts
+++ b/templates/ts-apollo-postgres-backend/src/generated-types.ts
@@ -1,6 +1,8 @@
 /* eslint-disable */
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -14,7 +16,7 @@ export type Scalars = {
 export type Comment = {
   __typename?: 'Comment';
   /**  @id  */
-  _id: Scalars['ID'];
+  id: Scalars['ID'];
   text?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   /** @manyToOne(field: 'comments', key: 'noteId') */
@@ -22,7 +24,7 @@ export type Comment = {
 };
 
 export type CommentFilter = {
-  _id?: Maybe<IdInput>;
+  id?: Maybe<IdInput>;
   text?: Maybe<StringInput>;
   description?: Maybe<StringInput>;
   noteId?: Maybe<IdInput>;
@@ -43,20 +45,18 @@ export type CommentSubscriptionFilter = {
   and?: Maybe<Array<CommentSubscriptionFilter>>;
   or?: Maybe<Array<CommentSubscriptionFilter>>;
   not?: Maybe<CommentSubscriptionFilter>;
-  _id?: Maybe<IdInput>;
+  id?: Maybe<IdInput>;
   text?: Maybe<StringInput>;
   description?: Maybe<StringInput>;
 };
 
 export type CreateCommentInput = {
-  _id?: Maybe<Scalars['ID']>;
   text?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   noteId?: Maybe<Scalars['ID']>;
 };
 
 export type CreateNoteInput = {
-  _id?: Maybe<Scalars['ID']>;
   title: Scalars['String'];
   description?: Maybe<Scalars['String']>;
 };
@@ -72,14 +72,14 @@ export type IdInput = {
 };
 
 export type MutateCommentInput = {
-  _id: Scalars['ID'];
+  id: Scalars['ID'];
   text?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   noteId?: Maybe<Scalars['ID']>;
 };
 
 export type MutateNoteInput = {
-  _id: Scalars['ID'];
+  id: Scalars['ID'];
   title?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
 };
@@ -128,7 +128,7 @@ export type MutationDeleteCommentArgs = {
 export type Note = {
   __typename?: 'Note';
   /**  @id  */
-  _id: Scalars['ID'];
+  id: Scalars['ID'];
   title: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   /**
@@ -145,7 +145,7 @@ export type NoteCommentsArgs = {
 };
 
 export type NoteFilter = {
-  _id?: Maybe<IdInput>;
+  id?: Maybe<IdInput>;
   title?: Maybe<StringInput>;
   description?: Maybe<StringInput>;
   and?: Maybe<Array<NoteFilter>>;
@@ -165,7 +165,7 @@ export type NoteSubscriptionFilter = {
   and?: Maybe<Array<NoteSubscriptionFilter>>;
   or?: Maybe<Array<NoteSubscriptionFilter>>;
   not?: Maybe<NoteSubscriptionFilter>;
-  _id?: Maybe<IdInput>;
+  id?: Maybe<IdInput>;
   title?: Maybe<StringInput>;
   description?: Maybe<StringInput>;
 };

--- a/templates/ts-apollo-postgres-backend/src/schema/schema.graphql
+++ b/templates/ts-apollo-postgres-backend/src/schema/schema.graphql
@@ -9,7 +9,7 @@ directive @specifiedBy(
 """ @model """
 type Comment {
   """ @id """
-  _id: ID!
+  id: ID!
   text: String
   description: String
 
@@ -18,7 +18,7 @@ type Comment {
 }
 
 input CommentFilter {
-  _id: IDInput
+  id: IDInput
   text: StringInput
   description: StringInput
   noteId: IDInput
@@ -38,20 +38,18 @@ input CommentSubscriptionFilter {
   and: [CommentSubscriptionFilter!]
   or: [CommentSubscriptionFilter!]
   not: CommentSubscriptionFilter
-  _id: IDInput
+  id: IDInput
   text: StringInput
   description: StringInput
 }
 
 input CreateCommentInput {
-  _id: ID
   text: String
   description: String
   noteId: ID
 }
 
 input CreateNoteInput {
-  _id: ID
   title: String!
   description: String
 }
@@ -67,14 +65,14 @@ input IDInput {
 }
 
 input MutateCommentInput {
-  _id: ID!
+  id: ID!
   text: String
   description: String
   noteId: ID
 }
 
 input MutateNoteInput {
-  _id: ID!
+  id: ID!
   title: String
   description: String
 }
@@ -91,7 +89,7 @@ type Mutation {
 """ @model """
 type Note {
   """ @id """
-  _id: ID!
+  id: ID!
   title: String!
   description: String
 
@@ -103,7 +101,7 @@ type Note {
 }
 
 input NoteFilter {
-  _id: IDInput
+  id: IDInput
   title: StringInput
   description: StringInput
   and: [NoteFilter!]
@@ -122,7 +120,7 @@ input NoteSubscriptionFilter {
   and: [NoteSubscriptionFilter!]
   or: [NoteSubscriptionFilter!]
   not: NoteSubscriptionFilter
-  _id: IDInput
+  id: IDInput
   title: StringInput
   description: StringInput
 }

--- a/templates/ts-react-apollo-client/schema.graphql
+++ b/templates/ts-react-apollo-client/schema.graphql
@@ -9,7 +9,7 @@ directive @specifiedBy(
 """ @model """
 type Comment {
   """ @id """
-  _id: ID!
+  id: ID!
   text: String
   description: String
 
@@ -18,7 +18,7 @@ type Comment {
 }
 
 input CommentFilter {
-  _id: IDInput
+  id: IDInput
   text: StringInput
   description: StringInput
   noteId: IDInput
@@ -38,20 +38,20 @@ input CommentSubscriptionFilter {
   and: [CommentSubscriptionFilter!]
   or: [CommentSubscriptionFilter!]
   not: CommentSubscriptionFilter
-  _id: IDInput
+  id: IDInput
   text: StringInput
   description: StringInput
 }
 
 input CreateCommentInput {
-  _id: ID
+  id: ID
   text: String
   description: String
   noteId: ID
 }
 
 input CreateNoteInput {
-  _id: ID
+  id: ID
   title: String!
   description: String
 }
@@ -67,14 +67,14 @@ input IDInput {
 }
 
 input MutateCommentInput {
-  _id: ID!
+  id: ID!
   text: String
   description: String
   noteId: ID
 }
 
 input MutateNoteInput {
-  _id: ID!
+  id: ID!
   title: String
   description: String
 }
@@ -91,7 +91,7 @@ type Mutation {
 """ @model """
 type Note {
   """ @id """
-  _id: ID!
+  id: ID!
   title: String!
   description: String
 
@@ -103,7 +103,7 @@ type Note {
 }
 
 input NoteFilter {
-  _id: IDInput
+  id: IDInput
   title: StringInput
   description: StringInput
   and: [NoteFilter!]
@@ -122,7 +122,7 @@ input NoteSubscriptionFilter {
   and: [NoteSubscriptionFilter!]
   or: [NoteSubscriptionFilter!]
   not: NoteSubscriptionFilter
-  _id: IDInput
+  id: IDInput
   title: StringInput
   description: StringInput
 }

--- a/templates/ts-react-apollo-client/src/App.tsx
+++ b/templates/ts-react-apollo-client/src/App.tsx
@@ -24,7 +24,7 @@ const App: React.FC = () => {
           {
             // TODO fix typings
             noteItems && noteItems.map((note: any) => (
-              <OneNote key={note._id} _id={note._id} title={note.title} description={note.description} comments={note.comments} />
+              <OneNote key={note.id} id={note.id} title={note.title} description={note.description} comments={note.comments} />
             ))
           }
         </ul>

--- a/templates/ts-react-apollo-client/src/components/comment/OneComment.tsx
+++ b/templates/ts-react-apollo-client/src/components/comment/OneComment.tsx
@@ -5,7 +5,7 @@ import './Comment.css';
 
 
 
-const OneComment = ({ _id, text, description }: Comment) => {
+const OneComment = ({ id, text, description }: Comment) => {
     const [deleteComment] = useDeleteCommentMutation();
 
     return (
@@ -13,7 +13,7 @@ const OneComment = ({ _id, text, description }: Comment) => {
             <li className="comment">
                 <strong >{text}</strong>:&nbsp;
               {description}
-                <Button variant="outlined" color="secondary" onClick={() => deleteComment({ variables: { input: { _id: _id } } })}>Delete Comment</Button>
+                <Button variant="outlined" color="secondary" onClick={() => deleteComment({ variables: { input: { id: id } } })}>Delete Comment</Button>
             </li>
         </div>
     );

--- a/templates/ts-react-apollo-client/src/components/notes/EditNote.tsx
+++ b/templates/ts-react-apollo-client/src/components/notes/EditNote.tsx
@@ -4,13 +4,13 @@ import { Button, TextField, Card } from '@material-ui/core';
 import './Note.css';
 
 type noteProps = {
-    _id: string
+    id: string
     title: string,
     description: string | undefined,
     editState: any
 }
 
-const EditNote = ({ _id, title, description, editState }: noteProps) => {
+const EditNote = ({ id, title, description, editState }: noteProps) => {
     const [updateNote] = useUpdateNoteMutation();
     const [NoteTitle, setNoteTitle] = useState(title);
     const [NoteDescription, setNoteDescription] = useState(description);
@@ -35,7 +35,7 @@ const EditNote = ({ _id, title, description, editState }: noteProps) => {
                     />
                     <Button variant="outlined" color="primary"
                         onClick={() => {
-                            updateNote({ variables: { input: { _id: _id, title: NoteTitle, description: NoteDescription } } });
+                            updateNote({ variables: { input: { id: id, title: NoteTitle, description: NoteDescription } } });
                             editState(false);
                         }}>Update Note</Button>
                 </form>

--- a/templates/ts-react-apollo-client/src/components/notes/OneNote.tsx
+++ b/templates/ts-react-apollo-client/src/components/notes/OneNote.tsx
@@ -5,7 +5,7 @@ import CreateComment from '../comment/CreateComment';
 import OneComment from '../comment/OneComment';
 import { Button, Card } from '@material-ui/core';
 
-const OneNote = ({ _id, title, description, comments }: Note) => {
+const OneNote = ({ id, title, description, comments }: Note) => {
     const [noteEdit, setNoteEdit] = useState(false)
     const [addComment, setAddComment] = useState(false)
 
@@ -17,15 +17,15 @@ const OneNote = ({ _id, title, description, comments }: Note) => {
                 {description}
                     <Button onClick={() => setNoteEdit(!noteEdit)} variant="outlined" color="primary" >Edit</Button>
                     <Button onClick={() => setAddComment(!addComment)} variant="outlined" color="primary" >Add Comment</Button>
-                    {noteEdit ? <EditNote _id={_id} title={title} description={description || ""} editState={setNoteEdit}></EditNote> : <div></div>}
-                    {addComment ? <CreateComment noteId={_id} addCommentState={setAddComment}></CreateComment> : <div></div>}
+                    {noteEdit ? <EditNote id={id} title={title} description={description || ""} editState={setNoteEdit}></EditNote> : <div></div>}
+                    {addComment ? <CreateComment noteId={id} addCommentState={setAddComment}></CreateComment> : <div></div>}
                     <ul>
                         {comments && comments.length > 0 ? comments.map((com) => {
                             if (!com) {
                                 return null;
                             }
                             return (
-                                <OneComment _id={com._id} text={com.text} description={com.description} key={com._id}></OneComment>
+                                <OneComment id={com.id} text={com.text} description={com.description} key={com.id}></OneComment>
                             );
                         }) : <div></div>}
                     </ul>

--- a/templates/ts-react-apollo-client/src/generated-types.tsx
+++ b/templates/ts-react-apollo-client/src/generated-types.tsx
@@ -16,7 +16,7 @@ export type Scalars = {
 export type Comment = {
   __typename?: 'Comment';
   /**  @id  */
-  _id: Scalars['ID'];
+  id: Scalars['ID'];
   text?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   /** @manyToOne(field: 'comments', key: 'noteId') */
@@ -24,7 +24,7 @@ export type Comment = {
 };
 
 export type CommentFilter = {
-  _id?: Maybe<IdInput>;
+  id?: Maybe<IdInput>;
   text?: Maybe<StringInput>;
   description?: Maybe<StringInput>;
   noteId?: Maybe<IdInput>;
@@ -45,20 +45,20 @@ export type CommentSubscriptionFilter = {
   and?: Maybe<Array<CommentSubscriptionFilter>>;
   or?: Maybe<Array<CommentSubscriptionFilter>>;
   not?: Maybe<CommentSubscriptionFilter>;
-  _id?: Maybe<IdInput>;
+  id?: Maybe<IdInput>;
   text?: Maybe<StringInput>;
   description?: Maybe<StringInput>;
 };
 
 export type CreateCommentInput = {
-  _id?: Maybe<Scalars['ID']>;
+  id?: Maybe<Scalars['ID']>;
   text?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   noteId?: Maybe<Scalars['ID']>;
 };
 
 export type CreateNoteInput = {
-  _id?: Maybe<Scalars['ID']>;
+  id?: Maybe<Scalars['ID']>;
   title: Scalars['String'];
   description?: Maybe<Scalars['String']>;
 };
@@ -74,14 +74,14 @@ export type IdInput = {
 };
 
 export type MutateCommentInput = {
-  _id: Scalars['ID'];
+  id: Scalars['ID'];
   text?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   noteId?: Maybe<Scalars['ID']>;
 };
 
 export type MutateNoteInput = {
-  _id: Scalars['ID'];
+  id: Scalars['ID'];
   title?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
 };
@@ -130,7 +130,7 @@ export type MutationDeleteCommentArgs = {
 export type Note = {
   __typename?: 'Note';
   /**  @id  */
-  _id: Scalars['ID'];
+  id: Scalars['ID'];
   title: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   /**
@@ -147,7 +147,7 @@ export type NoteCommentsArgs = {
 };
 
 export type NoteFilter = {
-  _id?: Maybe<IdInput>;
+  id?: Maybe<IdInput>;
   title?: Maybe<StringInput>;
   description?: Maybe<StringInput>;
   and?: Maybe<Array<NoteFilter>>;
@@ -167,7 +167,7 @@ export type NoteSubscriptionFilter = {
   and?: Maybe<Array<NoteSubscriptionFilter>>;
   or?: Maybe<Array<NoteSubscriptionFilter>>;
   not?: Maybe<NoteSubscriptionFilter>;
-  _id?: Maybe<IdInput>;
+  id?: Maybe<IdInput>;
   title?: Maybe<StringInput>;
   description?: Maybe<StringInput>;
 };
@@ -286,29 +286,29 @@ export type GetDraftNotesQuery = (
 
 export type NoteFieldsFragment = (
   { __typename?: 'Note' }
-  & Pick<Note, '_id' | 'title' | 'description'>
+  & Pick<Note, 'id' | 'title' | 'description'>
 );
 
 export type NoteExpandedFieldsFragment = (
   { __typename?: 'Note' }
-  & Pick<Note, '_id' | 'title' | 'description'>
+  & Pick<Note, 'id' | 'title' | 'description'>
   & { comments: Array<Maybe<(
     { __typename?: 'Comment' }
-    & Pick<Comment, '_id' | 'text' | 'description'>
+    & Pick<Comment, 'id' | 'text' | 'description'>
   )>> }
 );
 
 export type CommentFieldsFragment = (
   { __typename?: 'Comment' }
-  & Pick<Comment, '_id' | 'text' | 'description'>
+  & Pick<Comment, 'id' | 'text' | 'description'>
 );
 
 export type CommentExpandedFieldsFragment = (
   { __typename?: 'Comment' }
-  & Pick<Comment, '_id' | 'text' | 'description'>
+  & Pick<Comment, 'id' | 'text' | 'description'>
   & { note?: Maybe<(
     { __typename?: 'Note' }
-    & Pick<Note, '_id' | 'title' | 'description'>
+    & Pick<Note, 'id' | 'title' | 'description'>
   )> }
 );
 
@@ -534,18 +534,18 @@ export type DeletedCommentSubscription = (
 
 export const NoteFieldsFragmentDoc = gql`
     fragment NoteFields on Note {
-  _id
+  id
   title
   description
 }
     `;
 export const NoteExpandedFieldsFragmentDoc = gql`
     fragment NoteExpandedFields on Note {
-  _id
+  id
   title
   description
   comments {
-    _id
+    id
     text
     description
   }
@@ -553,18 +553,18 @@ export const NoteExpandedFieldsFragmentDoc = gql`
     `;
 export const CommentFieldsFragmentDoc = gql`
     fragment CommentFields on Comment {
-  _id
+  id
   text
   description
 }
     `;
 export const CommentExpandedFieldsFragmentDoc = gql`
     fragment CommentExpandedFields on Comment {
-  _id
+  id
   text
   description
   note {
-    _id
+    id
     title
     description
   }

--- a/templates/ts-react-apollo-client/src/graphql/graphback.graphql
+++ b/templates/ts-react-apollo-client/src/graphql/graphback.graphql
@@ -1,34 +1,34 @@
 fragment NoteFields on Note {
-   _id
+   id
    title
    description
 
 } 
 
 fragment NoteExpandedFields on Note {
-   _id
+   id
    title
    description
    comments {
-      _id
+      id
       text
       description
    }
 } 
 
 fragment CommentFields on Comment {
-   _id
+   id
    text
    description
 
 } 
 
 fragment CommentExpandedFields on Comment {
-   _id
+   id
    text
    description
    note {
-      _id
+      id
       title
       description
    }


### PR DESCRIPTION
<!--The content below is a suggested layout for writing your pull request description. You may extend or remove parts you deem relevant or irrelevant to your changes.-->

<!--Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to [link to that issue](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).-->

Fixes #2249 

## Types of changes

What types of changes does your code introduce to Graphback?

<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please specify)

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] I have read the [CONTRIBUTING](https://github.com/aerogear/graphback/blob/master/CONTRIBUTING.md) document.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Verification

<!--If there are any steps you took to verify that this works, please specify them here.-->

I tried running the CLI locally after the change and it was working. To test that the client and Postgres templates are working as well I copied them from the project directory and ran them individually and they are working as shown in the video.


https://user-images.githubusercontent.com/56963264/107873710-5866f380-6eda-11eb-9365-5255a9636469.mp4




## Further comments

<!--If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->

After discussion, it was decided to have the client app working with Postgres only and not mongo since client side queries are still there for testing if needed. To make the client template work with Postgres I made the following two changes:

1.  Replaced `_id` with `id` in postgres template's [datamodel.graphql](https://github.com/aerogear/graphback/blob/master/templates/ts-apollo-postgres-backend/model/datamodel.graphql) file. Ran `yarn generate` to update the required files.
2. Replaced all instances of `_id` with `id` in the client template.

Please let me know in case something needs to be changed. Thanks!
