### PR TITLE
fix: remove conditional requiring 'items' for path arg to get count

### DIFF
--- a/packages/graphback-core/src/runtime/CRUDService.ts
+++ b/packages/graphback-core/src/runtime/CRUDService.ts
@@ -121,7 +121,7 @@ export class CRUDService<Type = any> implements GraphbackCRUDService<Type>  {
     let requestedCount: boolean = false;
     if (info) {
       selectedFields = getSelectedFieldsFromResolverInfo(info, this.model, path);
-      requestedCount = path === 'items' && getResolverInfoFieldsList(info).some((field: string) => field === "count");
+      requestedCount = getResolverInfoFieldsList(info).some((field: string) => field === "count");
     }
 
     const items: Type[] = await this.db.findBy(args, selectedFields);


### PR DESCRIPTION
## Types of changes

Using the `context.graphback.Model.findBy` method should not require a path arg to get the count back.

`requestedCount` was returning false always if `"items"` was not passed as an argument to `findBy` in a custom resolver.

```ts
// would not return count, even if requested
await context.graphback.Model.findBy(args, context, info);

// this was required to get count back, which doesn't make much sense
await context.graphback.Model.findBy(args, context, info, 'items');
```

<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please specify)

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] I have read the [CONTRIBUTING](https://github.com/aerogear/graphback/blob/master/CONTRIBUTING.md) document.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Verification

Tested manually with custom resolvers.

## Further comments

<!--If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->
